### PR TITLE
Side Menu Changes

### DIFF
--- a/packages/client/src/pages/HomePage.tsx
+++ b/packages/client/src/pages/HomePage.tsx
@@ -328,7 +328,7 @@ export const HomePage = observer((): JSX.Element => {
                                 }}
                             />
                         </Stack>
-                        {configStore.isEngineOperationAvailable(
+                        {configStore.store.config.adminOnlyViewMenuBarFlag && configStore.isEngineOperationAvailable(
                             'APP',
                             'add',
                         ) && (

--- a/packages/client/src/pages/HomePage.tsx
+++ b/packages/client/src/pages/HomePage.tsx
@@ -328,21 +328,22 @@ export const HomePage = observer((): JSX.Element => {
                                 }}
                             />
                         </Stack>
-                        {configStore.store.config.adminOnlyViewMenuBarFlag && configStore.isEngineOperationAvailable(
-                            'APP',
-                            'add',
-                        ) && (
-                            <Button
-                                size={'large'}
-                                variant={'contained'}
-                                onClick={() => {
-                                    navigate('/app/new');
-                                }}
-                                aria-label={`Open the App Model`}
-                            >
-                                Create New App
-                            </Button>
-                        )}
+                        {configStore.store.config.adminOnlyViewMenuBarFlag &&
+                            configStore.isEngineOperationAvailable(
+                                'APP',
+                                'add',
+                            ) && (
+                                <Button
+                                    size={'large'}
+                                    variant={'contained'}
+                                    onClick={() => {
+                                        navigate('/app/new');
+                                    }}
+                                    aria-label={`Open the App Model`}
+                                >
+                                    Create New App
+                                </Button>
+                            )}
                     </Stack>
                 </Stack>
             }

--- a/packages/client/src/pages/NavigatorLayout.tsx
+++ b/packages/client/src/pages/NavigatorLayout.tsx
@@ -13,6 +13,8 @@ import { ErrorBoundary } from '@/components/common';
 import { ENGINE_ROUTES } from '@/pages/engine';
 import { ErrorPage } from './ErrorPage';
 import { PlatformMessages } from './PlatformMessages';
+import { useRootStore } from '@/hooks';
+import { useEffect, useState } from "react";
 
 const NAV_HEIGHT = '48px';
 const SIDEBAR_WIDTH = '56px';
@@ -81,10 +83,19 @@ const StyledContent = styled('div')(() => ({
  */
 export const NavigatorLayout = observer(() => {
     const { pathname } = useLocation();
+    const  { configStore } = useRootStore();
+    const [admingOnlyFlag ,setAdmingOnlyFlag ] = useState(false);
+    const [coreApiFlag ,setCoreApiFlag ] = useState(configStore.store.config.adminOnlyViewMenuBarFlag);
+
+     if(configStore.store.user.admin && coreApiFlag){
+        setAdmingOnlyFlag(true);
+    }
 
     return (
         <ErrorBoundary fallback={<ErrorPage />}>
+          
             <Navbar />
+            { admingOnlyFlag &&(
             <StyledSidebar>
                 <Tooltip title={`Open App Library`} placement="right">
                     <StyledSidebarItem
@@ -146,6 +157,7 @@ export const NavigatorLayout = observer(() => {
                     </StyledSidebarItem>
                 </Tooltip>
             </StyledSidebar>
+          )}
             <StyledContent>
                 <PlatformMessages platformAssist={true}>
                     <Outlet />

--- a/packages/client/src/pages/NavigatorLayout.tsx
+++ b/packages/client/src/pages/NavigatorLayout.tsx
@@ -14,7 +14,7 @@ import { ENGINE_ROUTES } from '@/pages/engine';
 import { ErrorPage } from './ErrorPage';
 import { PlatformMessages } from './PlatformMessages';
 import { useRootStore } from '@/hooks';
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
 
 const NAV_HEIGHT = '48px';
 const SIDEBAR_WIDTH = '56px';
@@ -83,57 +83,65 @@ const StyledContent = styled('div')(() => ({
  */
 export const NavigatorLayout = observer(() => {
     const { pathname } = useLocation();
-    const  { configStore } = useRootStore();
-    const [admingOnlyFlag ,setAdmingOnlyFlag ] = useState(false);
-    const [coreApiFlag ,setCoreApiFlag ] = useState(configStore.store.config.adminOnlyViewMenuBarFlag);
+    const { configStore } = useRootStore();
+    const [viewSidebar, setViewSidebar] = useState(false);
 
-     if(configStore.store.user.admin && coreApiFlag){
-        setAdmingOnlyFlag(true);
-    }
+    useEffect(() => {
+        if (configStore.store.user.admin) {
+            setViewSidebar(true);
+        } else if (
+            !configStore.store.user.admin &&
+            !configStore.store.config.adminOnlyViewMenuBarFlag
+        ) {
+            setViewSidebar(true);
+        }
+    }, [
+        configStore.store.user.admin,
+        configStore.store.config.adminOnlyViewMenuBarFlag,
+    ]);
 
     return (
         <ErrorBoundary fallback={<ErrorPage />}>
-          
             <Navbar />
-            { admingOnlyFlag &&(
-            <StyledSidebar>
-                <Tooltip title={`Open App Library`} placement="right">
-                    <StyledSidebarItem
-                        data-tour="nav-app-library"
-                        to={'/'}
-                        selected={
-                            !!matchPath('', pathname) ||
-                            !!matchPath('app/*', pathname)
-                        }
-                        aria-label={'Navigate to app library'}
-                    >
-                        <Icon>
-                            <LibraryBooksOutlined />
-                        </Icon>
-                    </StyledSidebarItem>
-                </Tooltip>
-                <StyledSidebarDivider />
-                {ENGINE_ROUTES.map((r) => (
-                    <Tooltip
-                        title={`Open ${r.name}`}
-                        key={r.path}
-                        placement="right"
-                    >
+            {viewSidebar && (
+                <StyledSidebar>
+                    <Tooltip title={`Open App Library`} placement="right">
                         <StyledSidebarItem
-                            data-testid={`${r.name}-icon`}
-                            // id={`${r.name}-icon`}
-                            data-tour={`nav-engine-${r.path}`}
-                            to={`/engine/${r.path}`}
+                            data-tour="nav-app-library"
+                            to={'/'}
                             selected={
-                                !!matchPath(`engine/${r.path}/*`, pathname)
+                                !!matchPath('', pathname) ||
+                                !!matchPath('app/*', pathname)
                             }
-                            aria-label={`Navigate to ${r.name}`}
+                            aria-label={'Navigate to app library'}
                         >
-                            <Icon>{createElement(r.icon, {})}</Icon>
+                            <Icon>
+                                <LibraryBooksOutlined />
+                            </Icon>
                         </StyledSidebarItem>
                     </Tooltip>
-                ))}
-                {/* <Tooltip title={`Open Prompt Hub`} placement="right">
+                    <StyledSidebarDivider />
+                    {ENGINE_ROUTES.map((r) => (
+                        <Tooltip
+                            title={`Open ${r.name}`}
+                            key={r.path}
+                            placement="right"
+                        >
+                            <StyledSidebarItem
+                                data-testid={`${r.name}-icon`}
+                                // id={`${r.name}-icon`}
+                                data-tour={`nav-engine-${r.path}`}
+                                to={`/engine/${r.path}`}
+                                selected={
+                                    !!matchPath(`engine/${r.path}/*`, pathname)
+                                }
+                                aria-label={`Navigate to ${r.name}`}
+                            >
+                                <Icon>{createElement(r.icon, {})}</Icon>
+                            </StyledSidebarItem>
+                        </Tooltip>
+                    ))}
+                    {/* <Tooltip title={`Open Prompt Hub`} placement="right">
                     <StyledSidebarItem
                         to={'/prompt'}
                         selected={!!matchPath('prompt/*', pathname)}
@@ -144,20 +152,20 @@ export const NavigatorLayout = observer(() => {
                         </Icon>
                     </StyledSidebarItem>
                 </Tooltip> */}
-                <Stack flex={1}>&nbsp;</Stack>
-                <Tooltip title={`Open Settings`} placement="right">
-                    <StyledSidebarItem
-                        to={'/settings'}
-                        selected={!!matchPath('settings/*', pathname)}
-                        aria-label={'Navigate to settings'}
-                    >
-                        <Icon>
-                            <Settings data-testid="Settings-icon" />
-                        </Icon>
-                    </StyledSidebarItem>
-                </Tooltip>
-            </StyledSidebar>
-          )}
+                    <Stack flex={1}>&nbsp;</Stack>
+                    <Tooltip title={`Open Settings`} placement="right">
+                        <StyledSidebarItem
+                            to={'/settings'}
+                            selected={!!matchPath('settings/*', pathname)}
+                            aria-label={'Navigate to settings'}
+                        >
+                            <Icon>
+                                <Settings data-testid="Settings-icon" />
+                            </Icon>
+                        </StyledSidebarItem>
+                    </Tooltip>
+                </StyledSidebar>
+            )}
             <StyledContent>
                 <PlatformMessages platformAssist={true}>
                     <Outlet />

--- a/packages/client/src/stores/config/config.store.ts
+++ b/packages/client/src/stores/config/config.store.ts
@@ -92,9 +92,9 @@ interface ConfigStoreInterface {
          */
         csrf: boolean;
         /*
-        * sidemenubar if adminOnlyViewMenuBarFlag is enabled
-        */
-         adminOnlyViewMenuBarFlag: boolean;
+         * sidemenubar if adminOnlyViewMenuBarFlag is enabled
+         */
+        adminOnlyViewMenuBarFlag: boolean;
         /**
          * Flags
          */

--- a/packages/client/src/stores/config/config.store.ts
+++ b/packages/client/src/stores/config/config.store.ts
@@ -91,7 +91,10 @@ interface ConfigStoreInterface {
          * Track if csrf is enabled
          */
         csrf: boolean;
-
+        /*
+        * CoreAI flag is enabled
+        */
+         adminOnlyViewMenuBarFlag: boolean;
         /**
          * Flags
          */
@@ -162,6 +165,7 @@ export class ConfigStore {
             r: true,
             python: true,
             csrf: false,
+            adminOnlyViewMenuBarFlag: false,
             adminOnlyDbAdd: false,
             adminOnlyDbAddAccess: false,
             adminOnlyDbDelete: false,

--- a/packages/client/src/stores/config/config.store.ts
+++ b/packages/client/src/stores/config/config.store.ts
@@ -92,7 +92,7 @@ interface ConfigStoreInterface {
          */
         csrf: boolean;
         /*
-        * CoreAI flag is enabled
+        * sidemenubar if adminOnlyViewMenuBarFlag is enabled
         */
          adminOnlyViewMenuBarFlag: boolean;
         /**


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Flag is added to on/off the side menu in the AI CORE app

## Changes Made
<!-- List the key changes made in this PR -->
ADMIN_ONLY_VIEW_MENU_BAR flag added

## How to Test
<!-- Explain how reviewers can test your changes -->

1. Login to the AI core app ,user can able to view the ai core page without side menu bar and catalog items .
2. Config api has the adminOnlyViewMenuBarFlag : true 
[Uploading AdminUser_updated.docx…]()


## Notes
<!-- Any further notes regarding changes -->

Monolith : https://github.com/SEMOSS/Monolith/pull/129
[Uploading AdminUser_updated.docx…]()
