### PR TITLE
Implemented functionality which allow user to change cell size in notebook

### DIFF
--- a/libs/renderer/src/components/cell-defaults/code-cell/CodeCell.tsx
+++ b/libs/renderer/src/components/cell-defaults/code-cell/CodeCell.tsx
@@ -110,10 +110,12 @@ export interface CodeCellDef extends CellDef<"code"> {
 const StyledContent = styled("div")(({ theme }) => ({
     position: "relative",
     width: "100%",
+    height: "100%",
 }));
 
 const StyledContainer = styled("div")(({ theme }) => ({
     width: "98%",
+    height: "100%",
 }));
 
 // track completion providers outside of render context
@@ -134,7 +136,7 @@ export const CodeCell: CellComponent<CodeCellDef> = observer((props) => {
 
     const diffEditorRef = useRef(null);
 
-    const { cell, isExpanded, agentModelEngine } = props;
+    const { cell, isExpanded, agentModelEngine, cellHeight } = props;
     const { state } = useBlocks();
     const notification = useNotification();
 
@@ -702,7 +704,7 @@ export const CodeCell: CellComponent<CodeCellDef> = observer((props) => {
                             ) : (
                                 <Editor
                                     width="100%"
-                                    height={getHeight()}
+                                    height={cellHeight ?? getHeight()}
                                     language={
                                         EDITOR_TYPE[cell.parameters.type].language
                                     }
@@ -795,7 +797,7 @@ export const CodeCell: CellComponent<CodeCellDef> = observer((props) => {
                                 <Editor
                                     key={count}
                                     width="100%"
-                                    height={getHeight()}
+                                    height={cellHeight ?? getHeight()}
                                     language={
                                         EDITOR_TYPE[cell.parameters.type].language
                                     }

--- a/libs/renderer/src/store/state/state.types.ts
+++ b/libs/renderer/src/store/state/state.types.ts
@@ -297,6 +297,11 @@ export type CellComponent<D extends CellDef = CellDef> =
         isExpanded?: boolean;
         /** Model to use for code help */
         agentModelEngine?: string;
+        /**
+         * Height of the cell
+         * This is used to calculate the height of the cell in the view
+         */
+        cellHeight?: number;
     }>;
 
 /**

--- a/packages/client/src/assets/img/ResizeIcon.tsx
+++ b/packages/client/src/assets/img/ResizeIcon.tsx
@@ -1,0 +1,9 @@
+export default function ResizeIcon() {
+    return (
+        <svg width="16" height="16" aria-hidden="true" focusable="false">
+            <line x1="4" y1="12" x2="12" y2="4" stroke="#888" strokeWidth="2" />
+            <line x1="8" y1="14" x2="14" y2="8" stroke="#888" strokeWidth="2" />
+            <line x1="2" y1="14" x2="14" y2="2" stroke="#bbb" strokeWidth="1" />
+        </svg>
+    );
+}

--- a/packages/client/src/components/notebook/NotebookCell.tsx
+++ b/packages/client/src/components/notebook/NotebookCell.tsx
@@ -33,6 +33,7 @@ import {
     Menu,
     MenuProps,
 } from '@semoss/ui';
+import ResizeIcon from '@/assets/img/ResizeIcon';
 
 import { NotebookAddCell } from './NotebookAddCell';
 import { NotebookCellConsole } from './NotebookCellConsole';
@@ -122,7 +123,7 @@ const StyledCard = styled(Card, {
         border: isCardCellSelected
             ? `1px solid ${theme.palette.secondary.main}`
             : 'unset',
-        borderRadius: shape.borderRadiusSm,
+        borderRadius: theme.shape.borderRadiusSm,
         boxShadow: 'none',
         '&:hover': {
             boxShadow: 'none',
@@ -130,7 +131,9 @@ const StyledCard = styled(Card, {
     };
 });
 
-const StyledCardContent = styled(Card.Content)(({ theme }) => ({
+const StyledCardContent = styled(Card.Content, {
+    shouldForwardProp: (prop) => prop !== 'cellHeight',
+})<{ cellHeight?: number }>(({ theme, cellHeight }) => ({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'start',
@@ -138,10 +141,35 @@ const StyledCardContent = styled(Card.Content)(({ theme }) => ({
     margin: '0',
     padding: theme.spacing(2),
     backgroundColor: theme.palette.background.default,
+    position: 'relative',
+    minHeight: 80,
+    height: cellHeight ? cellHeight : 'auto',
+    overflow: 'hidden', // Ensures children don't overflow
+    borderRadius: theme.shape.borderRadius,
+}));
+
+const StyledResizeHandle = styled('div')(({ theme }) => ({
+    position: 'absolute',
+    right: 2,
+    bottom: 2,
+    width: 20,
+    height: 20,
+    cursor: 'nwse-resize',
+    // background: theme.palette.action.hover,
+    // borderRadius: 4,
+    zIndex: 10,
+    // border: `1px solid ${theme.palette.divider}`,
+    display: 'flex',
+    alignItems: 'flex-end',
+    justifyContent: 'flex-end',
+    padding: 2,
 }));
 
 const StyledCardInput = styled('div')(() => ({
     width: '98%',
+    height: '100%', // Add this to ensure the input takes full height
+    display: 'flex',
+    flexDirection: 'column',
 }));
 
 const StyledCardActions = styled(Card.Actions)(({ theme }) => ({
@@ -270,11 +298,51 @@ export const NotebookCell = observer(
         const targetContentCollapseRef = useRef(null);
         const targetActionsCollapseRef = useRef(null);
 
+        const [cellHeight, setCellHeight] = useState<number | undefined>(
+            undefined,
+        );
+        const isResizing = useRef(false);
+        const startY = useRef(0);
+        const startHeight = useRef(0);
+
         // get the cell
         const query = state.getQuery(queryId);
         const cell = query.getCell(cellId);
 
         const variableName = state.getAlias(queryId, cellId);
+
+        // --- Resizable cell handlers ---
+        const onMouseDownResize = (e: React.MouseEvent) => {
+            e.preventDefault();
+            isResizing.current = true;
+            startY.current = e.clientY;
+            startHeight.current = cardContentRef.current
+                ? cardContentRef.current.offsetHeight
+                : 0;
+            document.body.style.cursor = 'nwse-resize';
+        };
+
+        useEffect(() => {
+            const onMouseMove = (e: MouseEvent) => {
+                if (isResizing.current && cardContentRef.current) {
+                    const delta = e.clientY - startY.current;
+                    const newHeight = Math.max(startHeight.current + delta, 80);
+                    setCellHeight(newHeight);
+                }
+            };
+            const onMouseUp = () => {
+                if (isResizing.current) {
+                    isResizing.current = false;
+                    document.body.style.cursor = '';
+                }
+            };
+            window.addEventListener('mousemove', onMouseMove);
+            window.addEventListener('mouseup', onMouseUp);
+            return () => {
+                window.removeEventListener('mousemove', onMouseMove);
+                window.removeEventListener('mouseup', onMouseUp);
+            };
+        }, []);
 
         useEffect(() => {
             if (cardContentRef.current) {
@@ -396,11 +464,13 @@ export const NotebookCell = observer(
                 cell: cell,
                 isExpanded: contentExpanded,
                 agentModelEngine: workspace.agentModelEngine,
+                cellHeight: cellHeight,
             });
         }, [
             cell.component ? cell.component : null,
             contentExpanded,
             workspace.agentModelEngine,
+            cellHeight,
         ]);
 
         const getExecutionTimeString = (
@@ -761,6 +831,7 @@ export const NotebookCell = observer(
                         <StyledCardContent
                             id={`notebook-cell-${queryId}-${cellId}-card-content`}
                             ref={cardContentRef}
+                            cellHeight={cellHeight}
                         >
                             <StyledRunIconButton
                                 title="Run cell"
@@ -791,6 +862,14 @@ export const NotebookCell = observer(
                                 )}
                             </StyledRunIconButton>
                             <StyledCardInput>{rendered}</StyledCardInput>
+                            <StyledResizeHandle
+                                onMouseDown={onMouseDownResize}
+                                aria-label="Resize cell"
+                                title="Drag to resize cell"
+                                tabIndex={0}
+                            >
+                                <ResizeIcon />
+                            </StyledResizeHandle>
                         </StyledCardContent>
                         {cell.parameters.type != 'markdown' && (
                             <>


### PR DESCRIPTION
## Description
This PR implements a feature that allows users to manually resize notebook cells by dragging the bottom right corner. This addresses issue #1399, where long text content was not fully visible due to the cell's fixed default size.

## Changes Made
- Added a draggable resize handle to each notebook cell.
- Users can now adjust the cell height vertically by clicking and dragging.
- Improved readability for cells containing large blocks of text.

![image](https://github.com/user-attachments/assets/7b929e2c-276c-48e1-b528-e92df64f51a4)
