### PR TITLE
Default Settings to Data Tab

### DIFF
--- a/libs/renderer/src/components/block-defaults/echart-visualization-block/VisualizationBlockMenu.tsx
+++ b/libs/renderer/src/components/block-defaults/echart-visualization-block/VisualizationBlockMenu.tsx
@@ -85,7 +85,7 @@ const StyledToggleTabsGroupItem = styled(ToggleTabsGroup.Item)(({ theme }) => ({
 
 export const VisualizationBlockMenu: BlockComponent = ({ id }) => {
     const { data, setData } = useBlockSettings<EchartVisualizationBlockDef>(id);
-    const [selectedTab, setSelectedTab] = useState("Tools");
+    const [selectedTab, setSelectedTab] = useState("Data");
     const [selectedColumn, setSelectedColumn] = useState<string[]>([]);
     const [forceRender, setForceRender] = useState(false);
     function updateFrame() {}


### PR DESCRIPTION
Whenever the user drag and drop the charts the default tab will be data tab in block settings