### PR TITLE
feat(client): implemented infinite scrolling on table modals in Team …

### DIFF
--- a/packages/client/src/components/teams/TeamEnginesTable.tsx
+++ b/packages/client/src/components/teams/TeamEnginesTable.tsx
@@ -197,6 +197,8 @@ export const TeamEnginesTable = (props: EnginesTableProps) => {
 
     const { monolithStore } = useRootStore();
     const notification = useNotification();
+    const AUTOCOMPLETE_LIMIT = 10;
+    const AUTOCOMPLETE_OFFSET = 0;
 
     /** Engine Table State */
     const [enginesPage, setEnginesPage] = useState<number>(1);
@@ -221,6 +223,30 @@ export const TeamEnginesTable = (props: EnginesTableProps) => {
     const [hasEngines, setHasEngines] = useState(false);
 
     const limit = 5;
+    const [searchEngineInput, setSearchEngineInput] = useState<string>('');
+    const [offset, setOffset] = useState(AUTOCOMPLETE_OFFSET);
+    const [isScrollBottom, setIsScrollBottom] = useState(false);
+    const [canCollect, setCanCollect] = useState<boolean>(true);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [searchLoading, setSearchLoading] = useState(false);
+
+    const nearBottom = (
+        target: {
+            scrollHeight?: number;
+            scrollTop?: number;
+            clientHeight?: number;
+        } = {},
+    ) => {
+        const diff = Math.round(target.scrollHeight - target.scrollTop);
+        return diff - 25 <= target.clientHeight;
+    };
+
+    /**
+     * @name getAdditionalEngines
+     */
+    const getAdditionalEngines = () => {
+        setOffset(offset + AUTOCOMPLETE_LIMIT);
+    };
 
     const engineSearchRef = useRef(undefined);
 
@@ -253,6 +279,32 @@ export const TeamEnginesTable = (props: EnginesTableProps) => {
                 setHasEngines(true);
             });
     }, []);
+
+    useEffect(() => {
+        if (isScrollBottom) {
+            if (canCollect) {
+                getAdditionalEngines();
+            }
+        }
+    }, [isScrollBottom]);
+
+    useEffect(() => {
+        if (searchEngineInput) {
+            setSearchLoading(true);
+        }
+        const timer = setTimeout(() => {
+            if (!offset) {
+                getEngines(false);
+            } else {
+                if (canCollect) {
+                    getEngines(false);
+                } else {
+                    getEngines(true);
+                }
+            }
+        }, 500);
+        return () => clearTimeout(timer);
+    }, [offset, searchEngineInput]);
 
     /**
      * @name submitNonGroupEngines
@@ -394,7 +446,11 @@ export const TeamEnginesTable = (props: EnginesTableProps) => {
      * @name getEngines
      * @desc Gets all engines without credentials
      */
-    const getEngines = async () => {
+    const getEngines = async (reset: boolean) => {
+        if (isLoading) {
+            return;
+        }
+        setIsLoading(true);
         try {
             let response;
             // possibly add more db table columns / keys here to get id type for display under engines
@@ -402,10 +458,14 @@ export const TeamEnginesTable = (props: EnginesTableProps) => {
             response = await monolithStore.getUnassignedTeamEngines(
                 groupId,
                 groupType,
+                AUTOCOMPLETE_LIMIT,
+                offset,
+                searchEngineInput,
             );
 
             // ignore if there is no response
             if (response) {
+                let requests = reset ? [] : nonCredentialedEngines;
                 const engines = response.map((val) => {
                     return {
                         ...val,
@@ -415,15 +475,19 @@ export const TeamEnginesTable = (props: EnginesTableProps) => {
                     };
                 });
 
-                setNonCredentialedEngines(engines);
+                requests = requests.concat(engines);
+                setNonCredentialedEngines(requests);
+                setCanCollect(engines.length === AUTOCOMPLETE_LIMIT);
+                setIsLoading(false);
+                setSearchLoading(false);
             }
         } catch (e) {
             notification.add({
                 color: 'error',
                 message: String(e),
             });
-        } finally {
-            setAddEngineModal(true);
+            setIsLoading(false);
+            setSearchLoading(false);
         }
     };
 
@@ -559,7 +623,8 @@ export const TeamEnginesTable = (props: EnginesTableProps) => {
                                 <Button
                                     variant={'contained'}
                                     onClick={() => {
-                                        getEngines();
+                                        getEngines(true);
+                                        setAddEngineModal(true);
                                     }}
                                 >
                                     Add Engines{' '}
@@ -780,7 +845,8 @@ export const TeamEnginesTable = (props: EnginesTableProps) => {
                             <Button
                                 variant={'contained'}
                                 onClick={() => {
-                                    getEngines();
+                                    getEngines(true);
+                                    setAddEngineModal(true);
                                 }}
                             >
                                 Add Engines
@@ -795,13 +861,18 @@ export const TeamEnginesTable = (props: EnginesTableProps) => {
                     <StyledModalContentText>
                         <Autocomplete
                             label="Select Engine"
+                            loading={searchLoading}
                             multiple={true}
+                            freeSolo={false}
+                            filterOptions={(x) => x}
                             options={nonCredentialedEngines}
+                            includeInputInList={true}
                             limitTags={2}
                             getLimitTagsText={() =>
                                 ` +${selectedNonCredentialedEngines.length - 2}`
                             }
-                            value={[...selectedNonCredentialedEngines]}
+                            value={selectedNonCredentialedEngines}
+                            inputValue={searchEngineInput}
                             getOptionLabel={(option: any) => {
                                 return `${option.engine_name}`;
                             }}
@@ -812,6 +883,23 @@ export const TeamEnginesTable = (props: EnginesTableProps) => {
                                 setSelectedNonCredentialedEngines([
                                     ...newValue,
                                 ]);
+                            }}
+                            ListboxProps={{
+                                onScroll: ({ target }) =>
+                                    setIsScrollBottom(
+                                        nearBottom(
+                                            target as {
+                                                scrollHeight?: number;
+                                                scrollTop?: number;
+                                                clientHeight?: number;
+                                            },
+                                        ),
+                                    ),
+                            }}
+                            onInputChange={(event, newValue) => {
+                                setSearchEngineInput(newValue);
+                                setOffset(0);
+                                setNonCredentialedEngines([]);
                             }}
                         />
 
@@ -1118,7 +1206,11 @@ export const TeamEnginesTable = (props: EnginesTableProps) => {
                 <Modal.Actions>
                     <Button
                         variant="outlined"
-                        onClick={() => setAddEngineModal(false)}
+                        onClick={() => {
+                            setAddEngineModal(false);
+                            setOffset(0);
+                            setNonCredentialedEngines([]);
+                        }}
                     >
                         Cancel
                     </Button>

--- a/packages/client/src/components/teams/TeamEnginesTable.tsx
+++ b/packages/client/src/components/teams/TeamEnginesTable.tsx
@@ -874,7 +874,7 @@ export const TeamEnginesTable = (props: EnginesTableProps) => {
                             value={selectedNonCredentialedEngines}
                             inputValue={searchEngineInput}
                             getOptionLabel={(option: any) => {
-                                return `${option.engine_name}`;
+                                return `${option.engine_name} ID: ${option.engine_id}`;
                             }}
                             isOptionEqualToValue={(option, value) => {
                                 return option.engine_name === value.engine_name;

--- a/packages/client/src/components/teams/TeamMembersTable.tsx
+++ b/packages/client/src/components/teams/TeamMembersTable.tsx
@@ -195,6 +195,8 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 
     const { monolithStore } = useRootStore();
     const notification = useNotification();
+    const AUTOCOMPLETE_LIMIT = 10;
+    const AUTOCOMPLETE_OFFSET = 0;
 
     /** Member Table State */
     const [membersPage, setMembersPage] = useState<number>(1);
@@ -218,6 +220,30 @@ export const TeamMembersTable = (props: MembersTableProps) => {
     const [hasMembers, setHasMembers] = useState(false);
 
     const limit = 5;
+    const [searchMemberInput, setSearchMemberInput] = useState<string>('');
+    const [offset, setOffset] = useState(AUTOCOMPLETE_OFFSET);
+    const [isScrollBottom, setIsScrollBottom] = useState(false);
+    const [canCollect, setCanCollect] = useState<boolean>(true);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [searchLoading, setSearchLoading] = useState(false);
+
+    const nearBottom = (
+        target: {
+            scrollHeight?: number;
+            scrollTop?: number;
+            clientHeight?: number;
+        } = {},
+    ) => {
+        const diff = Math.round(target.scrollHeight - target.scrollTop);
+        return diff - 25 <= target.clientHeight;
+    };
+
+    /**
+     * @name getAdditionalUsersNonGroup
+     */
+    const getAdditionalUsersNonGroup = () => {
+        setOffset(offset + AUTOCOMPLETE_LIMIT);
+    };
 
     const memberSearchRef = useRef(undefined);
 
@@ -249,6 +275,32 @@ export const TeamMembersTable = (props: MembersTableProps) => {
                 setHasMembers(true);
             });
     }, []);
+
+    useEffect(() => {
+        if (isScrollBottom) {
+            if (canCollect) {
+                getAdditionalUsersNonGroup();
+            }
+        }
+    }, [isScrollBottom]);
+
+    useEffect(() => {
+        if (searchMemberInput) {
+            setSearchLoading(true);
+        }
+        const timer = setTimeout(() => {
+            if (!offset) {
+                getUsersNonGroup(false);
+            } else {
+                if (canCollect) {
+                    getUsersNonGroup(false);
+                } else {
+                    getUsersNonGroup(true);
+                }
+            }
+        }, 500);
+        return () => clearTimeout(timer);
+    }, [offset, searchMemberInput]);
 
     /**
      * @name submitNonGroupUsers
@@ -386,15 +438,25 @@ export const TeamMembersTable = (props: MembersTableProps) => {
      * @name getUsersNonGroup
      * @desc Gets all users without credentials
      */
-    const getUsersNonGroup = async () => {
+    const getUsersNonGroup = async (reset: boolean) => {
+        if (isLoading) {
+            return;
+        }
+        setIsLoading(true);
         try {
             let response;
             // possibly add more db table columns / keys here to get id type for display under username
             // eslint-disable-next-line prefer-const
-            response = await monolithStore.getNonTeamUsers(groupId);
+            response = await monolithStore.getNonTeamUsers(
+                groupId,
+                AUTOCOMPLETE_LIMIT,
+                offset,
+                searchMemberInput,
+            );
 
             // ignore if there is no response
             if (response) {
+                let requests = reset ? [] : nonCredentialedUsers;
                 const users = response.map((val) => {
                     return {
                         ...val,
@@ -403,16 +465,19 @@ export const TeamMembersTable = (props: MembersTableProps) => {
                         ],
                     };
                 });
-
-                setNonCredentialedUsers(users);
+                requests = requests.concat(users);
+                setNonCredentialedUsers(requests);
+                setCanCollect(users.length === AUTOCOMPLETE_LIMIT);
+                setIsLoading(false);
+                setSearchLoading(false);
             }
         } catch (e) {
             notification.add({
                 color: 'error',
                 message: String(e),
             });
-        } finally {
-            setAddMembersModal(true);
+            setIsLoading(false);
+            setSearchLoading(false);
         }
     };
 
@@ -546,7 +611,8 @@ export const TeamMembersTable = (props: MembersTableProps) => {
                                 <Button
                                     variant={'contained'}
                                     onClick={() => {
-                                        getUsersNonGroup();
+                                        setAddMembersModal(true);
+                                        getUsersNonGroup(false);
                                     }}
                                 >
                                     Add Members{' '}
@@ -732,7 +798,8 @@ export const TeamMembersTable = (props: MembersTableProps) => {
                             <Button
                                 variant={'contained'}
                                 onClick={() => {
-                                    getUsersNonGroup();
+                                    setAddMembersModal(true);
+                                    getUsersNonGroup(false);
                                 }}
                             >
                                 Add Members{' '}
@@ -748,13 +815,18 @@ export const TeamMembersTable = (props: MembersTableProps) => {
                     <StyledModalContentText>
                         <Autocomplete
                             label="Search"
+                            loading={isLoading || searchLoading}
                             multiple={true}
+                            freeSolo={false}
+                            filterOptions={(x) => x}
                             options={nonCredentialedUsers}
+                            includeInputInList={true}
                             limitTags={2}
                             getLimitTagsText={() =>
                                 ` +${selectedNonCredentialedUsers.length - 2}`
                             }
-                            value={[...selectedNonCredentialedUsers]}
+                            value={selectedNonCredentialedUsers}
+                            inputValue={searchMemberInput}
                             getOptionLabel={(option: any) => {
                                 return `${option.name}`;
                             }}
@@ -763,6 +835,23 @@ export const TeamMembersTable = (props: MembersTableProps) => {
                             }}
                             onChange={(event, newValue: any) => {
                                 setSelectedNonCredentialedUsers([...newValue]);
+                            }}
+                            ListboxProps={{
+                                onScroll: ({ target }) =>
+                                    setIsScrollBottom(
+                                        nearBottom(
+                                            target as {
+                                                scrollHeight?: number;
+                                                scrollTop?: number;
+                                                clientHeight?: number;
+                                            },
+                                        ),
+                                    ),
+                            }}
+                            onInputChange={(event, newValue) => {
+                                setSearchMemberInput(newValue);
+                                setOffset(0);
+                                setNonCredentialedUsers([]);
                             }}
                         />
 
@@ -897,7 +986,11 @@ export const TeamMembersTable = (props: MembersTableProps) => {
                 <Modal.Actions>
                     <Button
                         variant="outlined"
-                        onClick={() => setAddMembersModal(false)}
+                        onClick={() => {
+                            setAddMembersModal(false);
+                            setOffset(0);
+                            setNonCredentialedUsers([]);
+                        }}
                     >
                         Cancel
                     </Button>

--- a/packages/client/src/components/teams/TeamProjectsTable.tsx
+++ b/packages/client/src/components/teams/TeamProjectsTable.tsx
@@ -887,7 +887,7 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                             value={selectedNonCredentialedProjects}
                             inputValue={searchProjectInput}
                             getOptionLabel={(option: any) => {
-                                return `${option.project_name}`;
+                                return `${option.project_name} ID: ${option.project_id}`;
                             }}
                             isOptionEqualToValue={(option, value) => {
                                 return (

--- a/packages/client/src/components/teams/TeamProjectsTable.tsx
+++ b/packages/client/src/components/teams/TeamProjectsTable.tsx
@@ -197,6 +197,8 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
 
     const { monolithStore } = useRootStore();
     const notification = useNotification();
+    const AUTOCOMPLETE_LIMIT = 10;
+    const AUTOCOMPLETE_OFFSET = 0;
 
     /** Project Table State */
     const [projectsPage, setProjectsPage] = useState<number>(1);
@@ -224,6 +226,30 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
     const [hasProjects, setHasProject] = useState(false);
 
     const limit = 5;
+    const [searchProjectInput, setSearchProjectInput] = useState<string>('');
+    const [offset, setOffset] = useState(AUTOCOMPLETE_OFFSET);
+    const [isScrollBottom, setIsScrollBottom] = useState(false);
+    const [canCollect, setCanCollect] = useState<boolean>(true);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [searchLoading, setSearchLoading] = useState(false);
+
+    const nearBottom = (
+        target: {
+            scrollHeight?: number;
+            scrollTop?: number;
+            clientHeight?: number;
+        } = {},
+    ) => {
+        const diff = Math.round(target.scrollHeight - target.scrollTop);
+        return diff - 25 <= target.clientHeight;
+    };
+
+    /**
+     * @name getAdditionalProjects
+     */
+    const getAdditionalProjects = () => {
+        setOffset(offset + AUTOCOMPLETE_LIMIT);
+    };
 
     const projectSearchRef = useRef(undefined);
 
@@ -257,6 +283,32 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                 setHasProject(true);
             });
     }, []);
+
+    useEffect(() => {
+        if (isScrollBottom) {
+            if (canCollect) {
+                getAdditionalProjects();
+            }
+        }
+    }, [isScrollBottom]);
+
+    useEffect(() => {
+        if (searchProjectInput) {
+            setSearchLoading(true);
+        }
+        const timer = setTimeout(() => {
+            if (!offset) {
+                getProjects(false);
+            } else {
+                if (canCollect) {
+                    getProjects(false);
+                } else {
+                    getProjects(true);
+                }
+            }
+        }, 500);
+        return () => clearTimeout(timer);
+    }, [offset, searchProjectInput]);
 
     /**
      * @name submitNonGroupProjects
@@ -398,7 +450,11 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
      * @name getProjects
      * @desc Gets all projects without credentials
      */
-    const getProjects = async () => {
+    const getProjects = async (reset: boolean) => {
+        if (isLoading) {
+            return;
+        }
+        setIsLoading(true);
         try {
             let response;
             // possibly add more db table columns / keys here to get id type for display under projects
@@ -406,10 +462,14 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
             response = await monolithStore.getUnassignedTeamProjects(
                 groupId,
                 groupType,
+                AUTOCOMPLETE_LIMIT,
+                offset,
+                searchProjectInput,
             );
 
             // ignore if there is no response
             if (response) {
+                let requests = reset ? [] : nonCredentialedProjects;
                 const projects = response.map((val) => {
                     return {
                         ...val,
@@ -419,15 +479,19 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                     };
                 });
 
-                setNonCredentialedProjects(projects);
+                requests = requests.concat(projects);
+                setNonCredentialedProjects(requests);
+                setCanCollect(projects.length === AUTOCOMPLETE_LIMIT);
+                setIsLoading(false);
+                setSearchLoading(false);
             }
         } catch (e) {
             notification.add({
                 color: 'error',
                 message: String(e),
             });
-        } finally {
-            setAddProjectModal(true);
+            setIsLoading(false);
+            setSearchLoading(false);
         }
     };
 
@@ -568,7 +632,8 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                                 <Button
                                     variant={'contained'}
                                     onClick={() => {
-                                        getProjects();
+                                        getProjects(true);
+                                        setAddProjectModal(true);
                                     }}
                                 >
                                     Add Projects{' '}
@@ -791,7 +856,8 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                             <Button
                                 variant={'contained'}
                                 onClick={() => {
-                                    getProjects();
+                                    getProjects(true);
+                                    setAddProjectModal(true);
                                 }}
                             >
                                 Add Projects
@@ -806,15 +872,20 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                     <StyledModalContentText>
                         <Autocomplete
                             label="Select App"
+                            loading={searchLoading}
                             multiple={true}
+                            freeSolo={false}
+                            filterOptions={(x) => x}
                             options={nonCredentialedProjects}
+                            includeInputInList={true}
                             limitTags={2}
                             getLimitTagsText={() =>
                                 ` +${
                                     selectedNonCredentialedProjects.length - 2
                                 }`
                             }
-                            value={[...selectedNonCredentialedProjects]}
+                            value={selectedNonCredentialedProjects}
+                            inputValue={searchProjectInput}
                             getOptionLabel={(option: any) => {
                                 return `${option.project_name}`;
                             }}
@@ -827,6 +898,23 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                                 setSelectedNonCredentialedProjects([
                                     ...newValue,
                                 ]);
+                            }}
+                            ListboxProps={{
+                                onScroll: ({ target }) =>
+                                    setIsScrollBottom(
+                                        nearBottom(
+                                            target as {
+                                                scrollHeight?: number;
+                                                scrollTop?: number;
+                                                clientHeight?: number;
+                                            },
+                                        ),
+                                    ),
+                            }}
+                            onInputChange={(event, newValue) => {
+                                setSearchProjectInput(newValue);
+                                setOffset(0);
+                                setNonCredentialedProjects([]);
                             }}
                         />
 
@@ -1133,7 +1221,11 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                 <Modal.Actions>
                     <Button
                         variant="outlined"
-                        onClick={() => setAddProjectModal(false)}
+                        onClick={() => {
+                            setAddProjectModal(false);
+                            setOffset(0);
+                            setNonCredentialedProjects([]);
+                        }}
                     >
                         Cancel
                     </Button>

--- a/packages/client/src/stores/monolith/monolith.store.ts
+++ b/packages/client/src/stores/monolith/monolith.store.ts
@@ -1188,7 +1188,12 @@ export class MonolithStore {
      * @name getNonTeamUsers
      * @param groupId
      */
-    async getNonTeamUsers(groupId: string) {
+    async getNonTeamUsers(
+        groupId: string,
+        limit: number,
+        offset: number,
+        searchTerm: string,
+    ) {
         let url = `${Env.MODULE}/api/auth/admin/`;
 
         url += 'group/getNonGroupMembers';
@@ -1196,6 +1201,9 @@ export class MonolithStore {
         const params = {};
 
         groupId && (params['groupId'] = groupId);
+        limit && (params['limit'] = limit);
+        offset && (params['offset'] = offset);
+        searchTerm && (params['searchTerm'] = searchTerm);
 
         const response = await axios
             .get(url, {
@@ -1463,7 +1471,13 @@ export class MonolithStore {
      * @param offSet
      * @param searchTerm
      */
-    async getUnassignedTeamProjects(groupId: string, groupType: string) {
+    async getUnassignedTeamProjects(
+        groupId: string,
+        groupType: string,
+        limit: number,
+        offset: number,
+        searchTerm: string,
+    ) {
         let url = `${Env.MODULE}/api/auth/admin/`;
 
         url += 'group/getAvailableProjectsForGroup';
@@ -1472,6 +1486,9 @@ export class MonolithStore {
 
         groupId && (params['groupId'] = groupId);
         groupType && (params['groupType'] = groupType);
+        limit && (params['limit'] = limit);
+        offset && (params['offset'] = offset);
+        searchTerm && (params['searchTerm'] = searchTerm);
 
         const response = await axios
             .get(url, {
@@ -1660,7 +1677,13 @@ export class MonolithStore {
      * @param offSet
      * @param searchTerm
      */
-    async getUnassignedTeamEngines(groupId: string, groupType: string) {
+    async getUnassignedTeamEngines(
+        groupId: string,
+        groupType: string,
+        limit: number,
+        offset: number,
+        searchTerm: string,
+    ) {
         let url = `${Env.MODULE}/api/auth/admin/`;
 
         url += 'group/getAvailableEnginesForGroup';
@@ -1669,6 +1692,9 @@ export class MonolithStore {
 
         groupId && (params['groupId'] = groupId);
         groupType && (params['groupType'] = groupType);
+        limit && (params['limit'] = limit);
+        offset && (params['offset'] = offset);
+        searchTerm && (params['searchTerm'] = searchTerm);
 
         const response = await axios
             .get(url, {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Implemented infinite scrolling and search functionality on table modal search inputs on the Team Permissions page.

## Changes Made
<!-- List the key changes made in this PR -->
- Added infinite scrolling and search functionality to the Autocomplete component for members, projects, and engine in the modal
- Added limit, offset, searchTerm data fields to the getNonTeamUsers, getUnassignedTeamProjects, and getUnassignedTeamEngines pixel calls.
- Added ID to the project and engine dropdown labels

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
On the Team Permissions page, when you click "Add Members", "Add Projects", or "Add Engines", it brings up a modal with a search input.
- Test the infinite scroll functionality within the autocomplete search component.
- When typing in the search input, check the network console to ensure that the search triggers a query to the back-end.

2. Expected outcomes
As you scroll near the bottom of the search component, a query gets called to grab the next set of 10 items.
When typing in the search input, the search triggers a query to the back-end.

## Notes
<!-- Any further notes regarding changes -->