### PR TITLE
Fix code apps should show always display reactor section

### DIFF
--- a/packages/client/src/components/app/AppSettings.tsx
+++ b/packages/client/src/components/app/AppSettings.tsx
@@ -196,6 +196,15 @@ const StyledTable = styled(Table)(({ theme }) => ({
     borderWidth: 'thin',
 }));
 
+const StyledCenteredFallback = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+    minHeight: 120,
+    width: '100%',
+}));
+
 const StyledPaper = styled(Paper)(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
     padding: theme.spacing(2),
@@ -752,84 +761,85 @@ export const AppSettings = (props: AppSettingsProps) => {
                     </StyledCardDiv>
                 </StyledTopCardContainer>
 
-                {portalReactors.reactors.length ? (
-                    <StyledCardContainer>
-                        <StyledCardDiv>
-                            <StyledCardLeft>
-                                <StyledListItemHeader>
-                                    <Typography variant="h6">
-                                        Reactors
-                                    </Typography>
-                                </StyledListItemHeader>
+                <StyledCardContainer>
+                    <StyledCardDiv>
+                        <StyledCardLeft>
+                            <StyledListItemHeader>
+                                <Typography variant="h6">Reactors</Typography>
+                            </StyledListItemHeader>
+                            <StyledListItemHeader>
+                                Custom reactors created for the portal.
+                            </StyledListItemHeader>
+                            <Button
+                                variant="contained"
+                                onClick={() => {
+                                    recompileReactors({ release: null });
+                                }}
+                            >
+                                Compile Changes on This Instance
+                            </Button>
+                            <Button
+                                variant="contained"
+                                onClick={() => {
+                                    recompileReactors({ release: true });
+                                }}
+                            >
+                                Deploy and Persist Changes
+                            </Button>
+                            {portalReactors.lastCompiled && (
+                                <StyledLeftActionContainer>
+                                    <StyledLeftActionDiv>
+                                        <StyledActionDivLeft>
+                                            <Typography variant="body2">
+                                                Last compiled by:
+                                            </Typography>
+                                        </StyledActionDivLeft>
+                                        <Avatar>
+                                            <StyledPersonIcon />
+                                        </Avatar>
+                                        <Typography variant="body2">
+                                            {portalReactors.compiledBy}
+                                        </Typography>
+                                        <Typography variant="body2">
+                                            on
+                                        </Typography>
+                                        <Typography variant="body2">
+                                            {portalReactors.lastCompiled}
+                                        </Typography>
+                                    </StyledLeftActionDiv>
+                                </StyledLeftActionContainer>
+                            )}
+                        </StyledCardLeft>
 
-                                <StyledListItemHeader>
-                                    Custom reactors created for the portal.
-                                </StyledListItemHeader>
-                                <Button
-                                    variant="contained"
-                                    onClick={() => {
-                                        recompileReactors({ release: null });
-                                    }}
-                                >
-                                    Compile Changes on This Instance
-                                </Button>
-                                <Button
-                                    variant="contained"
-                                    onClick={() => {
-                                        recompileReactors({ release: true });
-                                    }}
-                                >
-                                    Deploy and Persist Changes
-                                </Button>
-                                {portalReactors.lastCompiled && (
-                                    <StyledLeftActionContainer>
-                                        <StyledLeftActionDiv>
-                                            <StyledActionDivLeft>
-                                                <Typography variant="body2">
-                                                    Last compiled by:
-                                                </Typography>
-                                            </StyledActionDivLeft>
-                                            <Avatar>
-                                                <StyledPersonIcon />
-                                            </Avatar>
-                                            <Typography variant="body2">
-                                                {portalReactors.compiledBy}
-                                            </Typography>
-                                            <Typography variant="body2">
-                                                on
-                                            </Typography>
-                                            <Typography variant="body2">
-                                                {portalReactors.lastCompiled}
-                                            </Typography>
-                                        </StyledLeftActionDiv>{' '}
-                                    </StyledLeftActionContainer>
-                                )}
-                            </StyledCardLeft>
-                            <StyledCardRight>
+                        <StyledCardRight>
+                            {portalReactors.reactors.length > 0 ? (
                                 <StyledTable>
                                     <Table.Body>
                                         {portalReactors.reactors.map(
-                                            (reactor, i) => {
-                                                return (
-                                                    <Table.Row
-                                                        key={reactor + i}
-                                                    >
-                                                        <Table.Cell>
-                                                            {reactor}
-                                                        </Table.Cell>
-                                                        <Table.Cell align="right">
-                                                            <Java />
-                                                        </Table.Cell>
-                                                    </Table.Row>
-                                                );
-                                            },
+                                            (reactor, i) => (
+                                                <Table.Row key={reactor + i}>
+                                                    <Table.Cell>
+                                                        {reactor}
+                                                    </Table.Cell>
+                                                    <Table.Cell align="right">
+                                                        <Java />
+                                                    </Table.Cell>
+                                                </Table.Row>
+                                            ),
                                         )}
                                     </Table.Body>
                                 </StyledTable>
-                            </StyledCardRight>
-                        </StyledCardDiv>
-                    </StyledCardContainer>
-                ) : null}
+                            ) : (
+                                <StyledCenteredFallback>
+                                    <Typography variant="body2">
+                                        No reactors available.
+                                    </Typography>
+                                </StyledCenteredFallback>
+                            )}
+                        </StyledCardRight>
+                    </StyledCardDiv>
+                </StyledCardContainer>
+
                 <StyledCardContainer>
                     {isLoading && (
                         <LoadingScreen.Trigger description="Updating Project" />


### PR DESCRIPTION
## Description
This PR ensures that the Reactor section in the Code App settings panel is always displayed, regardless of whether the app currently has any reactors.

![image](https://github.com/user-attachments/assets/009679b7-6430-4ffa-90a3-a34ec6d4f885)


## Changes Made
- Previously, this section would be hidden if there was no reactor present.
- Removed the conditional check that hid the Reactor section when the reactors array was empty.
- Now, the Reactor section is always rendered, providing the Compile Changes button consistently.
- Added a fallback UI if no reactors present.

## How to Test
- Open the Code App Settings page for an app that does not have any reactors.
- Confirm that the Reactor section is visible, even if the reactors array is empty.
- Verify that the Compile Changes button is present and functional.
