### PR TITLE
Allow node more space in packages/ui scripts

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,8 +12,8 @@
     "scripts": {
         "start": "pnpm run storybook",
         "dev": "run-p build:dev storybook",
-        "build": "rollup -c",
-        "build:dev": "rollup -w -c",
+        "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 rollup -c",
+        "build:dev": "cross-env NODE_OPTIONS=--max_old_space_size=8192 rollup -w -c",
         "storybook": "cross-env NODE_OPTIONS=--max_old_space_size=8192 storybook dev -p 6006",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",


### PR DESCRIPTION
pnpm run build was giving 
`FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`
for some users. 

Increasing the node space seems to have fixed it.