### PR TITLE
feat(client): Undisabled actions in settings for admin mode users

### DIFF
--- a/packages/client/src/components/settings/MembersTable.tsx
+++ b/packages/client/src/components/settings/MembersTable.tsx
@@ -264,10 +264,10 @@ export const MembersTable = (props: MembersTableProps) => {
     // get the api
     const getMembersApi: Parameters<typeof useAPI>[0] =
         type === 'DATABASE' ||
-        type === 'STORAGE' ||
-        type === 'MODEL' ||
-        type === 'VECTOR' ||
-        type === 'FUNCTION'
+            type === 'STORAGE' ||
+            type === 'MODEL' ||
+            type === 'VECTOR' ||
+            type === 'FUNCTION'
             ? [
                   'getEngineUsers',
                   adminMode,
@@ -318,6 +318,15 @@ export const MembersTable = (props: MembersTableProps) => {
                 } else {
                     setUserPermission(
                         permissionPriorityMapper(data[0].permission)
+                            ?.permission as SETTINGS_ROLE,
+                    );
+                }
+            }else{
+                if (adminMode) {
+                    // if logged in admin, need to provide all Author option previledges
+                    const adminPermissionPriority = 'Author';
+                    setUserPermission(
+                        permissionPriorityMapper(adminPermissionPriority)
                             ?.permission as SETTINGS_ROLE,
                     );
                 }
@@ -670,7 +679,7 @@ export const MembersTable = (props: MembersTableProps) => {
                                     <Button
                                         disabled={
                                             isLoading ||
-                                            userPermission === 'Read-Only'
+                                            (!adminMode &&userPermission === 'Read-Only')
                                         }
                                         variant={'contained'}
                                         onClick={() => {
@@ -710,9 +719,9 @@ export const MembersTable = (props: MembersTableProps) => {
                                                     }
                                                     checked={
                                                         selectedMembers.length ===
-                                                            renderedMembers.length &&
+                                                        renderedMembers.length &&
                                                         renderedMembers.length >
-                                                            0
+                                                        0
                                                     }
                                                     onChange={() => {
                                                         if (
@@ -801,7 +810,7 @@ export const MembersTable = (props: MembersTableProps) => {
                                                             <StyledCheckbox
                                                                 disabled={
                                                                     userPermission ===
-                                                                    'Read-Only'
+                                                                    'Read-Only' && !adminMode
                                                                 }
                                                                 checked={
                                                                     isSelected
@@ -902,12 +911,13 @@ export const MembersTable = (props: MembersTableProps) => {
                                                                         !configStore.isEngineOperationAvailable(
                                                                             type,
                                                                             'access',
-                                                                        ) ||
+                                                                        ) ||(!adminMode &&
                                                                         permissionPriorityMapper(
                                                                             userPermission,
                                                                         )
                                                                             .priority >
                                                                             1
+                                                                    )
                                                                     }
                                                                 />
                                                                 <RadioGroup.Item
@@ -918,11 +928,11 @@ export const MembersTable = (props: MembersTableProps) => {
                                                                             type,
                                                                             'access',
                                                                         ) ||
-                                                                        permissionPriorityMapper(
+                                                                        (!adminMode && permissionPriorityMapper(
                                                                             userPermission,
                                                                         )
-                                                                            ?.priority >
-                                                                            2
+                                                                            ?.priority > 
+                                                                            2)
                                                                     }
                                                                 />
                                                                 <RadioGroup.Item
@@ -932,7 +942,7 @@ export const MembersTable = (props: MembersTableProps) => {
                                                                         !configStore.isEngineOperationAvailable(
                                                                             type,
                                                                             'access',
-                                                                        ) ||
+                                                                        ) ||(!adminMode &&(
                                                                         permissionPriorityMapper(
                                                                             userPermission,
                                                                         )
@@ -940,7 +950,7 @@ export const MembersTable = (props: MembersTableProps) => {
                                                                             3 ||
                                                                         readOnlyRestricted(
                                                                             user,
-                                                                        )
+                                                                        )))
                                                                     }
                                                                 />
                                                             </RadioGroup>
@@ -953,13 +963,13 @@ export const MembersTable = (props: MembersTableProps) => {
                                                             <>
                                                                 <Table.Cell>
                                                                     {user.usage_restriction !==
-                                                                    undefined
+                                                                        undefined
                                                                         ? formatValue(
-                                                                              user.usage_restriction,
-                                                                          )
+                                                                            user.usage_restriction,
+                                                                        )
                                                                         : formatValue(
-                                                                              'null',
-                                                                          )}
+                                                                            'null',
+                                                                        )}
                                                                 </Table.Cell>
                                                                 <Table.Cell>
                                                                     {user?.usage_restriction ===
@@ -1055,14 +1065,14 @@ export const MembersTable = (props: MembersTableProps) => {
                                         hoveredUser={
                                             hoveredUser
                                                 ? {
-                                                      id: hoveredUser.id,
-                                                      name:
-                                                          hoveredUser.name ||
-                                                          'Unknown',
-                                                      email:
-                                                          hoveredUser.email ||
-                                                          '',
-                                                  }
+                                                    id: hoveredUser.id,
+                                                    name: 
+                                                        hoveredUser.name || 
+                                                        'Unknown',
+                                                    email: 
+                                                        hoveredUser.email || 
+                                                        '',
+                                                }
                                                 : null
                                         }
                                         isPopoverOpen={Boolean(anchorEl)}


### PR DESCRIPTION
## Description
Undisabled all actions in App settings when in admin mode

## Changes Made
Undisabled all action button in App Settings like 
1. Add Member 
2. Icon Buttons
3. Radio Button
For Admin users doesn't having any permission for the apps

## How to Test
1. settings -> App settings -> Admin On 
2. Go to App having no access permission 
3. User can see the changes there
