### PR TITLE
feat(client): issue with modal closure upon clicking on close button

### DIFF
--- a/packages/client/src/components/workspace/panels/FileExplorerPanel.tsx
+++ b/packages/client/src/components/workspace/panels/FileExplorerPanel.tsx
@@ -149,6 +149,8 @@ export const FileExplorerPanel = (props: FileExplorerPanelProps) => {
                         // refresh the content
                         refreshFiles();
                     }
+                    // close the overlay
+                    workspace.closeOverlay();
                 }}
                 fileDeletePath={fileDeletePath}
             />


### PR DESCRIPTION
Fixed the Issue with closing modal while trying to delete any files.
<img width="951" alt="image" src="https://github.com/user-attachments/assets/b4d46eb4-9bb3-408a-b80c-04a0619d98a9">
