### PR TITLE
Side menu and product catalog non admin restriction

### DIFF
--- a/packages/client/src/pages/HomePage.tsx
+++ b/packages/client/src/pages/HomePage.tsx
@@ -287,7 +287,11 @@ export const HomePage = observer((): JSX.Element => {
             }
         }
     };
+    let isCreateAppUser = false;
 
+    if(configStore.store.user.admin){
+        isCreateAppUser  = true;
+    }
     return (
         <Page
             header={
@@ -328,6 +332,7 @@ export const HomePage = observer((): JSX.Element => {
                                 }}
                             />
                         </Stack>
+                        { isCreateAppUser && (
                         <Button
                             size={'large'}
                             variant={'contained'}
@@ -338,6 +343,7 @@ export const HomePage = observer((): JSX.Element => {
                         >
                             Create New App
                         </Button>
+                        )}
                     </Stack>
                 </Stack>
             }

--- a/packages/client/src/pages/NavigatorLayout.tsx
+++ b/packages/client/src/pages/NavigatorLayout.tsx
@@ -13,6 +13,7 @@ import { ErrorBoundary } from '@/components/common';
 import { ENGINE_ROUTES } from '@/pages/engine';
 import { ErrorPage } from './ErrorPage';
 import { PlatformMessages } from './PlatformMessages';
+import { usePixel, useRootStore } from '@/hooks';
 
 const NAV_HEIGHT = '48px';
 const SIDEBAR_WIDTH = '56px';
@@ -82,11 +83,21 @@ const StyledContent = styled('div')(() => ({
 export const NavigatorLayout = observer(() => {
     const { pathname } = useLocation();
 
+   const { configStore} = useRootStore();
+   let isSideMenu  = false
+      
+   if(configStore.store.user.admin){
+     isSideMenu  = true;
+   }
+
     return (
         <ErrorBoundary fallback={<ErrorPage />}>
             <Navbar />
+            { isSideMenu && (
             <StyledSidebar>
+          
                 <Tooltip title={`Open App Library`} placement="right">
+                   
                     <StyledSidebarItem
                         data-tour="nav-app-library"
                         to={'/'}
@@ -102,7 +113,8 @@ export const NavigatorLayout = observer(() => {
                     </StyledSidebarItem>
                 </Tooltip>
                 <StyledSidebarDivider />
-                {ENGINE_ROUTES.map((r) => (
+               
+                {  ENGINE_ROUTES.map((r) => (
                     <Tooltip
                         title={`Open ${r.name}`}
                         key={r.path}
@@ -122,6 +134,7 @@ export const NavigatorLayout = observer(() => {
                         </StyledSidebarItem>
                     </Tooltip>
                 ))}
+           
                 {/* <Tooltip title={`Open Prompt Hub`} placement="right">
                     <StyledSidebarItem
                         to={'/prompt'}
@@ -133,6 +146,7 @@ export const NavigatorLayout = observer(() => {
                         </Icon>
                     </StyledSidebarItem>
                 </Tooltip> */}
+                  
                 <Stack flex={1}>&nbsp;</Stack>
                 <Tooltip title={`Open Settings`} placement="right">
                     <StyledSidebarItem
@@ -146,6 +160,7 @@ export const NavigatorLayout = observer(() => {
                     </StyledSidebarItem>
                 </Tooltip>
             </StyledSidebar>
+            )}
             <StyledContent>
                 <PlatformMessages platformAssist={true}>
                     <Outlet />


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Restrict the AICORE app display ADMIN/NONADMIN

## Changes Made
<!-- List the key changes made in this PR -->

Added the condition check for admin/nonadmin 

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
   1.Log in to AI core ,user unable to see the  sidemenu bar and filter and create app button.(Non admin user)
   2.Log in to AI core ,user able to see the  sidemenu bar and filter and create app button.(admin user)
3. Expected outcomes
    Refence screen shots attached
<img width="960" alt="image" src="https://github.com/user-attachments/assets/16302ba9-29e3-4ed2-9d9b-6beff4958a8c" />

## Notes
<!-- Any further notes regarding changes -->