### PR TITLE
feat(client): Restriction on deleting all admins from Members table

### DIFF
--- a/packages/client/src/components/settings/MembersTable.tsx
+++ b/packages/client/src/components/settings/MembersTable.tsx
@@ -470,9 +470,11 @@ export const MembersTable = (props: MembersTableProps) => {
      *
      * @param members - members that will be deleted
      */
-    const openDeleteMembersModal = (members: SETTINGS_PROVISIONED_USER[]) => {
+    const openDeleteMembersModal = (
+        selectedMembers: SETTINGS_PROVISIONED_USER[],
+    ) => {
         // notify if no members
-        if (members.length === 0) {
+        if (selectedMembers.length === 0) {
             notification.add({
                 color: 'warning',
                 message: `No permissions to change`,
@@ -481,8 +483,25 @@ export const MembersTable = (props: MembersTableProps) => {
             return;
         }
 
+        const authors = renderedMembers.filter(
+            (m) =>
+                permissionPriorityMapper(m.permission)?.permission === 'Author',
+        );
+
+        const authorsToDelete = selectedMembers.filter(
+            (m) =>
+                permissionPriorityMapper(m.permission)?.permission === 'Author',
+        );
+        if (authors.length > 0 && authorsToDelete.length === authors.length) {
+            notification.add({
+                color: 'error',
+                message: `You cannot delete the all admin (Author) in the table.`,
+            });
+            return;
+        }
+
         // set the pending members
-        setPendingDeletedMembers(members);
+        setPendingDeletedMembers(selectedMembers);
 
         // close the model
         setDeleteMembersModal(true);

--- a/packages/client/src/components/settings/MembersTable.tsx
+++ b/packages/client/src/components/settings/MembersTable.tsx
@@ -495,7 +495,7 @@ export const MembersTable = (props: MembersTableProps) => {
         if (authors.length > 0 && authorsToDelete.length === authors.length) {
             notification.add({
                 color: 'error',
-                message: `You cannot delete the all admin (Author) in the table.`,
+                message: `You cannot delete all the admins(Authors) from the table.`,
             });
             return;
         }


### PR DESCRIPTION
## Description
Restricted The deletion of all admins from the Members Table

## Changes Made
1. Added logic to the members table to prevent deleting all users with the "Author" (admin) permission at the same time.
2. If all Authors are selected for deletion, an error notification is shown and the action is blocked.
3. Ensures at least one admin remains in the system at all times.

## How to Test
1. Log in as an Author
2. Go to settings and then App Settings
3. Try to delete all admins(Authors)
4. It will show a pop-up saying 'You cannot delete the all admin (Author) in the table.'

![Admin-deletion-restriction](https://github.com/user-attachments/assets/c91fcc46-d358-41f4-9178-c7362ba55713)

