### PR TITLE
Fix ghost block remaining stuck to the cursor when a dragged element is released outside the designated area

### DIFF
--- a/packages/client/src/components/designer/AddBlocksMenuCard.tsx
+++ b/packages/client/src/components/designer/AddBlocksMenuCard.tsx
@@ -89,6 +89,16 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
         // ID of newly added block
         let id = '';
 
+        // put a placeholder action to check if it is valid
+        const placeholderAction = designer.drag.placeholderAction;
+        if (!placeholderAction || !placeholderAction.id) {
+            designer.deactivateDrag();
+            designer.setHovered('');
+            designer.setSelected('');
+            setLocal(false);
+            return;
+        }
+
         // Track block in session storage
         localStorage.setItem(
             'blocks--frequently-used',
@@ -108,8 +118,16 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
         );
 
         // apply the action
-        const placeholderAction = designer.drag.placeholderAction;
         const sw = state.getBlock(placeholderAction.id);
+
+        // Safely get the block associated with the placeholder action
+        if (!sw) {
+            designer.deactivateDrag();
+            designer.setHovered('');
+            designer.setSelected('');
+            setLocal(false);
+            return;
+        }
 
         // TODO: Add logic to prevent adding block it iter block if one is already present
 
@@ -132,7 +150,17 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
                 const siblingWidget = state.getBlock(placeholderAction.id);
 
                 if (siblingWidget?.parent) {
+                    if (!sw.parent || !sw.parent.id) {
+                        designer.deactivateDrag();
+                        setLocal(false);
+                        return;
+                    }
                     const parent = state.getBlock(sw.parent.id);
+                    if (!parent) {
+                        designer.deactivateDrag();
+                        setLocal(false);
+                        return;
+                    }
                     if (parent.widget === 'iteration') {
                         if (parent.slots.children.children.length) {
                             notification.add({


### PR DESCRIPTION
## Description
Fixes an issue where a ghost pattern if the block would remain visible when a dragged block was released outside the designated drop area.

## Changes Made
- Added a guard clause early in the handleDocumentMouseUp function to detect when there is no valid placeholder and reset the state accordingly.
- Checks if the drop target is invalid — i.e., the user released the block outside the workspace or green lines.
- Cancels the drag operation, which removes the ghost block and resets internal dragging flags in the designer store or context.
- Resets the local state (local is the internal useState that tracks whether this block is currently being dragged).

## How to Test
1. Open the drag-and-drop editor in the browser
2. Drag any block and release it **outside** the designated canvas or drop area
3. Verify that the ghost outline or placeholder does **not persist**
4. Ensure that valid drops still work as expected