### PR TITLE
feat: app clone from another app

### DIFF
--- a/packages/client/src/components/app/AppTileCard.tsx
+++ b/packages/client/src/components/app/AppTileCard.tsx
@@ -26,6 +26,7 @@ import { APP_IMAGES } from './app.images';
 import { removeUnderscores } from '@/utility';
 import { AppDeleteModal } from '@/components/app';
 import { useNavigate } from 'react-router-dom';
+import { AddAppCloneModal } from '@/components/app/save-app/AddAppCloneModal';
 
 const StyledName = styled(Typography)(() => ({
     fontWeight: 500,
@@ -220,11 +221,18 @@ export const AppTileCard = (props: AppTileCardProps) => {
     const navigate = useNavigate();
 
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-
+    const [isUploadOpen, setIsUploadOpen] = useState(false);
     const [isAppDeleteModalOpen, setIsAppDeleteModalOpen] = useState(false);
 
     const open = Boolean(anchorEl);
 
+    const navigateApp = (appId: string) => {
+        if (!appId) {
+            return;
+        }
+
+        navigate(`/workspace/${appId}`);
+    };
     const copyProjectId = (projectId: string) => {
         try {
             navigator.clipboard.writeText(projectId);
@@ -478,6 +486,16 @@ export const AppTileCard = (props: AppTileCardProps) => {
                 </Menu.Item>
                 {app?.user_permission && app.user_permission < 2 && (
                     <Menu.Item
+                        value="clone"
+                        onClick={() => {
+                            setIsUploadOpen(true);
+                        }}
+                    >
+                        Clone This App
+                    </Menu.Item>
+                )}
+                {app?.user_permission && app.user_permission < 2 && (
+                    <Menu.Item
                         value="delete"
                         onClick={() => {
                             setIsAppDeleteModalOpen(true);
@@ -499,6 +517,22 @@ export const AppTileCard = (props: AppTileCardProps) => {
                     onDelete();
                 }}
             />
+            {isUploadOpen ? (
+                <AddAppCloneModal
+                    open={isUploadOpen}
+                    appId={app.project_id}
+                    handleClose={(appId) => {
+                        console.log('ok');
+                        // if there is an appId navigate to it
+                        if (appId) {
+                            navigateApp(appId);
+                        }
+
+                        // close it
+                        setIsUploadOpen(false);
+                    }}
+                />
+            ) : null}
         </StyledTileCard>
     );
 };

--- a/packages/client/src/components/app/save-app/AddAppCloneModal.tsx
+++ b/packages/client/src/components/app/save-app/AddAppCloneModal.tsx
@@ -20,7 +20,6 @@ import { Control } from 'react-hook-form';
 type AddAppForm = {
     [ADD_APP_FORM_FIELD_NAME]: string;
     [ADD_APP_FORM_FIELD_APP_TYPE]: string;
-    [ADD_APP_FORM_FIELD_UPLOAD]: File;
     [ADD_APP_FORM_FIELD_IS_GLOBAL]: boolean;
     [ADD_APP_FORM_FIELD_TYPE]: string;
 };
@@ -75,7 +74,6 @@ export const AddAppCloneModal = (props: AddAppProps) => {
     const defaultFormValues: AddAppForm = {
         [ADD_APP_FORM_FIELD_NAME]: '',
         [ADD_APP_FORM_FIELD_APP_TYPE]: 'CODE',
-        [ADD_APP_FORM_FIELD_UPLOAD]: null,
         [ADD_APP_FORM_FIELD_IS_GLOBAL]: false,
         [ADD_APP_FORM_FIELD_TYPE]: 'Assets Copy',
     };
@@ -84,26 +82,34 @@ export const AddAppCloneModal = (props: AddAppProps) => {
      * Method that is called to clone the app
      */
     const cloneApp = async (data: AddAppForm) => {
-        const clonePorjectResponse = await monolithStore.runQuery(
-            `CreateAppFromTemplate(project=["${data[ADD_APP_FORM_FIELD_NAME]}"], projectTemplate=["${appId}"], global=["${data[ADD_APP_FORM_FIELD_IS_GLOBAL]}"]);`,
-        );
-        let output = undefined;
-        let type = undefined;
+        try {
+            const cloneProjectResponse = await monolithStore.runQuery(
+                `CreateAppFromTemplate(project=["${data[ADD_APP_FORM_FIELD_NAME]}"], projectTemplate=["${appId}"], global=["${data[ADD_APP_FORM_FIELD_IS_GLOBAL]}"]);`,
+            );
+            let output = undefined;
+            let type = undefined;
 
-        output = clonePorjectResponse.pixelReturn[0].output;
-        type = clonePorjectResponse.pixelReturn[0].operationType[0];
+            output = cloneProjectResponse.pixelReturn[0].output;
+            type = cloneProjectResponse.pixelReturn[0].operationType[0];
 
-        if (type.indexOf('ERROR') > -1) {
+            if (type.indexOf('ERROR') > -1) {
+                notification.add({
+                    color: 'error',
+                    message: output,
+                });
+
+                return;
+            }
+            // close it
+
+            handleClose(output.project_id);
+        } catch (error) {
             notification.add({
                 color: 'error',
-                message: output,
+                message:
+                    'There was an error cloning your app. Please check your template files and try again.',
             });
-
-            return;
         }
-        // close it
-
-        handleClose(output.project_id);
     };
 
     return (

--- a/packages/client/src/components/app/save-app/AddAppCloneModal.tsx
+++ b/packages/client/src/components/app/save-app/AddAppCloneModal.tsx
@@ -84,7 +84,7 @@ export const AddAppCloneModal = (props: AddAppProps) => {
     const cloneApp = async (data: AddAppForm) => {
         try {
             const cloneProjectResponse = await monolithStore.runQuery(
-                `CreateAppFromTemplate(project=["${data[ADD_APP_FORM_FIELD_NAME]}"], projectTemplate=["${appId}"], global=["${data[ADD_APP_FORM_FIELD_IS_GLOBAL]}"]);`,
+                `CreateAppFromTemplate(project=["${data[ADD_APP_FORM_FIELD_NAME]}"], projectTemplateId=["${appId}"], global=["${data[ADD_APP_FORM_FIELD_IS_GLOBAL]}"]);`,
             );
             let output = undefined;
             let type = undefined;

--- a/packages/client/src/components/app/save-app/AddAppCloneModal.tsx
+++ b/packages/client/src/components/app/save-app/AddAppCloneModal.tsx
@@ -84,7 +84,7 @@ export const AddAppCloneModal = (props: AddAppProps) => {
     const cloneApp = async (data: AddAppForm) => {
         try {
             const cloneProjectResponse = await monolithStore.runQuery(
-                `CreateAppFromTemplate(project=["${data[ADD_APP_FORM_FIELD_NAME]}"], projectTemplateId=["${appId}"], global=["${data[ADD_APP_FORM_FIELD_IS_GLOBAL]}"]);`,
+                `CreateAppFromTemplate(project=["${data[ADD_APP_FORM_FIELD_NAME]}"], projectTemplate=["${appId}"], global=["${data[ADD_APP_FORM_FIELD_IS_GLOBAL]}"]);`,
             );
             let output = undefined;
             let type = undefined;

--- a/packages/client/src/components/app/save-app/AddAppCloneModal.tsx
+++ b/packages/client/src/components/app/save-app/AddAppCloneModal.tsx
@@ -1,0 +1,120 @@
+import React, { Dispatch, SetStateAction, useState } from 'react';
+import { useRootStore } from '@/hooks';
+import { Edit, LocalOffer, Visibility } from '@mui/icons-material';
+import {
+    ADD_APP_FORM_FIELD_APP_TYPE,
+    ADD_APP_FORM_FIELD_DESCRIPTION,
+    ADD_APP_FORM_FIELD_IS_GLOBAL,
+    ADD_APP_FORM_FIELD_NAME,
+    ADD_APP_FORM_FIELD_TAGS,
+    ADD_APP_FORM_FIELD_UPLOAD,
+    ADD_APP_FORM_FIELD_TYPE,
+} from './save-app.constants';
+import { AppAccessStep } from './AppAccessStep';
+import { SaveAppModal } from './SaveAppModal';
+import { AppDetailsStep } from './AppDetailsStep';
+import { useNotification } from '@semoss/ui';
+import { AppTagsStep } from './AppTagsStep';
+import { Control } from 'react-hook-form';
+
+type AddAppForm = {
+    [ADD_APP_FORM_FIELD_NAME]: string;
+    [ADD_APP_FORM_FIELD_APP_TYPE]: string;
+    [ADD_APP_FORM_FIELD_UPLOAD]: File;
+    [ADD_APP_FORM_FIELD_IS_GLOBAL]: boolean;
+    [ADD_APP_FORM_FIELD_TYPE]: string;
+};
+
+export type AddAppFormStep = {
+    name: string;
+    icon: React.ReactElement;
+    title: string;
+    component: React.FunctionComponent<{
+        control: Control<any, any>;
+        disabled: boolean;
+        setAddAppFormSteps?: Dispatch<SetStateAction<AddAppFormStep[]>>;
+        appZipFormSteps?: AddAppFormStep[];
+        projectZipFormSteps?: AddAppFormStep[];
+    }>;
+    requiredFields: string[];
+};
+
+interface AddAppProps {
+    /** Track if the model is open */
+    open: boolean;
+    appId: string;
+    /** Callback that is triggered on close */
+    handleClose: (appId?: string) => void;
+}
+
+export const AddAppCloneModal = (props: AddAppProps) => {
+    const projectZipFormSteps = [
+        {
+            name: 'Details',
+            icon: <Edit />,
+            title: 'Details',
+            component: AppDetailsStep,
+            requiredFields: [ADD_APP_FORM_FIELD_NAME],
+        },
+        {
+            name: 'Access',
+            icon: <Visibility />,
+            title: 'Access',
+            component: AppAccessStep,
+            requiredFields: [],
+        },
+    ];
+
+    const [addAppFormSteps] = useState<AddAppFormStep[]>(projectZipFormSteps);
+
+    const { open, handleClose, appId } = props;
+
+    const { monolithStore } = useRootStore();
+    const notification = useNotification();
+
+    const defaultFormValues: AddAppForm = {
+        [ADD_APP_FORM_FIELD_NAME]: '',
+        [ADD_APP_FORM_FIELD_APP_TYPE]: 'CODE',
+        [ADD_APP_FORM_FIELD_UPLOAD]: null,
+        [ADD_APP_FORM_FIELD_IS_GLOBAL]: false,
+        [ADD_APP_FORM_FIELD_TYPE]: 'Assets Copy',
+    };
+
+    /**
+     * Method that is called to clone the app
+     */
+    const cloneApp = async (data: AddAppForm) => {
+        const clonePorjectResponse = await monolithStore.runQuery(
+            `CreateAppFromTemplate(project=["${data[ADD_APP_FORM_FIELD_NAME]}"], projectTemplate=["${appId}"], global=["${data[ADD_APP_FORM_FIELD_IS_GLOBAL]}"]);`,
+        );
+        let output = undefined;
+        let type = undefined;
+
+        output = clonePorjectResponse.pixelReturn[0].output;
+        type = clonePorjectResponse.pixelReturn[0].operationType[0];
+
+        if (type.indexOf('ERROR') > -1) {
+            notification.add({
+                color: 'error',
+                message: output,
+            });
+
+            return;
+        }
+        // close it
+
+        handleClose(output.project_id);
+    };
+
+    return (
+        <SaveAppModal
+            open={open}
+            handleClose={handleClose}
+            title="Want to clone this app ?"
+            steps={addAppFormSteps}
+            defaultFormValues={defaultFormValues}
+            handleFormSubmit={cloneApp}
+            errorMessage="There was an error cloning your app. Please check your template files and try again."
+        />
+    );
+};


### PR DESCRIPTION
## Description
This is app clone feature, which was pending from long time. Initially discuss longtime ago, It'll create a clone from previous apps.

## Changes Made
UI changes and New Model added for the app clone funtinality

## How to Test
1. Go to the main dashboard page, clicking on 3 dots will show a popup for delete and also include cloning the app. 
2. Click on clone this app to trigger the modal and follow the steps and create a new app.

## Notes
Initially created by @mananmittal07 , just look at the PR, and check once. 
Used the **CreateAppFromTemplate** Reactor, there will be connecting PR which is required to accept projectTemplate properly. @Khumar23 will be adding that soon. 