### PR TITLE
305 sort on permissions member's table

### DIFF
--- a/packages/client/src/components/settings/MembersTable.tsx
+++ b/packages/client/src/components/settings/MembersTable.tsx
@@ -24,6 +24,7 @@ import { useRootStore, useAPI, useSettings, useDebounceValue } from '@/hooks';
 import { SETTINGS_PROVISIONED_USER } from './settings.types';
 import { MembersDeleteOverlay } from './MembersDeleteOverlay';
 import { MembersAddOverlay } from './MembersAddOverlay';
+import { TableSortLabel } from '@mui/material';
 
 const AvatarWrapper = styled('div')({
     display: 'inline-block',
@@ -236,6 +237,9 @@ export const MembersTable = (props: MembersTableProps) => {
     const [selectedMembers, setSelectedMembers] = useState<
         SETTINGS_PROVISIONED_USER[]
     >([]);
+    /* Table Sorting */
+    const [order, setOrder] = useState<'asc' | 'desc'>('asc');
+    const [orderBy, setOrderBy] = useState<string>('name');
 
     // debounce the input
     const debouncedSearch = useDebounceValue(search);
@@ -438,6 +442,32 @@ export const MembersTable = (props: MembersTableProps) => {
     const hasMembers =
         getMembers.status === 'SUCCESS' && getMembers.data['totalMembers'] > 0;
 
+    /**  
+    * Handle Table Sorting Logic
+    * 
+    * @param sortingMethod
+    */
+    const handleRequestSort = (sortingMethod: string) => {
+        const isAsc = orderBy === sortingMethod && order === 'asc';
+        setOrder(isAsc ? 'desc' : 'asc');
+        setOrderBy(sortingMethod);
+    };
+
+    /**
+     * Sort Members
+     * 
+     * @returns sorted members
+     */
+    const sortedMembers = useMemo(() => {
+        return [...renderedMembers].sort((a, b) => {
+            if (orderBy === 'name') {
+                return order === 'asc'
+                    ? a.name.localeCompare(b.name)
+                    : b.name.localeCompare(a.name);
+            }
+            return 0; // Add more sorting logic for other columns if needed
+        });
+    }, [renderedMembers, order, orderBy]);
     // Avatars rendered
     const Avatars = useMemo(() => {
         if (!renderedMembers.length) {
@@ -584,10 +614,16 @@ export const MembersTable = (props: MembersTableProps) => {
                                                 />
                                             </Table.Cell>
                                             <Table.Cell size="small">
-                                                Name
+                                                <TableSortLabel
+                                                    active={orderBy === 'name'}
+                                                    direction={order}
+                                                    onClick={() => handleRequestSort('name')}            
+                                                >
+                                                    Name
+                                                </TableSortLabel>
                                             </Table.Cell>
                                             <Table.Cell size="small">
-                                                Permission
+                                                <TableSortLabel>Permission</TableSortLabel>
                                             </Table.Cell>
                                             {type === 'MODEL' && (
                                                 <>
@@ -608,8 +644,8 @@ export const MembersTable = (props: MembersTableProps) => {
                                         </Table.Row>
                                     </Table.Head>
                                     <Table.Body>
-                                        {renderedMembers.map((x, i) => {
-                                            const user = renderedMembers[i];
+                                        {sortedMembers.map((x, i) => {
+                                            const user = sortedMembers[i];
 
                                             let isSelected = false;
 

--- a/packages/client/src/components/settings/MembersTable.tsx
+++ b/packages/client/src/components/settings/MembersTable.tsx
@@ -473,10 +473,7 @@ export const MembersTable = (props: MembersTableProps) => {
             return permissionOrder[permissionMapper[permission]] || 0;
         };
         return [...renderedMembers].sort((a, b) => {
-                // sort by name
-                const nameComparison = nameOrder === 'asc'
-                    ? a.name.localeCompare(b.name)
-                    : b.name.localeCompare(a.name);
+                
                 // sort by permission
                 const permissionA = getPermissionOrder(a.permission);
                 const permissionB = getPermissionOrder(b.permission);
@@ -484,8 +481,13 @@ export const MembersTable = (props: MembersTableProps) => {
                 const permissionComparison = permissionOrder === 'asc'
                     ? permissionA - permissionB
                     : permissionB - permissionA;
-                // Apply both sorts independently
-                return nameComparison || permissionComparison;
+                
+                if(permissionComparison === 0) {
+                    return nameOrder === 'asc'
+                        ? a.name.localeCompare(b.name)
+                        : b.name.localeCompare(a.name);
+                }
+                return permissionComparison;
             });
     }, [renderedMembers, nameOrder, permissionOrder]);
     /**

--- a/packages/client/src/components/settings/MembersTable.tsx
+++ b/packages/client/src/components/settings/MembersTable.tsx
@@ -238,8 +238,8 @@ export const MembersTable = (props: MembersTableProps) => {
         SETTINGS_PROVISIONED_USER[]
     >([]);
     /* Table Sorting */
-    const [order, setOrder] = useState<'asc' | 'desc'>('asc');
-    const [orderBy, setOrderBy] = useState<string>('name');
+    const [nameOrder, setNameOrder] = useState<'asc' | 'desc'>('asc');
+    const [permissionOrder, setPermissionOrder] = useState<'asc' | 'desc'>('asc');
 
     // debounce the input
     const debouncedSearch = useDebounceValue(search);
@@ -442,16 +442,16 @@ export const MembersTable = (props: MembersTableProps) => {
     const hasMembers =
         getMembers.status === 'SUCCESS' && getMembers.data['totalMembers'] > 0;
 
-    /**  
-    * Handle Table Sorting Logic
-    * 
-    * @param sortingMethod
-    */
-    const handleRequestSort = (sortingMethod: string) => {
-        const isAsc = orderBy === sortingMethod && order === 'asc';
-        setOrder(isAsc ? 'desc' : 'asc');
-        setOrderBy(sortingMethod);
-    };
+    // /**  
+    // * Handle Table Sorting Logic
+    // * 
+    // * @param sortingMethod
+    // */
+    // const handleRequestSort = (sortingMethod: string) => {
+    //     const isAsc = orderBy === sortingMethod && order === 'asc';
+    //     setOrder(isAsc ? 'desc' : 'asc');
+    //     setOrderBy(sortingMethod);
+    // };
 
     /**
      * Sort Members
@@ -473,18 +473,36 @@ export const MembersTable = (props: MembersTableProps) => {
             return permissionOrder[permissionMapper[permission]] || 0;
         };
         return [...renderedMembers].sort((a, b) => {
-            if (orderBy === 'name') {
-                return order === 'asc'
+                // sort by name
+                const nameComparison = nameOrder === 'asc'
                     ? a.name.localeCompare(b.name)
                     : b.name.localeCompare(a.name);
-            } else if (orderBy === 'permission') {
+                // sort by permission
                 const permissionA = getPermissionOrder(a.permission);
                 const permissionB = getPermissionOrder(b.permission);
-                return order === 'asc' ? permissionA - permissionB : permissionB - permissionA; // Because Three Permissions, get first two , returns the difference. (if A is alphabetically smaller, it should be earlier because asc)
-            }
-            return 0;
-        });
-    }, [renderedMembers, order, orderBy]);
+                //A - B means A is before B
+                const permissionComparison = permissionOrder === 'asc'
+                    ? permissionA - permissionB
+                    : permissionB - permissionA;
+                // Apply both sorts independently
+                return nameComparison || permissionComparison;
+            });
+    }, [renderedMembers, nameOrder, permissionOrder]);
+    /**
+     * Handle Table Sorting Logic for Names
+     * 
+     */
+    const handleNameSort = () => {
+        setNameOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    };
+     /**
+     * Handle Table Sorting Logic for Pames
+     * 
+     */
+    const handlePermissionSort = () => {
+        setPermissionOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    };
+
     // Avatars rendered
     const Avatars = useMemo(() => {
         if (!renderedMembers.length) {
@@ -632,18 +650,18 @@ export const MembersTable = (props: MembersTableProps) => {
                                             </Table.Cell>
                                             <Table.Cell size="small">
                                                 <TableSortLabel
-                                                    active={orderBy === 'name'}
-                                                    direction={order}
-                                                    onClick={() => handleRequestSort('name')}
+                                                    active={true} // sort icon is always visible
+                                                    direction={nameOrder} // direction of the icon, up is asc
+                                                    onClick={() => handleNameSort()}
                                                 >
                                                     Name
                                                 </TableSortLabel>
                                             </Table.Cell>
                                             <Table.Cell size="small">
                                                 <TableSortLabel
-                                                    active={orderBy === 'permission'}
-                                                    direction={order}
-                                                    onClick={() => handleRequestSort('permission')}
+                                                    active={true}
+                                                    direction={permissionOrder}
+                                                    onClick={() => handlePermissionSort()}
                                                 >
                                                     Permission
                                                 </TableSortLabel>

--- a/packages/client/src/components/settings/MembersTable.tsx
+++ b/packages/client/src/components/settings/MembersTable.tsx
@@ -459,13 +459,30 @@ export const MembersTable = (props: MembersTableProps) => {
      * @returns sorted members
      */
     const sortedMembers = useMemo(() => {
+        /**
+         * 
+         * @param permission 
+         * @returns order of the permission
+         */
+        const getPermissionOrder = (permission: string): number => {
+            const permissionOrder = {
+                'Author': 1,
+                'Editor': 2,
+                'Read-Only': 3,
+            };
+            return permissionOrder[permissionMapper[permission]] || 0;
+        };
         return [...renderedMembers].sort((a, b) => {
             if (orderBy === 'name') {
                 return order === 'asc'
                     ? a.name.localeCompare(b.name)
                     : b.name.localeCompare(a.name);
+            } else if (orderBy === 'permission') { 
+                const permissionA = getPermissionOrder(a.permission); 
+                const permissionB = getPermissionOrder(b.permission);
+                return order === 'asc' ? permissionA - permissionB : permissionB - permissionA; // Because Three Permissions, get first two , returns the difference. (if A is alphabetically smaller, it should be earlier because asc)
             }
-            return 0; // Add more sorting logic for other columns if needed
+            return 0;
         });
     }, [renderedMembers, order, orderBy]);
     // Avatars rendered
@@ -623,7 +640,13 @@ export const MembersTable = (props: MembersTableProps) => {
                                                 </TableSortLabel>
                                             </Table.Cell>
                                             <Table.Cell size="small">
-                                                <TableSortLabel>Permission</TableSortLabel>
+                                                <TableSortLabel
+                                                    active={orderBy === 'permission'}
+                                                    direction={order}
+                                                    onClick={() => handleRequestSort('permission')}
+                                                >
+                                                    Permission
+                                                </TableSortLabel>
                                             </Table.Cell>
                                             {type === 'MODEL' && (
                                                 <>

--- a/packages/client/src/components/settings/MembersTable.tsx
+++ b/packages/client/src/components/settings/MembersTable.tsx
@@ -260,30 +260,30 @@ export const MembersTable = (props: MembersTableProps) => {
     // get the api
     const getMembersApi: Parameters<typeof useAPI>[0] =
         type === 'DATABASE' ||
-        type === 'STORAGE' ||
-        type === 'MODEL' ||
-        type === 'VECTOR' ||
-        type === 'FUNCTION'
+            type === 'STORAGE' ||
+            type === 'MODEL' ||
+            type === 'VECTOR' ||
+            type === 'FUNCTION'
             ? [
-                  'getEngineUsers',
-                  adminMode,
-                  id,
-                  debouncedSearch ? debouncedSearch : undefined,
-                  permissionMapper[permissionFilter],
-                  (page + 1) * rowsPerPage - rowsPerPage, // offset
-                  rowsPerPage, // limit
-              ]
+                'getEngineUsers',
+                adminMode,
+                id,
+                debouncedSearch ? debouncedSearch : undefined,
+                permissionMapper[permissionFilter],
+                (page + 1) * rowsPerPage - rowsPerPage, // offset
+                rowsPerPage, // limit
+            ]
             : type === 'APP'
-            ? [
-                  'getProjectUsers',
-                  adminMode,
-                  id,
-                  debouncedSearch ? debouncedSearch : undefined,
-                  permissionMapper[permissionFilter],
-                  (page + 1) * rowsPerPage - rowsPerPage, // offset
-                  rowsPerPage, // limit
-              ]
-            : null;
+                ? [
+                    'getProjectUsers',
+                    adminMode,
+                    id,
+                    debouncedSearch ? debouncedSearch : undefined,
+                    permissionMapper[permissionFilter],
+                    (page + 1) * rowsPerPage - rowsPerPage, // offset
+                    rowsPerPage, // limit
+                ]
+                : null;
 
     const getMembers = useAPI(getMembersApi);
 
@@ -477,8 +477,8 @@ export const MembersTable = (props: MembersTableProps) => {
                 return order === 'asc'
                     ? a.name.localeCompare(b.name)
                     : b.name.localeCompare(a.name);
-            } else if (orderBy === 'permission') { 
-                const permissionA = getPermissionOrder(a.permission); 
+            } else if (orderBy === 'permission') {
+                const permissionA = getPermissionOrder(a.permission);
                 const permissionB = getPermissionOrder(b.permission);
                 return order === 'asc' ? permissionA - permissionB : permissionB - permissionA; // Because Three Permissions, get first two , returns the difference. (if A is alphabetically smaller, it should be earlier because asc)
             }
@@ -610,9 +610,9 @@ export const MembersTable = (props: MembersTableProps) => {
                                                 <Checkbox
                                                     checked={
                                                         selectedMembers.length ===
-                                                            renderedMembers.length &&
+                                                        renderedMembers.length &&
                                                         renderedMembers.length >
-                                                            0
+                                                        0
                                                     }
                                                     onChange={() => {
                                                         if (
@@ -634,7 +634,7 @@ export const MembersTable = (props: MembersTableProps) => {
                                                 <TableSortLabel
                                                     active={orderBy === 'name'}
                                                     direction={order}
-                                                    onClick={() => handleRequestSort('name')}            
+                                                    onClick={() => handleRequestSort('name')}
                                                 >
                                                     Name
                                                 </TableSortLabel>
@@ -743,8 +743,8 @@ export const MembersTable = (props: MembersTableProps) => {
                                                                 row
                                                                 defaultValue={
                                                                     permissionMapper[
-                                                                        user
-                                                                            .permission
+                                                                    user
+                                                                        .permission
                                                                     ]
                                                                 }
                                                                 onChange={(
@@ -753,9 +753,9 @@ export const MembersTable = (props: MembersTableProps) => {
                                                                     updateSelectedUsers(
                                                                         [user],
                                                                         permissionMapper[
-                                                                            e
-                                                                                .target
-                                                                                .value
+                                                                        e
+                                                                            .target
+                                                                            .value
                                                                         ],
                                                                     );
                                                                 }}
@@ -778,13 +778,13 @@ export const MembersTable = (props: MembersTableProps) => {
                                                             <>
                                                                 <Table.Cell>
                                                                     {user.usage_restriction !==
-                                                                    undefined
+                                                                        undefined
                                                                         ? formatValue(
-                                                                              user.usage_restriction,
-                                                                          )
+                                                                            user.usage_restriction,
+                                                                        )
                                                                         : formatValue(
-                                                                              'null',
-                                                                          )}
+                                                                            'null',
+                                                                        )}
                                                                 </Table.Cell>
                                                                 <Table.Cell>
                                                                     {user?.usage_restriction ===


### PR DESCRIPTION
## Description
Adding the feature to allow for Alphabetical sorting on the Member's table. Sorting capability for "Name" and "Permissions"

## Changes Made

- Sorting Icon Label to Table Headers
- Created variables to handle the order method and option.
- Sorting function 
- Indentation formatting for MembersTable.tsx

## How to Test

- Add members to the members table.
- click on the arrow icon next to either Name or Permissions

## Notes
https://github.com/orgs/SEMOSS/projects/34/views/1?pane=issue&itemId=105205896&issue=SEMOSS%7Ccommunity%7C305