### PR TITLE
feat(client): members_settings_page_add_restriction

### DIFF
--- a/packages/client/src/components/settings/UserAddOverlay.tsx
+++ b/packages/client/src/components/settings/UserAddOverlay.tsx
@@ -200,6 +200,7 @@ export const UserAddOverlay = observer((props: UserAddOverlayProps) => {
         // reset on open or close
         reset({
             ...(user || {}),
+            model_usage_restriction: user?.model_usage_restriction ?? 'null', // always set default for new user
         });
     }, [user, open]);
 


### PR DESCRIPTION
## Description
Member Settings page allows user to add multiple subsequent member without a fail.

## Changes Made
Earlier Member Settings page allows user to add 1 new member, adding a subsequent member led to form failure with the error "Form is Invalid. model_usage_restriction is a required field." 
Now user can add multiple subsequent user without any error. 

## How to Test
1. Go to Settings page
2. Click on 'Admin On'
3. Click on 'Member Settings'
4. Click on 'Add Members'
5. Select 'Native' for type
6. Enter a user id
7. Enter a name
8. Enter a phone number
9. Click on 'Save'
10. Repeat steps 4 through 9 using distinct values for user id, name, and phone number
11. User doesn't get error while adding multiple subsequent members.
