### PR TITLE
fix(client): updated SocialProperty to edit, send and reset data fields

### DIFF
--- a/packages/client/src/pages/settings/ConfigurationsPage.tsx
+++ b/packages/client/src/pages/settings/ConfigurationsPage.tsx
@@ -473,7 +473,6 @@ const SocialProperty = (props) => {
                                 }}
                             />
                         </StyledKeyValue>
-                        <TextField placeholder="Description"></TextField>
                     </StyledPropContainer>
                 );
             })}

--- a/packages/client/src/pages/settings/ConfigurationsPage.tsx
+++ b/packages/client/src/pages/settings/ConfigurationsPage.tsx
@@ -170,7 +170,6 @@ export const ConfigurationsPage = () => {
     const [authentication, setAuthentication] = useState(
         Object.keys(socialProps),
     );
-    // const [authExpanded, setAuthExpanded] = useState(true);
 
     const [tabValue, setTabValue] = useState(0);
 

--- a/packages/client/src/pages/settings/ConfigurationsPage.tsx
+++ b/packages/client/src/pages/settings/ConfigurationsPage.tsx
@@ -7,7 +7,6 @@ import React, {
     Suspense,
     lazy,
 } from 'react';
-import { useForm } from 'react-hook-form';
 
 import { useAPI, useRootStore, useSettings } from '@/hooks';
 import { LoadingScreen } from '@/components/ui';
@@ -57,27 +56,27 @@ const SOCIAL = {
     },
 };
 
-const StyledConfigurationsOptionsAccordion = styled('div')(({ theme }) => ({
+const StyledConfigurationsOptionsAccordion = styled('div')({
     display: 'flex',
-}));
+});
 
-const StyledAccordion = styled(Accordion)(({ theme }) => ({
+const StyledAccordion = styled(Accordion)({
     width: '291px',
-}));
+});
 
-const StyledBox = styled(Box)(({ theme }) => ({
+const StyledBox = styled(Box)({
     padding: '0px 12px 12px 12px',
-}));
+});
 
-const StyledSearchIcon = styled(SearchOutlined)(({ theme }) => ({
-    color: '#5c5c5c',
-}));
+// const StyledSearchIcon = styled(SearchOutlined)({
+//     color: '#5c5c5c',
+// });
 
-const StyledAccordionContent = styled(Accordion.Content)(({ theme }) => ({
+const StyledAccordionContent = styled(Accordion.Content)({
     fontSize: '14px',
     margin: 0,
     padding: '12px 16px 16px 16px',
-}));
+});
 
 const StyledListButton = styled(Button)(({ theme }) => ({
     textTransform: 'none',
@@ -85,9 +84,9 @@ const StyledListButton = styled(Button)(({ theme }) => ({
     justifyContent: 'left',
 }));
 
-const StyledDivider = styled(Divider)(({ theme }) => ({
+const StyledDivider = styled(Divider)({
     marginBottom: '8px',
-}));
+});
 
 const StyledImage = styled('img')({
     objectFit: 'cover',
@@ -134,13 +133,13 @@ const StyledPropContainer = styled('div')(({ theme }) => ({
     boxShadow: '0px 5px 22px 0px rgba(0, 0, 0, 0.06)',
 }));
 
-const StyledToggleTabsGroup = styled(ToggleTabsGroup)(({ theme }) => ({
+const StyledToggleTabsGroup = styled(ToggleTabsGroup)({
     marginBottom: '16px',
-}));
+});
 
-const StyledTextField = styled(TextField)(({ theme }) => ({
+const StyledTextField = styled(TextField)({
     marginRight: '12px',
-}));
+});
 
 const initialState = {
     socialProps: {},
@@ -175,7 +174,7 @@ export const ConfigurationsPage = () => {
     const [authentication, setAuthentication] = useState(
         Object.keys(socialProps),
     );
-    const [authExpanded, setAuthExpanded] = useState(true);
+    // const [authExpanded, setAuthExpanded] = useState(true);
 
     const [tabValue, setTabValue] = useState(0);
 
@@ -215,7 +214,9 @@ export const ConfigurationsPage = () => {
             value: formattedProperties,
         });
 
-        setAccordionValue(Object.keys(formattedProperties)[0]);
+        if (!accordionValue) {
+            setAccordionValue(Object.keys(formattedProperties)[0]);
+        }
         setAuthentication(Object.keys(formattedProperties));
         authSearchBarRef.current?.focus();
     }, [loginProperties.status, loginProperties.data]);
@@ -247,9 +248,14 @@ export const ConfigurationsPage = () => {
         setTabValue(newValue);
     };
 
-    const changeSocialProps = (fieldName, value) => {
+    const updateSocialProps = (
+        fieldName: string,
+        value: string,
+        label: string,
+        index,
+    ) => {
         const socialPropsCopy = socialProps;
-        socialPropsCopy[fieldName] = value;
+        socialPropsCopy[fieldName][index]['value'] = value;
 
         dispatch({
             type: 'field',
@@ -257,6 +263,14 @@ export const ConfigurationsPage = () => {
             value: socialPropsCopy,
         });
         // setSocialProps(socialPropsCopy);
+    };
+
+    /**
+     * @name resetLoginProperties
+     * @desc refreshes getLoginProperties
+     */
+    const resetLoginProperties = () => {
+        loginProperties.refresh();
     };
 
     const settingsPage = () => {
@@ -307,7 +321,8 @@ export const ConfigurationsPage = () => {
                         key={authentication.indexOf(accordionValue)}
                         fieldName={accordionValue}
                         fields={socialProps[accordionValue]}
-                        onChange={changeSocialProps}
+                        updateSocialProps={updateSocialProps}
+                        resetLoginProperties={resetLoginProperties}
                     ></SocialProperty>
                 )}
             </StyledConfigurationsOptionsAccordion>
@@ -366,13 +381,11 @@ export const ConfigurationsPage = () => {
     );
 };
 
-const mapDefaultValues = (vals) => {
-    const value: unknown = {};
+const mapDefaultValues = (vals: FieldProps[]) => {
+    const value = {};
 
-    vals.map((f: FieldProps) => {
-        if (!value[f.label]) {
-            value[f.label] = f.value;
-        }
+    vals.forEach((f: FieldProps) => {
+        value[f.label] = f.value || '';
     });
 
     return value;
@@ -389,47 +402,26 @@ interface FieldProps {
 // }
 
 const SocialProperty = (props) => {
-    const { fieldName, fields, onChange } = props;
+    const { fieldName, fields, resetLoginProperties, updateSocialProps } =
+        props;
 
     const { monolithStore } = useRootStore();
     const notification = useNotification();
-
-    // used for reset
-    const [defaultValues, setDefaultValues] = useState<FieldProps[]>();
-
-    const { handleSubmit, reset } = useForm({
-        defaultValues: mapDefaultValues(fields),
-    });
 
     /**
      * @name onSubmit
      * @desc changes properties based on updates to social props
      * @param data - form data
      */
-    const onSubmit = handleSubmit((data) => {
-        monolithStore.modifyLoginProperties(fieldName, data).then(() => {
+    const onSubmit = () => {
+        const values = mapDefaultValues(fields);
+        monolithStore.modifyLoginProperties(fieldName, values).then(() => {
             notification.add({
                 color: 'success',
                 message: `Succesfully modified ${fieldName} properties`,
             });
-
-            const valueCopy = [];
-            // structure values to pass to parent and defaultValues
-            Object.entries(data).map((k) => {
-                const objCopy = {
-                    label: k[0],
-                    value: k[1],
-                };
-                valueCopy.push(objCopy);
-            });
-
-            // pass to the parent that holds state of all properties
-            onChange(fieldName, valueCopy);
-
-            // set new default values for reset
-            setDefaultValues(valueCopy);
         });
-    });
+    };
 
     return (
         <StyledForm>
@@ -442,11 +434,7 @@ const SocialProperty = (props) => {
                     <StyledButton
                         variant="outlined"
                         onClick={() => {
-                            if (!defaultValues) {
-                                reset();
-                            } else {
-                                reset(mapDefaultValues(defaultValues));
-                            }
+                            resetLoginProperties(fieldName);
                         }}
                     >
                         Reset
@@ -466,14 +454,23 @@ const SocialProperty = (props) => {
                         <StyledKeyValue>
                             <StyledTextField
                                 label="key"
-                                defaultValue={f.label}
+                                value={f.label}
                                 variant="outlined"
                                 fullWidth
+                                disabled={true}
                             />
                             <TextField
                                 label="value"
-                                defaultValue={f.value}
+                                value={f.value}
                                 fullWidth
+                                onChange={(e) => {
+                                    updateSocialProps(
+                                        fieldName,
+                                        e.target.value,
+                                        f.label,
+                                        i,
+                                    );
+                                }}
                             />
                         </StyledKeyValue>
                         <TextField placeholder="Description"></TextField>

--- a/packages/client/src/pages/settings/ConfigurationsPage.tsx
+++ b/packages/client/src/pages/settings/ConfigurationsPage.tsx
@@ -29,7 +29,7 @@ import github from '../../assets/img/github.png';
 import other from '../../assets/img/other.png';
 
 import { useNavigate } from 'react-router-dom';
-import { KeyboardArrowDown, SearchOutlined } from '@mui/icons-material';
+import { KeyboardArrowDown } from '@mui/icons-material';
 
 const Editor = lazy(() => import('@monaco-editor/react'));
 
@@ -67,10 +67,6 @@ const StyledAccordion = styled(Accordion)({
 const StyledBox = styled(Box)({
     padding: '0px 12px 12px 12px',
 });
-
-// const StyledSearchIcon = styled(SearchOutlined)({
-//     color: '#5c5c5c',
-// });
 
 const StyledAccordionContent = styled(Accordion.Content)({
     fontSize: '14px',

--- a/packages/client/src/stores/monolith/monolith.store.ts
+++ b/packages/client/src/stores/monolith/monolith.store.ts
@@ -451,11 +451,15 @@ export class MonolithStore {
 
         postData += 'modifications=' + JSON.stringify(properties);
 
-        const response = await axios.post<boolean>(url, postData, {
-            headers: {
-                'content-type': 'application/x-www-form-urlencoded',
-            },
-        });
+        const response = await axios
+            .post<boolean>(url, postData, {
+                headers: {
+                    'content-type': 'application/x-www-form-urlencoded',
+                },
+            })
+            .catch((error) => {
+                throw Error(error);
+            });
 
         return response.data;
     }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Updated SocialProperty state to edit, send and reset data fields. 

## Changes Made
<!-- List the key changes made in this PR -->
- I removed the useForm in the SocialProperty and updated the fields to point to the state values so that we could track, edit, and submit the updated textField changes.
- Updated the reset functionality by adding a refresh functionality that calls the getLoginProperties reactor.
- Added error handling for modifyLoginProperties.

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Go to the settings page
Enter admin mode
Click on configuration
Select any authentication mode
Enter value fields for the data
Click save

2. Expected outcomes
- On the network console, test to see if modifyLoginProperties returns the updated payload values
- For the reset functionality, test to see if the textField values reset to the last submitted value.

## Notes
<!-- Any further notes regarding changes -->
I noticed that we have a description text field for each login property, but I don't see a description value key being returned in the getLoginProperties reactor. Should we remove the description text field?

Also, I disabled the login key text field from being edited, but let me know if we want a user to be able to also edit the login key text field as well.