### PR TITLE
feat(client): after adding member, admin doesn't turn off

### DIFF
--- a/packages/client/src/components/settings/MembersAddOverlay.tsx
+++ b/packages/client/src/components/settings/MembersAddOverlay.tsx
@@ -469,10 +469,6 @@ export const MembersAddOverlay = (props: MembersAddOverlayProps) => {
         } finally {
             // close the overlay
             closeOverlay(type, success);
-            //adding a refresh to the page so that the updated by and timestamp show up
-            if (success) {
-                window.location.reload();
-            }
         }
     };
 


### PR DESCRIPTION
## Description
feat(client): after adding member, admin doesn't turn off

## Changes Made
After Adding user, the page doesn't get refreshed automatically. So, 'Admin On' remains as it is.

## How to Test
1. Log in as an Admin.
2. Navigate to the Members settings page for an app or engine that user don't have an access for.
3. On 'Admin On', Add Member.
4. User can see that after Member being added Admin remains on.
