### PR TITLE
Add "Copy to Clipboard" Action for Button OnClick to Copy Variable Value

### DIFF
--- a/libs/renderer/src/components/block-settings/ListenerActionOverlay.tsx
+++ b/libs/renderer/src/components/block-settings/ListenerActionOverlay.tsx
@@ -223,6 +223,10 @@ export const ListenerActionOverlay = observer(
                 });
             } else if (message === ActionMessages.DISPATCH_OUTPUTS_EVENT) {
                 setValue("payload", {});
+            } else if (message === ActionMessages.COPY_TO_CLIPBOARD) {
+                setValue("payload", {
+                    text: "",
+                });
             } else if (message === ActionMessages.RUN_CELL) {
                 if (listeners[listener].order[actionIdx]) {
                     if (
@@ -252,6 +256,7 @@ export const ListenerActionOverlay = observer(
             }
         }, [message]);
 
+        console.log(cells)
         return (
             <>
                 <Modal.Title>
@@ -277,6 +282,7 @@ export const ListenerActionOverlay = observer(
                                             ActionMessages.DISPATCH_EVENT,
                                             ActionMessages.DISPATCH_OUTPUTS_EVENT,
                                             ActionMessages.DISPATCH_OPEN_EVENT,
+                                            ActionMessages.COPY_TO_CLIPBOARD,
                                         ].map((a, aIdx) => (
                                             <Select.Item key={aIdx} value={a}>
                                                 {ACTIONS_DISPLAY[a]}
@@ -369,7 +375,7 @@ export const ListenerActionOverlay = observer(
                                                     const variableName =
                                                         state.getAlias(
                                                             queryId,
-                                                            c.id,
+                                                            c.id
                                                         );
 
                                                     return (
@@ -377,13 +383,13 @@ export const ListenerActionOverlay = observer(
                                                             key={c.id}
                                                             value={c.id}
                                                         >
-                                                            <Typography
-                                                                variant={
-                                                                    "body2"
-                                                                }
-                                                            >
-                                                                {variableName}
-                                                            </Typography>
+                                                                <Typography
+                                                                    variant={
+                                                                        "body2"
+                                                                    }
+                                                                >
+                                                                    {variableName}
+                                                                </Typography>
                                                         </Select.Item>
                                                     );
                                                 })}
@@ -532,6 +538,34 @@ export const ListenerActionOverlay = observer(
                                         }}
                                     />
                                 )}
+                            </>
+                        ) : null}
+
+                        {message === ActionMessages.COPY_TO_CLIPBOARD ? (
+                            <>
+                                <Controller
+                                    name={"payload.text"}
+                                    control={control}
+                                    render={({ field }) => (
+                                        <Select
+                                            label="Variable"
+                                            value={
+                                                field.value
+                                                    ? field.value
+                                                    : ""
+                                            }
+                                            onChange={(value) =>
+                                                field.onChange(value)
+                                            }
+                                        >
+                                            {Object.keys(state.variables).map(variableName => (
+                                                <Select.Item key={variableName} value={variableName}>
+                                                    {variableName}
+                                                </Select.Item>
+                                            ))}
+                                        </Select>
+                                    )}
+                                />
                             </>
                         ) : null}
                     </Stack>

--- a/libs/renderer/src/store/state/state.actions.ts
+++ b/libs/renderer/src/store/state/state.actions.ts
@@ -37,6 +37,7 @@ export enum ActionMessages {
    DISPATCH_EVENT = "DISPATCH_EVENT",
    DISPATCH_OUTPUTS_EVENT = "DISPATCH_OUTPUTS_EVENT",
    RUN_MARKDOWN_CELL = "RUN_MARKDOWN_CELL",
+   COPY_TO_CLIPBOARD = "COPY_TO_CLIPBOARD",
    DISPATCH_OPEN_EVENT = "DISPATCH_OPEN_EVENT",
 }
 
@@ -65,7 +66,8 @@ export type Actions =
     | RenameVariableAction
     | EditVariableAction
     | DeleteVariableAction
-    | SetSheetExecutionOrderAction;
+    | SetSheetExecutionOrderAction
+    | CopyToClipboardAction;
 
 export interface Action {
     message: string;
@@ -82,6 +84,13 @@ export interface SetStateAction extends Action {
 export interface DispatchOutputsEventAction extends Action {
     message: ActionMessages.DISPATCH_OUTPUTS_EVENT;
     payload: {};
+}
+
+export interface CopyToClipboardAction extends Action {
+    message: ActionMessages.COPY_TO_CLIPBOARD;
+    payload: {
+        text: string;
+    };
 }
 
 export interface DispatchOpenEventAction extends Action {

--- a/libs/renderer/src/store/state/state.constants.ts
+++ b/libs/renderer/src/store/state/state.constants.ts
@@ -36,5 +36,6 @@ export const ACTIONS_DISPLAY = {
     [ActionMessages.RUN_CELL]: "Run Cell",
     [ActionMessages.DISPATCH_EVENT]: "Dispatch Event",
     [ActionMessages.DISPATCH_OUTPUTS_EVENT]: "Dispatch App Outputs",
+    [ActionMessages.COPY_TO_CLIPBOARD]: "Copy to Clipboard",
     [ActionMessages.DISPATCH_OPEN_EVENT]: "Navigate",
 };

--- a/libs/renderer/src/store/state/state.store.ts
+++ b/libs/renderer/src/store/state/state.store.ts
@@ -467,6 +467,10 @@ export class StateStore {
             } else if (ActionMessages.DISPATCH_OUTPUTS_EVENT === action.message) {
 
                 this.dispatchOutputsEvent()
+            } else if (ActionMessages.COPY_TO_CLIPBOARD === action.message) {
+                const { text } = action.payload;
+                
+                this.copyVariableToClipboard(text);
             } else if(ActionMessages.DISPATCH_OPEN_EVENT === action.message) {
                 const {destinationType, destination} = action.payload;
 
@@ -547,6 +551,10 @@ export class StateStore {
             } else if (ActionMessages.DISPATCH_OUTPUTS_EVENT === action.message) {
 
                 this.dispatchOutputsEvent()
+            } else if (ActionMessages.COPY_TO_CLIPBOARD === action.message) {
+                const { text } = action.payload;
+
+                this.copyVariableToClipboard(text);
             } else if (ActionMessages.DISPATCH_OPEN_EVENT === action.message) {
                 const { destinationType, destination } = action.payload;
 
@@ -1704,6 +1712,33 @@ export class StateStore {
         
         // dispatch the event to the window
         window.dispatchEvent(event);
+    };
+
+    /**
+     * Copy a variable's value to the clipboard
+     * @param variableName - the variable to copy
+    */
+
+    private copyVariableToClipboard = (variableName: string): void => {
+        let value = this.parseVariable(`{{${variableName}}}`);
+        // If found MobX observable/proxy, convert to plain JS using toJS and then stringify for clipboard
+        if (value && typeof value === "object") {
+            value = toJS(value);
+            try {
+                value = JSON.stringify(value, null, 2);
+            } catch {
+                value = String(value);
+            }
+        }
+        if (value !== undefined && value !== null) {
+            navigator.clipboard.writeText(String(value)).then(() => {
+                console.log(`Variable "${variableName}" copied to clipboard:`, value);
+            }).catch((err) => {
+                console.error("Failed to copy variable to clipboard:", err);
+            });
+        } else {
+            console.error(`Value of variable "${variableName}" not found.`);
+        }
     };
 
     private dispatchOpenEvent = (destinationType: string, destination: string): void => {

--- a/libs/renderer/src/store/state/state.types.ts
+++ b/libs/renderer/src/store/state/state.types.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { RunQueryAction, DispatchEventAction, DispatchOutputsEventAction, RunCellAction, DispatchOpenEventAction } from "./state.actions";
+import { RunQueryAction, DispatchEventAction, DispatchOutputsEventAction, RunCellAction, CopyToClipboardAction, DispatchOpenEventAction } from "./state.actions";
 import { CellState } from "./cell.state";
 import { QueryStateConfig } from "./query.state";
 
@@ -267,7 +267,7 @@ export type RegistryUnwrap<R extends Registry<BlockDef>> = R extends Registry<
 /**
  * Listener Actions
  */
-export type ListenerActions = RunQueryAction | DispatchEventAction | DispatchOutputsEventAction | RunCellAction | DispatchOpenEventAction;
+export type ListenerActions = RunQueryAction | DispatchEventAction | DispatchOutputsEventAction | RunCellAction | CopyToClipboardAction | DispatchOpenEventAction;
 
 /**
  * Cell Definition


### PR DESCRIPTION
## Description
This PR introduces a new option to the existing button onClick actions in the app builder interface. App creators can now configure a button to copy the value of a variable to the clipboard when clicked.

## Changes Made
- Added a new onClick action: "Copy to Clipboard".
- When this action is selected:
- A secondary dropdown appears to allow the user to select from existing variables.
- On button click, the selected variable’s value is copied to the clipboard.
- Clipboard functionality is implemented securely and works across supported browsers.
