### PR TITLE
246 filters in url params

### DIFF
--- a/packages/client/src/components/ui/Filterbox/Filterbox.tsx
+++ b/packages/client/src/components/ui/Filterbox/Filterbox.tsx
@@ -287,7 +287,6 @@ export const Filterbox = (props: FilterboxProps) => {
             }
         });
         // Pass filters to parent
-        console.log('HANDLING IT', constructedFilters);
         onChange(constructedFilters);
         // Update query params in the URL
         setSearchParams(constructedFilters);

--- a/packages/client/src/components/ui/Filterbox/Filterbox.tsx
+++ b/packages/client/src/components/ui/Filterbox/Filterbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useReducer } from 'react';
+import { useEffect, useState, useReducer, Fragment } from 'react';
 import {
     Avatar,
     Collapse,
@@ -12,6 +12,7 @@ import {
 import { usePixel, useRootStore } from '@/hooks';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { removeUnderscores, toTitleCase } from '@/utility';
+import { useSearchParams } from 'react-router-dom';
 
 const StyledFilter = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -88,6 +89,7 @@ const reducer = (state, action) => {
 export const Filterbox = (props: FilterboxProps) => {
     const { type, onChange } = props;
     const { configStore } = useRootStore();
+    const [searchParams, setSearchParams] = useSearchParams();
 
     const [state, dispatch] = useReducer(reducer, initialState);
     const { filterSearch } = state;
@@ -169,6 +171,16 @@ export const Filterbox = (props: FilterboxProps) => {
             : '',
     );
 
+    // Apply the URL's query params to the filters' state on component mount.
+    useEffect(() => {
+        if (searchParams.size > 0) {
+            searchParams.forEach((value, key) => {
+                setSelectedFilters(key, { value, count: 0 });
+            });
+        }
+        handleFiltersSideEffects();
+    }, []);
+
     /**
      * @desc Catalog filters
      */
@@ -205,7 +217,6 @@ export const Filterbox = (props: FilterboxProps) => {
         });
 
         metaKeysWithOpts.forEach((filter) => {
-            console.log(filter);
             if (filter.display_values) {
                 const split = filter.display_values.split(',');
                 const formatted = [];
@@ -261,7 +272,13 @@ export const Filterbox = (props: FilterboxProps) => {
 
         // Now update filter object to have new selected values
         setFilterVisibility({ ...filterVisibility });
+    };
 
+    /**
+     * @name handleFiltersSideEffects
+     * @desc handles what actions/effects are needed when the filters are changed
+     */
+    const handleFiltersSideEffects = () => {
         const constructedFilters = {};
 
         Object.entries(filterVisibility).forEach((obj) => {
@@ -270,7 +287,10 @@ export const Filterbox = (props: FilterboxProps) => {
             }
         });
         // Pass filters to parent
+        console.log('HANDLING IT', constructedFilters);
         onChange(constructedFilters);
+        // Update query params in the URL
+        setSearchParams(constructedFilters);
     };
 
     return (
@@ -378,82 +398,81 @@ export const Filterbox = (props: FilterboxProps) => {
                                             ) {
                                                 shownListItems += 1;
                                                 return (
-                                                    <>
-                                                        <List.Item
+                                                    <List.Item
+                                                        disableGutters
+                                                        key={i}
+                                                    >
+                                                        <List.ItemButton
                                                             disableGutters
-                                                            key={i}
-                                                        >
-                                                            <List.ItemButton
-                                                                disableGutters
-                                                                sx={{
-                                                                    paddingLeft:
-                                                                        '16px',
-                                                                    paddingRight:
-                                                                        '16px',
-                                                                }}
-                                                                selected={
-                                                                    filterVisibility[
-                                                                        entries[0]
-                                                                    ].value.indexOf(
-                                                                        filterOption.value,
-                                                                    ) > -1
-                                                                }
-                                                                onClick={() => {
-                                                                    dispatch({
-                                                                        type: 'field',
-                                                                        field: 'databases',
-                                                                        value: [],
-                                                                    });
+                                                            sx={{
+                                                                paddingLeft:
+                                                                    '16px',
+                                                                paddingRight:
+                                                                    '16px',
+                                                            }}
+                                                            selected={
+                                                                filterVisibility[
+                                                                    entries[0]
+                                                                ].value.indexOf(
+                                                                    filterOption.value,
+                                                                ) > -1
+                                                            }
+                                                            onClick={() => {
+                                                                dispatch({
+                                                                    type: 'field',
+                                                                    field: 'databases',
+                                                                    value: [],
+                                                                });
 
-                                                                    setSelectedFilters(
-                                                                        entries[0],
-                                                                        filterOption,
-                                                                    );
+                                                                setSelectedFilters(
+                                                                    entries[0],
+                                                                    filterOption,
+                                                                );
+                                                                handleFiltersSideEffects();
+                                                            }}
+                                                            aria-label={
+                                                                filterVisibility[
+                                                                    entries[0]
+                                                                ].value.indexOf(
+                                                                    filterOption.value,
+                                                                ) > -1
+                                                                    ? `Unfilter ${filterOption.value}`
+                                                                    : `Filter ${filterOption.value}`
+                                                            }
+                                                        >
+                                                            <div
+                                                                style={{
+                                                                    width: '100%',
+                                                                    display:
+                                                                        'flex',
+                                                                    justifyContent:
+                                                                        'space-between',
                                                                 }}
-                                                                aria-label={
-                                                                    filterVisibility[
-                                                                        entries[0]
-                                                                    ].value.indexOf(
-                                                                        filterOption.value,
-                                                                    ) > -1
-                                                                        ? `Unfilter ${filterOption.value}`
-                                                                        : `Filter ${filterOption.value}`
-                                                                }
                                                             >
-                                                                <div
-                                                                    style={{
-                                                                        width: '100%',
-                                                                        display:
-                                                                            'flex',
-                                                                        justifyContent:
-                                                                            'space-between',
-                                                                    }}
-                                                                >
-                                                                    <List.ItemText
-                                                                        disableTypography
-                                                                        primary={
-                                                                            <Typography variant="body1">
-                                                                                {
-                                                                                    filterOption.value
-                                                                                }
-                                                                            </Typography>
-                                                                        }
-                                                                    />
-                                                                    {filterOption.count && (
-                                                                        <StyledAvatarCount
-                                                                            variant={
-                                                                                'rounded'
-                                                                            }
-                                                                        >
+                                                                <List.ItemText
+                                                                    disableTypography
+                                                                    primary={
+                                                                        <Typography variant="body1">
                                                                             {
-                                                                                filterOption.count
+                                                                                filterOption.value
                                                                             }
-                                                                        </StyledAvatarCount>
-                                                                    )}
-                                                                </div>
-                                                            </List.ItemButton>
-                                                        </List.Item>
-                                                    </>
+                                                                        </Typography>
+                                                                    }
+                                                                />
+                                                                {filterOption.count && (
+                                                                    <StyledAvatarCount
+                                                                        variant={
+                                                                            'rounded'
+                                                                        }
+                                                                    >
+                                                                        {
+                                                                            filterOption.count
+                                                                        }
+                                                                    </StyledAvatarCount>
+                                                                )}
+                                                            </div>
+                                                        </List.ItemButton>
+                                                    </List.Item>
                                                 );
                                             }
                                         }

--- a/packages/client/src/pages/HomePage.tsx
+++ b/packages/client/src/pages/HomePage.tsx
@@ -10,7 +10,7 @@ import {
     InputAdornment,
 } from '@semoss/ui';
 
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { usePixel, useRootStore } from '@/hooks';
 import { Page } from '@/components/ui';
@@ -144,12 +144,12 @@ const TERMINAL_APP: AppMetadata = {
 export const HomePage = observer((): JSX.Element => {
     const { configStore, monolithStore } = useRootStore();
     const navigate = useNavigate();
+    const [searchParams, setSearchParams] = useSearchParams();
 
     const [state, dispatch] = useReducer(reducer, initialState);
     const { favoritedApps, apps } = state;
 
     const [search, setSearch] = useState<string>('');
-    const [metaFilters, setMetaFilters] = useState<Record<string, unknown>>({});
     const [mode, setMode] = useState<MODE>('Mine');
 
     // get a list of the keys
@@ -178,7 +178,7 @@ export const HomePage = observer((): JSX.Element => {
         ...metaKeys,
         'description',
     ])}, metaFilters=[${JSON.stringify(
-        metaFilters,
+        searchParams,
     )}], filterWord=["${search}"], onlyPortals=[true]);`;
 
     /**
@@ -211,8 +211,8 @@ export const HomePage = observer((): JSX.Element => {
     favoritePixel += `(metaKeys = ${JSON.stringify([
         ...metaKeys,
         'description',
-    ])}, metaFilters=[${JSON.stringify(
-        metaFilters,
+    ])}, searchParams=[${JSON.stringify(
+        searchParams,
     )}], filterWord=["${search}"], onlyFavorites=[true]);`;
     const getFavoritedApps = usePixel(favoritePixel);
 
@@ -349,8 +349,8 @@ export const HomePage = observer((): JSX.Element => {
                 <div>
                     <Filterbox
                         type={'APP'}
-                        onChange={(filters: Record<string, unknown>) => {
-                            setMetaFilters(filters);
+                        onChange={(filters: { [key: string]: string[] }) => {
+                            setSearchParams(filters);
                         }}
                     />
                 </div>

--- a/packages/client/src/pages/HomePage.tsx
+++ b/packages/client/src/pages/HomePage.tsx
@@ -10,7 +10,7 @@ import {
     InputAdornment,
 } from '@semoss/ui';
 
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { usePixel, useRootStore } from '@/hooks';
 import { Page } from '@/components/ui';
@@ -144,12 +144,12 @@ const TERMINAL_APP: AppMetadata = {
 export const HomePage = observer((): JSX.Element => {
     const { configStore, monolithStore } = useRootStore();
     const navigate = useNavigate();
-    const [searchParams, setSearchParams] = useSearchParams();
 
     const [state, dispatch] = useReducer(reducer, initialState);
     const { favoritedApps, apps } = state;
 
     const [search, setSearch] = useState<string>('');
+    const [metaFilters, setMetaFilters] = useState<Record<string, unknown>>({});
     const [mode, setMode] = useState<MODE>('Mine');
 
     // get a list of the keys
@@ -178,7 +178,7 @@ export const HomePage = observer((): JSX.Element => {
         ...metaKeys,
         'description',
     ])}, metaFilters=[${JSON.stringify(
-        searchParams,
+        metaFilters,
     )}], filterWord=["${search}"], onlyPortals=[true]);`;
 
     /**
@@ -211,8 +211,8 @@ export const HomePage = observer((): JSX.Element => {
     favoritePixel += `(metaKeys = ${JSON.stringify([
         ...metaKeys,
         'description',
-    ])}, searchParams=[${JSON.stringify(
-        searchParams,
+    ])}, metaFilters=[${JSON.stringify(
+        metaFilters,
     )}], filterWord=["${search}"], onlyFavorites=[true]);`;
     const getFavoritedApps = usePixel(favoritePixel);
 
@@ -349,8 +349,8 @@ export const HomePage = observer((): JSX.Element => {
                 <div>
                     <Filterbox
                         type={'APP'}
-                        onChange={(filters: { [key: string]: string[] }) => {
-                            setSearchParams(filters);
+                        onChange={(filters: Record<string, unknown>) => {
+                            setMetaFilters(filters);
                         }}
                     />
                 </div>

--- a/packages/client/src/pages/engine/EngineCatalogPage.tsx
+++ b/packages/client/src/pages/engine/EngineCatalogPage.tsx
@@ -16,7 +16,7 @@ import {
 } from '@semoss/ui';
 import { SearchOff, Search as SearchIcon } from '@mui/icons-material';
 
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { ENGINE_TYPES } from '@/types';
 import { usePixel, useRootStore } from '@/hooks';
@@ -137,6 +137,7 @@ export const EngineCatalogPage = observer(
         const [state, dispatch] = useReducer(reducer, initialState);
         const { favoritedDbs, databases } = state;
 
+        const [searchParams, setSearchParams] = useSearchParams();
         const [offset, setOffset] = useState(0);
         const [canCollect, setCanCollect] = useState(true);
         const canCollectRef = useRef(true);
@@ -152,9 +153,6 @@ export const EngineCatalogPage = observer(
 
         // which view we are on
         const [mode, setMode] = useState<MODE>('Mine');
-        const [metaFilters, setMetaFilters] = useState<Record<string, unknown>>(
-            {},
-        );
 
         const dbPixelPrefix: string =
             mode === 'Mine' ? `MyEngines` : 'MyDiscoverableEngines';
@@ -165,7 +163,7 @@ export const EngineCatalogPage = observer(
         ${dbPixelPrefix}(metaKeys = ${JSON.stringify(
             metaKeysDescription,
         )}, metaFilters = [ ${JSON.stringify(
-            metaFilters,
+            searchParams,
         )} ] , filterWord=["${search}"], onlyFavorites=[true], ${
             route ? `engineTypes=['${route.type}']` : ''
         });
@@ -194,8 +192,8 @@ export const EngineCatalogPage = observer(
         >(
             `${dbPixelPrefix}( metaKeys = ${JSON.stringify(
                 metaKeysDescription,
-            )} , metaFilters = [ ${JSON.stringify(
-                metaFilters,
+            )} , searchParams = [ ${JSON.stringify(
+                searchParams,
             )} ] , filterWord=["${search}"], userT = [true], ${
                 route ? `engineTypes=['${route.type}'], ` : ''
             } offset=[${offset}], limit=[${limit}]) ;`,
@@ -380,7 +378,7 @@ export const EngineCatalogPage = observer(
             });
             setCanCollect(true);
             setOffset(0);
-            setMetaFilters({});
+            setSearchParams({});
         }, [route.type]);
 
         /**
@@ -541,13 +539,13 @@ export const EngineCatalogPage = observer(
                 <StyledContainer>
                     <Filterbox
                         type={type}
-                        onChange={(filters: Record<string, unknown>) => {
+                        onChange={(filters: { [key: string]: string[] }) => {
                             dispatch({
                                 type: 'field',
                                 field: 'databases',
                                 value: [],
                             });
-                            setMetaFilters(filters);
+                            setSearchParams(filters);
                             setOffset(0);
                         }}
                     />
@@ -585,7 +583,7 @@ export const EngineCatalogPage = observer(
                         </Stack>
 
                         {'bi'.includes(search.toLowerCase()) &&
-                            Object.entries(metaFilters).length === 0 &&
+                            Object.entries(searchParams).length === 0 &&
                             'terminal'.includes(search.toLowerCase()) &&
                             favoritedDbs.length > 0 && (
                                 <StyledSectionLabel variant="subtitle1">
@@ -594,7 +592,7 @@ export const EngineCatalogPage = observer(
                             )}
 
                         {favoritedDbs.length &&
-                        Object.entries(metaFilters).length === 0 ? (
+                        Object.entries(searchParams).length === 0 ? (
                             <Grid container spacing={3}>
                                 {favoritedDbs.map((db) => {
                                     return (
@@ -643,7 +641,7 @@ export const EngineCatalogPage = observer(
                         ) : null}
 
                         {'bi'.includes(search.toLowerCase()) &&
-                            Object.entries(metaFilters).length === 0 &&
+                            Object.entries(searchParams).length === 0 &&
                             'terminal'.includes(search.toLowerCase()) &&
                             databases.length > 0 && (
                                 <StyledSectionLabel variant="subtitle1">


### PR DESCRIPTION
Please note that while working through this ticket, I came across a pre-existing bug related to the FilterBox component on the EngineCatalogPage that I was unable to address in this ticket due to time constraints.

**The bug:** when a user tabs through the various Catalog pages (I.E., models, engines., etc..), the state of the filters is maintained regardless of if that filter applies to the page or not. Additionally, let's say a user selects a filter on the Models page, then navigates to another catalog page and back to the Models page; the previous filters state in the FilterBox is maintained, but the filter is not applied to the fetch for the Models listed on the page. This is because the `EngineCatalogPage.tsx` is not aware of the state being maintained in the `FilterBox.tsx`.
**Possible Solutions:** either the FilterBox's state needs to be reset if the Catalog Type changes, OR, the FilterBox needs to relay its state back to the parent when the Catalog Type changes. 
Between the two, I feel that clearing the filters on any page change would be the better UX.