### PR TITLE
207 task fix admin mode on our settings flow in UI

### DIFF
--- a/packages/client/src/components/app/AppSettings.tsx
+++ b/packages/client/src/components/app/AppSettings.tsx
@@ -23,7 +23,7 @@ import {
     Publish,
 } from '@mui/icons-material';
 import { Controller, useForm } from 'react-hook-form';
-import { usePixel, useRootStore } from '@/hooks';
+import { usePixel, useRootStore, useSettings } from '@/hooks';
 import { LoadingScreen } from '@/components/ui';
 
 import { Java } from '@/assets/img/Java';
@@ -223,6 +223,7 @@ export const AppSettings = (props: AppSettingsProps) => {
     const { id, condensed = false } = props;
     const { monolithStore, configStore } = useRootStore();
     const notification = useNotification();
+    const { adminMode } = useSettings();
     const [isLoading, setIsLoading] = useState<boolean>(false);
 
     const { handleSubmit, control, reset, watch } = useForm<EditAppForm>({
@@ -271,9 +272,15 @@ export const AppSettings = (props: AppSettingsProps) => {
         project_portal_url?: string;
         lastCompiled?: string;
         compiledBy?: string;
-    }>(`
+    }>(
+        adminMode
+            ? `
+        AdminGetProjectPortalDetails('${id}');
+    `
+            : `
         GetProjectPortalDetails('${id}');
-    `);
+    `,
+    );
 
     useEffect(() => {
         if (getPortalDetails.status !== 'SUCCESS') {
@@ -302,7 +309,9 @@ export const AppSettings = (props: AppSettingsProps) => {
      * @name getPortalReactors
      */
     const getPortalReactors = () => {
-        const pixelString = `GetProjectAvailableReactors(project=['${id}']);`;
+        const pixelString = adminMode
+            ? `AdminGetProjectAvailableReactors(project=['${id}']);`
+            : `GetProjectAvailableReactors(project=['${id}']);`;
 
         monolithStore
             .runQuery(pixelString)

--- a/packages/client/src/pages/engine/EngineLayout.tsx
+++ b/packages/client/src/pages/engine/EngineLayout.tsx
@@ -12,7 +12,7 @@ import { styled, ToggleTabsGroup } from '@semoss/ui';
 
 import { ENGINE_TYPES } from '@/types';
 import { EngineContext } from '@/contexts';
-import { usePixel, useAPI, useRootStore } from '@/hooks';
+import { usePixel, useAPI, useRootStore, useSettings } from '@/hooks';
 
 import { LoadingScreen } from '@/components/ui';
 import { EngineShell } from '@/components/engine';
@@ -57,6 +57,7 @@ export const EngineLayout = (props: EngineLayoutProps) => {
     const resolvedPath = useResolvedPath('');
     const { pathname } = useLocation();
     const navigate = useNavigate();
+    const { adminMode } = useSettings();
 
     // get the matching route
     const route: (typeof ENGINE_ROUTES)[number] | null = useMemo(() => {
@@ -133,7 +134,8 @@ export const EngineLayout = (props: EngineLayoutProps) => {
     }, [engineMetaStatus, engineMetaData, JSON.stringify(metaKeys)]);
 
     // get the user's role
-    const getUserEnginePermission = useAPI(['getUserEnginePermission', id]);
+    const getUserEnginePermission =
+        !adminMode && useAPI(['getUserEnginePermission', id]);
 
     // get the tabs based on permission
     const tabs = useMemo(() => {

--- a/packages/client/src/pages/settings/AppSettingsDetailPage.tsx
+++ b/packages/client/src/pages/settings/AppSettingsDetailPage.tsx
@@ -39,7 +39,8 @@ export const AppSettingsDetailPage = () => {
     const [view, setView] = useState<VIEW>('CURRENT');
     const [permission, setPermission] = useState<Role | null>(null);
 
-    const getUserEnginePermission = useAPI(['getUserProjectPermission', id]);
+    const getUserEnginePermission =
+        !adminMode && useAPI(['getUserProjectPermission', id]);
 
     /**
      * @name useEffect

--- a/packages/client/src/pages/settings/EngineSettingsDetailPage.tsx
+++ b/packages/client/src/pages/settings/EngineSettingsDetailPage.tsx
@@ -56,7 +56,8 @@ export const EngineSettingsDetailPage = (
     const [view, setView] = useState<VIEW>('CURRENT');
     const [permission, setPermission] = useState<Role | null>(null);
 
-    const getUserEnginePermission = useAPI(['getUserEnginePermission', id]);
+    const getUserEnginePermission =
+        !adminMode && useAPI(['getUserEnginePermission', id]);
 
     /**
      * @name useEffect


### PR DESCRIPTION
 Added in two new admin related reactors: 
 **AdminGetProjectPortalDetails
AdminGetProjectAvailableReactors**

A follow up ticket will need to be made to determine what to display on the FE if the user is in admin mode, but not a member of the App, Db, etc.. 
