### PR TITLE
Resolve: Edit Project Details

### DIFF
--- a/packages/client/src/components/app/EditDetailsModal.tsx
+++ b/packages/client/src/components/app/EditDetailsModal.tsx
@@ -46,10 +46,11 @@ interface EditDetailsModalProps {
     onClose: (reset?: boolean) => void;
     control: Control<any, any>;
     onSubmit: any;
+    values: Record<string, unknown>;
 }
 
 export const EditDetailsModal = (props: EditDetailsModalProps) => {
-    const { isOpen, onClose, control, onSubmit } = props;
+    const { isOpen, onClose, control, onSubmit, values = {} } = props;
     const { configStore } = useRootStore();
 
     const filter = createFilterOptions<string>();
@@ -61,12 +62,8 @@ export const EditDetailsModal = (props: EditDetailsModalProps) => {
     // filter metakeys to the ones we want
     const projectMetaKeys = configStore.store.config.projectMetaKeys.filter(
         (k) => {
-            return (
-                k.metakey !== 'description' &&
-                k.metakey !== 'markdown' &&
-                k.metakey !== 'tag' &&
-                k.metakey !== 'tags'
-            );
+            // filter the fields to the ones that are passed in
+            return Object.prototype.hasOwnProperty.call(values, k.metakey);
         },
     );
 

--- a/packages/client/src/pages/app/AppDetailPage.tsx
+++ b/packages/client/src/pages/app/AppDetailPage.tsx
@@ -38,7 +38,7 @@ import {
 import { ShareOverlay } from '@/components/workspace';
 import { SettingsContext } from '@/contexts';
 import { Env } from '@/env';
-import { useRootStore } from '@/hooks';
+import { useEngine, useRootStore } from '@/hooks';
 import { formatPermission, toTitleCase } from '@/utility';
 import {
     Add,
@@ -202,6 +202,8 @@ export const AppDetailPage = () => {
         ];
     }, []);
 
+    // get the database information
+    const { metaVals } = useEngine();
     const { monolithStore, configStore } = useRootStore();
     const navigate = useNavigate();
     const notification = useNotification();
@@ -851,6 +853,7 @@ export const AppDetailPage = () => {
                 onClose={handleCloseEditDetailsModal}
                 control={control}
                 onSubmit={onSubmit}
+                values={metaVals}
             />
 
             <EditDependenciesModal


### PR DESCRIPTION
We are now getting the metavalues by the useEngine hook in app details edit details modal instead of hardcoding metavalues.