### PR TITLE
fix(client): added driver property in pgvector

### DIFF
--- a/packages/client/src/pages/import/import.constants.ts
+++ b/packages/client/src/pages/import/import.constants.ts
@@ -5505,7 +5505,7 @@ export const CONNECTION_OPTIONS = {
                         },
                         disabled: false,
                         rules: { required: true },
-                    },                
+                    },
                 ],
             },
         ],
@@ -5859,6 +5859,17 @@ export const CONNECTION_OPTIONS = {
                         disabled: true,
                         hidden: true,
                         rules: { required: true },
+                    },
+                    {
+                        fieldName: 'DRIVER',
+                        label: 'Driver Property',
+                        defaultValue: 'org.postgresql.Driver',
+                        options: {
+                            component: 'text-field',
+                        },
+                        disabled: true,
+                        hidden: true,
+                        rules: { required: false },
                     },
                     {
                         fieldName: 'NAME',
@@ -6313,7 +6324,7 @@ export const CONNECTION_OPTIONS = {
                         rules: { required: false },
                         advanced: true,
                         helperText: '',
-                    }
+                    },
                 ],
             },
             {


### PR DESCRIPTION
DRIVER Property required for the use_connection_pooling. In PGVector the driver property was not passed from the frontend. Hope this solves the issue. 