### PR TITLE
refactor: restore AddAppModal to use addAppFormSteps

### DIFF
--- a/packages/client/src/components/app/save-app/AddAppModal.tsx
+++ b/packages/client/src/components/app/save-app/AddAppModal.tsx
@@ -152,7 +152,6 @@ export const AddAppModal = (props: AddAppProps) => {
                 [data[ADD_APP_FORM_FIELD_UPLOAD]],
                 configStore.store.insightID,
             );
-            // *** Waiting on the ImportApp reactor to be ready so that we can hook up the metadata ****.
             const resp = await monolithStore.runQuery(
                 `UploadProjectApp(filePath=["${upload[0].fileLocation}"], global=[${data[ADD_APP_FORM_FIELD_IS_GLOBAL]}]);`,
             );
@@ -268,7 +267,7 @@ export const AddAppModal = (props: AddAppProps) => {
             open={open}
             handleClose={handleClose}
             title="Upload app from my computer"
-            steps={projectZipFormSteps}
+            steps={addAppFormSteps}
             defaultFormValues={defaultFormValues}
             handleFormSubmit={createApp}
             errorMessage="There was an error creating your app. Please check your zip file and try again."


### PR DESCRIPTION
Since the importApp() reactor isn't ready, I restored the AddAppModal to use the defaulted addAppFormSteps instead of the projectZipFormSteps. 

<img width="918" alt="image" src="https://github.com/user-attachments/assets/5fba2988-0192-4855-afc8-f2f3e0b151d5" />

