### PR TITLE
fix(client): user engines settings page change issue resolve

### DIFF
--- a/packages/client/src/components/settings/MembersTable.tsx
+++ b/packages/client/src/components/settings/MembersTable.tsx
@@ -262,8 +262,8 @@ export const MembersTable = (props: MembersTableProps) => {
             return;
         }
 
-        setPage(0);
-        setSelectedMembers([]);
+        // setPage(0);
+        // setSelectedMembers([]);
 
         // select the member when done mounting
         memberSearchRef.current?.focus();


### PR DESCRIPTION
Hi @neelneelneel 

I discovered an issue with the user engine settings. Even when clicking on the next page, it still displays page 1. This wasn't the case in the previous build. I've made a minor fix in the `useEffect` call to resolve this. I didn't notice any breaking changes, so I've raised this PR for your review. Please review it before merging.

The commit that caused this issue is:
feat(client): updating/refactoring settings

Please let me know if this looks good to merge.