### PR TITLE
fix(ui/client): bug fix for the metadata page going blank after successful connection with postgres database due to wrong url navigation

### DIFF
--- a/packages/client/src/pages/import/EstablishConnectionPage.tsx
+++ b/packages/client/src/pages/import/EstablishConnectionPage.tsx
@@ -392,7 +392,7 @@ export const MetamodelView = (props: MetamodelViewProps) => {
                 message: output,
             });
         } else {
-            navigate(`/database/${output.database_id}`);
+            navigate(`/engine/database/${output.database_id}`);
             return;
         }
     };


### PR DESCRIPTION
The issue was, the page was getting blank after creating the connection with the database because it was navigating to some wrong url.