### PR TITLE
Sidemenu change

### DIFF
--- a/packages/client/src/pages/HomePage.tsx
+++ b/packages/client/src/pages/HomePage.tsx
@@ -349,7 +349,7 @@ export const HomePage = observer((): JSX.Element => {
         >
             <StyledContainer>
                 <div>
-                     {configStore.isEngineOperationAvailable(
+                     { configStore.store.config.coreAdminFlag && configStore.isEngineOperationAvailable(
                             'APP',
                             'add',
                         ) && (

--- a/packages/client/src/pages/HomePage.tsx
+++ b/packages/client/src/pages/HomePage.tsx
@@ -349,12 +349,17 @@ export const HomePage = observer((): JSX.Element => {
         >
             <StyledContainer>
                 <div>
+                     {configStore.isEngineOperationAvailable(
+                            'APP',
+                            'add',
+                        ) && (
                     <Filterbox
                         type={'APP'}
                         onChange={(filters: Record<string, unknown>) => {
                             setMetaFilters(filters);
                         }}
                     />
+                    )}
                 </div>
                 <StyledContentContainer>
                     <Stack

--- a/packages/client/src/pages/HomePage.tsx
+++ b/packages/client/src/pages/HomePage.tsx
@@ -349,7 +349,7 @@ export const HomePage = observer((): JSX.Element => {
         >
             <StyledContainer>
                 <div>
-                     { configStore.store.config.coreAdminFlag && configStore.isEngineOperationAvailable(
+                      { configStore.store.config.adminOnlyViewMenuBarFlag && configStore.isEngineOperationAvailable(
                             'APP',
                             'add',
                         ) && (

--- a/packages/client/src/pages/NavigatorLayout.tsx
+++ b/packages/client/src/pages/NavigatorLayout.tsx
@@ -85,8 +85,8 @@ export const NavigatorLayout = observer(() => {
     const { pathname } = useLocation();
     const  { configStore } = useRootStore();
     const [admingOnlyFlag ,setAdmingOnlyFlag ] = useState(false);
-    
-    if(configStore.store.user.admin){
+    const [coreApiFlag ,setCoreApiFlag ] = useState(configStore.store.config.coreAdminFlag);
+     if(configStore.store.user.admin && coreApiFlag){
         setAdmingOnlyFlag(true);
     }
 

--- a/packages/client/src/pages/NavigatorLayout.tsx
+++ b/packages/client/src/pages/NavigatorLayout.tsx
@@ -85,7 +85,8 @@ export const NavigatorLayout = observer(() => {
     const { pathname } = useLocation();
     const  { configStore } = useRootStore();
     const [admingOnlyFlag ,setAdmingOnlyFlag ] = useState(false);
-    const [coreApiFlag ,setCoreApiFlag ] = useState(configStore.store.config.coreAdminFlag);
+    const [coreApiFlag ,setCoreApiFlag ] = useState(configStore.store.config.adminOnlyViewMenuBarFlag);
+ 
      if(configStore.store.user.admin && coreApiFlag){
         setAdmingOnlyFlag(true);
     }

--- a/packages/client/src/pages/NavigatorLayout.tsx
+++ b/packages/client/src/pages/NavigatorLayout.tsx
@@ -13,6 +13,8 @@ import { ErrorBoundary } from '@/components/common';
 import { ENGINE_ROUTES } from '@/pages/engine';
 import { ErrorPage } from './ErrorPage';
 import { PlatformMessages } from './PlatformMessages';
+import { useRootStore } from '@/hooks';
+import { useEffect, useState } from "react";
 
 const NAV_HEIGHT = '48px';
 const SIDEBAR_WIDTH = '56px';
@@ -81,10 +83,17 @@ const StyledContent = styled('div')(() => ({
  */
 export const NavigatorLayout = observer(() => {
     const { pathname } = useLocation();
+    const  { configStore } = useRootStore();
+    const [admingOnlyFlag ,setAdmingOnlyFlag ] = useState(false);
+    
+    if(configStore.store.user.admin){
+        setAdmingOnlyFlag(true);
+    }
 
     return (
         <ErrorBoundary fallback={<ErrorPage />}>
             <Navbar />
+              { admingOnlyFlag &&(
             <StyledSidebar>
                 <Tooltip title={`Open App Library`} placement="right">
                     <StyledSidebarItem
@@ -146,6 +155,7 @@ export const NavigatorLayout = observer(() => {
                     </StyledSidebarItem>
                 </Tooltip>
             </StyledSidebar>
+            )}
             <StyledContent>
                 <PlatformMessages platformAssist={true}>
                     <Outlet />

--- a/packages/client/src/stores/config/config.store.ts
+++ b/packages/client/src/stores/config/config.store.ts
@@ -94,7 +94,7 @@ interface ConfigStoreInterface {
         /*
         * CoreAI flag is enabled
         */
-        coreAdminFlag: boolean;
+         adminOnlyViewMenuBarFlag: boolean;
         /**
          * Flags
          */
@@ -165,7 +165,7 @@ export class ConfigStore {
             r: true,
             python: true,
             csrf: false,
-            coreAdminFlag:false,
+            adminOnlyViewMenuBarFlag: boolean;
             adminOnlyDbAdd: false,
             adminOnlyDbAddAccess: false,
             adminOnlyDbDelete: false,

--- a/packages/client/src/stores/config/config.store.ts
+++ b/packages/client/src/stores/config/config.store.ts
@@ -91,7 +91,10 @@ interface ConfigStoreInterface {
          * Track if csrf is enabled
          */
         csrf: boolean;
-
+        /*
+        * CoreAI flag is enabled
+        */
+        coreAdminFlag: boolean;
         /**
          * Flags
          */
@@ -162,6 +165,7 @@ export class ConfigStore {
             r: true,
             python: true,
             csrf: false,
+            coreAdminFlag:false,
             adminOnlyDbAdd: false,
             adminOnlyDbAddAccess: false,
             adminOnlyDbDelete: false,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Flag is added to on/off the side menu in the AI CORE app

## Changes Made
<!-- List the key changes made in this PR -->
ADMIN_ONLY_VIEW_MENU_BAR flag added

## How to Test
<!-- Explain how reviewers can test your changes -->

1. Login to the AI core app ,user can able to view the ai core page without side menu bar and catalog items .
2. Config api has the adminOnlyViewMenuBarFlag : true 
[Uploading AdminUser_updated.docx…]()


## Notes
<!-- Any further notes regarding changes -->
[Uploading AdminUser_updated.docx…]()
