### PR TITLE
256 task ctrl + s saves the app state

### DIFF
--- a/packages/client/src/components/blocks-workspace/BlocksWorkspaceActions.tsx
+++ b/packages/client/src/components/blocks-workspace/BlocksWorkspaceActions.tsx
@@ -98,7 +98,7 @@ export const BlocksWorkspaceActions = observer(() => {
 
             notification.add({
                 color: 'success',
-                message: 'Success',
+                message: 'Save successful! Make sure to double-check your changes for correctness',
             });
         } catch (e) {
             console.error(e);

--- a/packages/client/src/components/blocks-workspace/BlocksWorkspaceActions.tsx
+++ b/packages/client/src/components/blocks-workspace/BlocksWorkspaceActions.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useCallback } from 'react';
 import { observer } from 'mobx-react-lite';
 import {
     styled,
@@ -196,6 +197,26 @@ export const BlocksWorkspaceActions = observer(() => {
             workspace.setLoading(false);
         }
     };
+
+    /**
+     * Trigger save on ctrl+s
+     */
+        const onDocumentKeydown = useCallback((event: KeyboardEvent) => {
+            if (event.key === 's' && event.ctrlKey) {
+                event.preventDefault();
+                saveApp();
+            }
+        }, []);
+    
+        useEffect(() => {
+            // attach the event listener
+            document.addEventListener('keydown', onDocumentKeydown);
+    
+            // remove the event listener
+            return () => {
+                document.removeEventListener('keydown', onDocumentKeydown);
+            };
+        }, [onDocumentKeydown]);
 
     return (
         <Stack direction="row" spacing={1} alignItems={'center'}>


### PR DESCRIPTION
<img width="552" alt="image" src="https://github.com/user-attachments/assets/51d3abd3-4c82-4d5c-84e0-a34ccba91977">

Ctrl+s now saves.
Added event listener for ctrl S and disabled default behavior.
Added message in the modal at the top right after saving.