### PR TITLE
Add warning when refreshing screen in drag and drop notebook

### DIFF
--- a/packages/client/src/components/blocks-workspace/BlocksWorkspace.tsx
+++ b/packages/client/src/components/blocks-workspace/BlocksWorkspace.tsx
@@ -247,6 +247,19 @@ export const BlocksWorkspace = observer((props: BlocksWorkspaceProps) => {
 
     const [state, setState] = useState<StateStore>();
 
+    //to throw a warning when the user tried to reload the page
+    // this is to prevent the user from losing their work
+    useEffect(() => {
+        const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+            e.preventDefault();
+            e.returnValue = '';
+        };
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        return () => {
+            window.removeEventListener('beforeunload', handleBeforeUnload);
+        };
+    }, []);
+
     useEffect(() => {
         // start the loading screen
         workspace.setLoading(true);


### PR DESCRIPTION
## Description
These changes are to add warning when refreshing screen in drag and drop notebook to prevent the user from losing their work.

Refer ticket: https://github.com/issues/assigned?issue=SEMOSS%7CSemoss%7C711

## Changes Made
Added a BeforeUnloadEvent to the page

## How to Test
1. Create a drag and drop application
2. Add some components
3. Try to refresh the page

## Notes
<img width="1182" alt="image" src="https://github.com/user-attachments/assets/ba19ab4a-c55c-4ac6-9fb7-88a4667ee8f2" />