### PR TITLE
fix(client): default border size to 0px in layout container block

### DIFF
--- a/packages/client/src/components/block-settings/custom/BorderSettings.tsx
+++ b/packages/client/src/components/block-settings/custom/BorderSettings.tsx
@@ -202,7 +202,7 @@ export const BorderSettings = observer(
                         onChange={(e) => {
                             if (e.target.value) {
                                 onChange(
-                                    borderSizeValue ?? '0.125rem',
+                                    borderSizeValue ?? '0px',
                                     e.target.value,
                                     borderColorValue ?? '#FFFFFF',
                                 );
@@ -227,7 +227,7 @@ export const BorderSettings = observer(
                         onChange={(e) => {
                             if (e.target.value) {
                                 onChange(
-                                    borderSizeValue ?? '0.125rem',
+                                    borderSizeValue ?? '0px',
                                     borderStyleValue ?? 'solid',
                                     e.target.value,
                                 );


### PR DESCRIPTION
**Fixed Bug - Updated the default border size to 0px when changing the border color**


<img width="757" alt="image" src="https://github.com/user-attachments/assets/25584483-777b-48dc-a77d-cd12e4c733e3">
