### PR TITLE
#202 Phone info does not persist Bug Fix

### DIFF
--- a/packages/client/src/stores/monolith/monolith.store.ts
+++ b/packages/client/src/stores/monolith/monolith.store.ts
@@ -325,7 +325,7 @@ export class MonolithStore {
             '&email=' +
             encodeURIComponent(email) +
             '&password=' +
-            encodeURIComponent(password);
+            encodeURIComponent(password)+
         '&phone=' +
             encodeURIComponent(phone) +
             '&phoneextension=' +


### PR DESCRIPTION
## Description
When a User creates an account using the Native Registration option and adds their phone info through the Phone Number, Extension, and Country Code fields, that phone info was not appearing when viewing that User from the Member Settings page thus changes has been made to include that info.

## Changes Made
; has been replaced with + in monolith.store.ts for const create to include phone, phoneextension and countrycode in payload

## How to Test
1.Go to the platform login page and select the Register Now option
2.Fill out the form with a test User's info, including the 3 phone fields.
3.Submit the Native Registration form.
4.Log in as an administrator and navigate to the Member Settings page.
5.Click on the row that corresponds to the Native User you just added
6.Observe that the phone info is now populated there.

## Notes
No notes