### PR TITLE
Resolve 'Members Page Search Pagination Bug'

### DIFF
--- a/packages/client/src/components/settings/UserTable.tsx
+++ b/packages/client/src/components/settings/UserTable.tsx
@@ -232,7 +232,7 @@ export const UserTable = (props: UserTableProps) => {
         adminMode,
         debouncedSearch ? debouncedSearch : '',
         (page + 1) * rowsPerPage - rowsPerPage, // offset
-        rowsPerPage, // limit
+        count, // limit
     ]);
 
     // track if the page is loading


### PR DESCRIPTION
## Description
Edit limit in getUsers to match count, now we return all search results.

## Changes Made
Edit limit in getUsers to match total user count.

## How to Test
1. Go to 'http://localhost:9090/SemossWeb/packages/client/dist/#'
2. Click on 'Admin Page'
3. Scroll down to and select 'Members Settings'
4. Select '25' for 'RowsPerPage' dropdown
5. Add 26 Users (UserId1 - UserId26)

1. Returns 26 results.
2. See the 1 - 25, need to use pagination to see result 26.
