### PR TITLE
Task 111: added title elispse after two lines and tooltip hover feature

### DIFF
--- a/libs/ui/src/components/TruncatedText/TruncatedText.tsx
+++ b/libs/ui/src/components/TruncatedText/TruncatedText.tsx
@@ -1,0 +1,49 @@
+import { useRef, useEffect, useState } from "react";
+import { Typography, Tooltip, TypographyProps, SxProps } from "@mui/material";
+
+interface TruncatedTextProps {
+    children: string;
+    variant?: TypographyProps["variant"];
+    sx?: SxProps;
+}
+
+export const TruncatedText = ({
+    children,
+    variant = "body1",
+    sx,
+}: TruncatedTextProps) => {
+    const textRef = useRef<HTMLElement>(null);
+    const [isTextTruncated, setIsTextTruncated] = useState(false);
+
+    useEffect(() => {
+        const element = textRef.current;
+        if (!element || typeof children !== "string") return;
+
+        setIsTextTruncated(element.scrollHeight > element.clientHeight);
+    }, [children, variant]);
+
+    const truncatedTypography = (
+        <Typography
+            ref={textRef}
+            variant={variant}
+            sx={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                display: "-webkit-box",
+                WebkitLineClamp: 2, // Truncates after two lines
+                WebkitBoxOrient: "vertical",
+                ...sx,
+            }}
+        >
+            {children}
+        </Typography>
+    );
+
+    return isTextTruncated && typeof children === "string" ? (
+        <Tooltip title={children} placement="top-start">
+            {truncatedTypography}
+        </Tooltip>
+    ) : (
+        truncatedTypography
+    );
+};

--- a/libs/ui/src/components/TruncatedText/index.ts
+++ b/libs/ui/src/components/TruncatedText/index.ts
@@ -1,0 +1,1 @@
+export { TruncatedText } from "./TruncatedText";

--- a/libs/ui/src/components/Typography/Typography.tsx
+++ b/libs/ui/src/components/Typography/Typography.tsx
@@ -2,6 +2,7 @@ import {
     Typography as MuiTypography,
     TypographyProps as MuiTypographyProps,
     SxProps,
+    Tooltip,
 } from "@mui/material";
 
 export interface TypographyProps {
@@ -51,10 +52,21 @@ export interface TypographyProps {
 }
 
 export const Typography = (props: TypographyProps) => {
-    const { sx, color, ...otherProps } = props;
+    const { sx, color, variant, ...otherProps } = props;
+
     return (
         <MuiTypography
-            sx={sx}
+            sx={{
+                ...(variant === "body1" && {
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    display: "-webkit-box",
+                    WebkitLineClamp: "2",
+                    WebkitBoxOrient: "vertical",
+                }),
+                ...sx,
+            }}
+            variant={variant}
             color={
                 color === "success"
                     ? "success.text"

--- a/libs/ui/src/components/Typography/Typography.tsx
+++ b/libs/ui/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     SxProps,
     Tooltip,
 } from "@mui/material";
+import { useRef, useState, useEffect } from "react";
 
 export interface TypographyProps {
     /** custom style object */
@@ -52,10 +53,29 @@ export interface TypographyProps {
 }
 
 export const Typography = (props: TypographyProps) => {
-    const { sx, color, variant, ...otherProps } = props;
+    const { sx, color, variant, children, ...otherProps } = props;
+    const typographyRef = useRef<HTMLElement>(null);
+    const [isTruncated, setIsTruncated] = useState(false);
 
-    return (
+    useEffect(() => {
+        const checkTruncation = () => {
+            const element = typographyRef.current;
+            if (!element || typeof children !== "string") return;
+
+            // console.log(`Text: "${children}", Scroll height: ${element.scrollHeight}, Client height: ${element.clientHeight}`)
+
+            setIsTruncated(element.scrollHeight > element.clientHeight);
+        };
+
+        checkTruncation();
+        window.addEventListener("resize", checkTruncation);
+
+        return () => window.removeEventListener("resize", checkTruncation);
+    }, [children]);
+
+    const typographyComponent = (
         <MuiTypography
+            ref={typographyRef}
             sx={{
                 ...(variant === "body1" && {
                     overflow: "hidden",
@@ -81,6 +101,18 @@ export const Typography = (props: TypographyProps) => {
                     : color
             }
             {...otherProps}
-        />
+        >
+            {children}
+        </MuiTypography>
     );
+
+    if (variant === "body1" && typeof children === "string" && isTruncated) {
+        return (
+            <Tooltip title={children} placement="top-start">
+                {typographyComponent}
+            </Tooltip>
+        );
+    }
+
+    return typographyComponent;
 };

--- a/libs/ui/src/components/Typography/Typography.tsx
+++ b/libs/ui/src/components/Typography/Typography.tsx
@@ -2,9 +2,7 @@ import {
     Typography as MuiTypography,
     TypographyProps as MuiTypographyProps,
     SxProps,
-    Tooltip,
 } from "@mui/material";
-import { useRef, useState, useEffect } from "react";
 
 export interface TypographyProps {
     /** custom style object */
@@ -53,31 +51,11 @@ export interface TypographyProps {
 }
 
 export const Typography = (props: TypographyProps) => {
-    const { sx, color, variant, children, ...otherProps } = props;
-    const typographyRef = useRef<HTMLElement>(null);
-    const [isTruncated, setIsTruncated] = useState(false);
+    const { sx, color, ...otherProps } = props;
 
-    useEffect(() => {
-        const element = typographyRef.current;
-        if (!element || typeof children !== "string") return;
-
-        setIsTruncated(element.scrollHeight > element.clientHeight);
-    }, [children, variant]);
-
-    const typographyComponent = (
+    return (
         <MuiTypography
-            ref={typographyRef}
-            sx={{
-                ...(variant === "body1" && {
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    display: "-webkit-box",
-                    WebkitLineClamp: "2",
-                    WebkitBoxOrient: "vertical",
-                }),
-                ...sx,
-            }}
-            variant={variant}
+            sx={sx}
             color={
                 color === "success"
                     ? "success.text"
@@ -92,18 +70,6 @@ export const Typography = (props: TypographyProps) => {
                     : color
             }
             {...otherProps}
-        >
-            {children}
-        </MuiTypography>
+        />
     );
-
-    if (variant === "body1" && typeof children === "string" && isTruncated) {
-        return (
-            <Tooltip title={children} placement="top-start">
-                {typographyComponent}
-            </Tooltip>
-        );
-    }
-
-    return typographyComponent;
 };

--- a/libs/ui/src/components/Typography/Typography.tsx
+++ b/libs/ui/src/components/Typography/Typography.tsx
@@ -58,20 +58,11 @@ export const Typography = (props: TypographyProps) => {
     const [isTruncated, setIsTruncated] = useState(false);
 
     useEffect(() => {
-        const checkTruncation = () => {
-            const element = typographyRef.current;
-            if (!element || typeof children !== "string") return;
+        const element = typographyRef.current;
+        if (!element || typeof children !== "string") return;
 
-            // console.log(`Text: "${children}", Scroll height: ${element.scrollHeight}, Client height: ${element.clientHeight}`)
-
-            setIsTruncated(element.scrollHeight > element.clientHeight);
-        };
-
-        checkTruncation();
-        window.addEventListener("resize", checkTruncation);
-
-        return () => window.removeEventListener("resize", checkTruncation);
-    }, [children]);
+        setIsTruncated(element.scrollHeight > element.clientHeight);
+    }, [children, variant]);
 
     const typographyComponent = (
         <MuiTypography

--- a/packages/client/src/components/engine/GenericEngineCards.tsx
+++ b/packages/client/src/components/engine/GenericEngineCards.tsx
@@ -27,6 +27,7 @@ import { Env } from '@/env';
 import GOOGLE from '@/assets/img/google.png';
 import { ENGINE_IMAGES } from '../../pages/import/import.constants';
 import BRAIN from '@/assets/img/BRAIN.png';
+import { TruncatedText } from '../../../../../libs/ui/src/components/TruncatedText';
 
 const StyledCardImg = styled('img')({
     display: 'flex',
@@ -362,7 +363,10 @@ export const EngineLandscapeCard = (props: DatabaseCardProps) => {
                 <StyledLandscapeCardHeaderDiv>
                     <Typography variant={'body1'}>
                         <Typography variant={'body1'}>
-                            {formatDBName(name)}
+                            <TruncatedText variant="body1">
+                                {formatDBName(name)}
+                            </TruncatedText>
+                            {/* {formatDBName(name)} */}
                         </Typography>
                         {sub_type === 'EMBEDDED' ? (
                             <StyledCardImg src={GOOGLE}></StyledCardImg>


### PR DESCRIPTION
## Description
Enhanced the Typography component to improve readability of long text in body1 variant by adding automatic truncation after two lines with an ellipsis. Added a smart tooltip that appears only when text is actually truncated.

## Impact Areas
This change affects all components using Typography with body1 variant, including similar items on other pages (e.g. list of features)

## Screenshots
![image](https://github.com/user-attachments/assets/dfead3b0-e557-48da-a253-bb19a75740d9)
