### PR TITLE
feat(client): improve styling of switch components in block settings

### DIFF
--- a/libs/ui/src/components/Switch/Switch.tsx
+++ b/libs/ui/src/components/Switch/Switch.tsx
@@ -2,10 +2,6 @@ import { ReactNode } from "react";
 import { Switch as MuiSwitch, SxProps, styled } from "@mui/material";
 
 const StyledSwitch = styled(MuiSwitch)(({ theme }) => ({
-    width: "52px",
-    height: "32px",
-    padding: 0,
-
     "& .MuiSwitch-switchBase": {
         padding: 0,
         margin: "4px",
@@ -33,8 +29,6 @@ const StyledSwitch = styled(MuiSwitch)(({ theme }) => ({
 
     "& .MuiSwitch-thumb": {
         boxSizing: "border-box",
-        width: "24px",
-        height: "24px",
         color: theme.palette.background.paper,
     },
 
@@ -118,6 +112,6 @@ export interface SwitchProps {
 }
 
 export const Switch = (props: SwitchProps) => {
-    const { sx } = props;
-    return <StyledSwitch sx={sx} {...props} />;
+    const { sx, size } = props;
+    return <StyledSwitch sx={sx} size={size} {...props} />;
 };

--- a/libs/ui/src/components/Switch/Switch.tsx
+++ b/libs/ui/src/components/Switch/Switch.tsx
@@ -1,7 +1,10 @@
 import { ReactNode } from "react";
 import { Switch as MuiSwitch, SxProps, styled } from "@mui/material";
 
-const StyledSwitch = styled(MuiSwitch)(({ theme }) => ({
+const StyledSwitch = styled(MuiSwitch)(({ theme, size }) => ({
+    width: size === "small" ? "42px" : "52px",
+    height: size === "small" ? "24px" : "32px",
+    padding: size === "small" ? "7px" : "0px",
     "& .MuiSwitch-switchBase": {
         padding: 0,
         margin: "4px",
@@ -29,6 +32,8 @@ const StyledSwitch = styled(MuiSwitch)(({ theme }) => ({
 
     "& .MuiSwitch-thumb": {
         boxSizing: "border-box",
+        width: size === "medium" ? "24px" : "16px",
+        height: size === "medium" ? "24px" : "16px",
         color: theme.palette.background.paper,
     },
 
@@ -112,6 +117,6 @@ export interface SwitchProps {
 }
 
 export const Switch = (props: SwitchProps) => {
-    const { sx, size } = props;
+    const { sx, size = "medium" } = props;
     return <StyledSwitch sx={sx} size={size} {...props} />;
 };

--- a/libs/ui/src/components/Switch/Switch.tsx
+++ b/libs/ui/src/components/Switch/Switch.tsx
@@ -2,9 +2,9 @@ import { ReactNode } from "react";
 import { Switch as MuiSwitch, SxProps, styled } from "@mui/material";
 
 const StyledSwitch = styled(MuiSwitch)(({ theme, size }) => ({
-    width: size === "small" ? "42px" : "52px",
-    height: size === "small" ? "24px" : "32px",
-    padding: size === "small" ? "7px" : "0px",
+    width: size === "small" ? "40px" : "52px",
+    height: size === "small" ? "20px" : "32px",
+    padding: 0,
     "& .MuiSwitch-switchBase": {
         padding: 0,
         margin: "4px",
@@ -32,8 +32,8 @@ const StyledSwitch = styled(MuiSwitch)(({ theme, size }) => ({
 
     "& .MuiSwitch-thumb": {
         boxSizing: "border-box",
-        width: size === "medium" ? "24px" : "16px",
-        height: size === "medium" ? "24px" : "16px",
+        width: size === "medium" ? "24px" : "12px",
+        height: size === "medium" ? "24px" : "12px",
         color: theme.palette.background.paper,
     },
 

--- a/packages/client/src/components/block-settings/shared/SwitchSettings.tsx
+++ b/packages/client/src/components/block-settings/shared/SwitchSettings.tsx
@@ -138,7 +138,12 @@ export const SwitchSettings = observer(
                             </Tooltip>
                         )}
                     </Stack>
-                    <Stack direction="row" justifyContent="end">
+                    <Stack
+                        direction="row"
+                        justifyContent="end"
+                        height="16px"
+                        alignItems="center"
+                    >
                         <Switch
                             checked={value}
                             onChange={() => {

--- a/packages/client/src/components/block-settings/shared/SwitchSettings.tsx
+++ b/packages/client/src/components/block-settings/shared/SwitchSettings.tsx
@@ -7,6 +7,8 @@ import { useBlockSettings } from '@/hooks';
 import { Block, BlockDef } from '@/stores';
 import { getValueByPath } from '@/utility';
 import { BaseSettingSection } from '../BaseSettingSection';
+import { styled, Tooltip, Typography, Stack } from '@mui/material';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 
 interface SwitchSettingsProps<D extends BlockDef = BlockDef> {
     /**
@@ -31,6 +33,11 @@ interface SwitchSettingsProps<D extends BlockDef = BlockDef> {
      */
     description?: string;
 }
+
+const StyledTypography = styled(Typography)(() => ({
+    overflowWrap: 'break-word',
+    whiteSpace: 'normal',
+}));
 
 export const SwitchSettings = observer(
     <D extends BlockDef = BlockDef>({
@@ -103,15 +110,46 @@ export const SwitchSettings = observer(
         };
 
         return (
-            <BaseSettingSection label={label} description={description}>
-                <Switch
-                    checked={value}
-                    onChange={(e) => {
-                        // sync the data on change
-                        onChange(!value);
-                    }}
-                />
-            </BaseSettingSection>
+            <div>
+                <Stack
+                    direction="row"
+                    alignItems="center"
+                    spacing={2}
+                    marginTop="8px"
+                >
+                    <Stack
+                        direction="row"
+                        alignItems="center"
+                        spacing={0.5}
+                        width="100%"
+                    >
+                        <StyledTypography variant="body2">
+                            {label}
+                        </StyledTypography>
+                        {description && (
+                            <Tooltip placement="top" title={description} arrow>
+                                <HelpOutlineIcon
+                                    color="action"
+                                    sx={{
+                                        fontSize: 15,
+                                        marginLeft: '5px', // Small margin to separate tooltip from label
+                                    }}
+                                />
+                            </Tooltip>
+                        )}
+                    </Stack>
+                    <Stack direction="row" justifyContent="end">
+                        <Switch
+                            checked={value}
+                            onChange={() => {
+                                // sync the data on change
+                                onChange(!value);
+                            }}
+                            size="small"
+                        />
+                    </Stack>
+                </Stack>
+            </div>
         );
     },
 );


### PR DESCRIPTION
After changes, the switch button looks like this:
![image](https://github.com/user-attachments/assets/af4a00c2-40fe-4e9b-8e0f-08b0e4aff554)

Before changes, it was looking like this:
![image](https://github.com/user-attachments/assets/6005934a-8f7e-4a6b-ab47-736d522b151d)



