### PR TITLE
feat(client): deleting_app_redirects_to_new_app_library_ui

### DIFF
--- a/packages/client/src/components/workspace/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/workspace/panels/SettingsPanel.tsx
@@ -140,10 +140,10 @@ export const SettingsPanel = () => {
                                             '/settings/app/',
                                         )
                                     ) {
-                                        // If in app settings, go to app library
+                                        // If in app settings
                                         navigate('/settings/app');
                                     } else {
-                                        // Default: go to home
+                                        // If in App Library
                                         navigate('/');
                                     }
                                 }}

--- a/packages/client/src/components/workspace/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/workspace/panels/SettingsPanel.tsx
@@ -135,7 +135,17 @@ export const SettingsPanel = () => {
                                 name={workspace.metadata?.project_name || 'app'}
                                 direction="row"
                                 onDelete={() => {
-                                    navigate('/settings/app');
+                                    if (
+                                        location.pathname.startsWith(
+                                            '/settings/app/',
+                                        )
+                                    ) {
+                                        // If in app settings, go to app library
+                                        navigate('/settings/app');
+                                    } else {
+                                        // Default: go to home
+                                        navigate('/');
+                                    }
                                 }}
                             />
                         ) : null}


### PR DESCRIPTION
## Description
On deleting app from App Library, it redirects to the new App Library UI instead of the old UI.

## Changes Made
When user delete app from app library user is redirected to the new UI of App Library which is earlier been redirected to the old UI i.e. App Settings folder view from Settings. Also if user delete app from App setting then it is redirected to the folder view of App Settings only. 

## How to Test
For App Library:
App Library -> Select App -> Edit -> Settings -> delete

For App Settings:
Open Settings -> App Settings -> Select App -> Delete
