### PR TITLE
feat(client): solving two skeleton effect on app card

### DIFF
--- a/packages/client/src/pages/app/AppCatalogPage.tsx
+++ b/packages/client/src/pages/app/AppCatalogPage.tsx
@@ -70,6 +70,7 @@ const initialState = {
     favoritedApps: [],
     apps: [],
 };
+const SKELETON_CARD_COUNT = 6;
 
 const reducer = (state, action) => {
     switch (action.type) {
@@ -451,6 +452,20 @@ export const AppCatalogPage = observer((): JSX.Element => {
                                 )}
                             </StyledSection>
                         )}
+                        {mode != 'System' && getApps.status !== 'SUCCESS' ? (
+                            <StyledSection>
+                                {Array.from({ length: SKELETON_CARD_COUNT }).map((_, i) => (
+                                    <AppTileCard
+                                        key={`skeleton-${i}`}
+                                        app={TERMINAL_APP}
+                                        systemApp={false}
+                                        isDiscoverable={mode !== 'Mine'}
+                                        isLoading={true}
+                                        showSkeleton={true}
+                                    />
+                                ))}
+                            </StyledSection>
+                        ) : null}
                         {mode != 'System' && apps.length > 0 ? (
                             <StyledSectionLabel variant="subtitle1">
                                 All Apps
@@ -505,7 +520,7 @@ export const AppCatalogPage = observer((): JSX.Element => {
                                                     removeApp(app);
                                                 }}
                                                 isLoading={true}
-                                                showSkeleton={true}
+                                                showSkeleton={false}
                                             />
                                         );
                                     })}

--- a/packages/client/src/pages/app/AppCatalogPage.tsx
+++ b/packages/client/src/pages/app/AppCatalogPage.tsx
@@ -381,16 +381,16 @@ export const AppCatalogPage = observer((): JSX.Element => {
 
                         {mode != 'System' && favoritedApps.length > 0 ? (
                             <StyledSection>
-                                {favoritedApps.map((app, i) => {
+                                {favoritedApps.map((app) => {
                                     return (
                                         <AppTileCard
-                                            key={i}
+                                            key={app.project_id}
                                             app={app}
                                             systemApp={false}
                                             href={
                                                 mode === 'Discoverable'
                                                     ? `#/app/${app.project_id}/detail`
-                                                    : `#/app/${app.project_id}`
+                                                    : `#/app/${app.project_id}/view`
                                             }
                                             onAction={() => {
                                                 if (mode === 'Discoverable') {
@@ -399,7 +399,7 @@ export const AppCatalogPage = observer((): JSX.Element => {
                                                     );
                                                 } else {
                                                     navigate(
-                                                        `/app/${app.project_id}`,
+                                                        `/app/${app.project_id}/view`,
                                                     );
                                                 }
                                             }}

--- a/packages/client/src/pages/app/AppCatalogPage.tsx
+++ b/packages/client/src/pages/app/AppCatalogPage.tsx
@@ -5,7 +5,6 @@ import {
     Typography,
     Button,
     styled,
-    Skeleton,
     ToggleTabsGroup,
     TextField,
     InputAdornment,
@@ -65,14 +64,6 @@ const StyledToggleTabsGroupItem = styled(ToggleTabsGroup.Item)(({ theme }) => ({
     },
 }));
 
-const AppTileSkeleton = styled('div')(({ theme }) => ({
-    display: 'flex',
-    flexDirection: 'column',
-    margin: theme.spacing(1),
-    marginRight: theme.spacing(0.5),
-    marginTop: theme.spacing(5),
-    marginBottom: theme.spacing(5),
-}));
 type MODE = 'Mine' | 'Discoverable' | 'System';
 
 const initialState = {
@@ -388,65 +379,43 @@ export const AppCatalogPage = observer((): JSX.Element => {
                             </StyledSectionLabel>
                         ) : null}
 
-                        {mode !== 'System' &&
-                            (getFavoritedApps.status === 'LOADING' ||
-                                favoritedApps.length > 0) && (
-                                <StyledSection>
-                                    {getFavoritedApps.status === 'LOADING'
-                                        ? Array.from({ length: 3 }).map(
-                                              (_, i) => (
-                                                  <AppTileSkeleton key={i}>
-                                                      <Skeleton
-                                                          variant="rectangular"
-                                                          width={250}
-                                                          height={118}
-                                                      />
-                                                      <Skeleton
-                                                          width="100%"
-                                                          height={25}
-                                                      />
-                                                      <Skeleton
-                                                          width="60%"
-                                                          height={25}
-                                                      />
-                                                  </AppTileSkeleton>
-                                              ),
-                                          )
-                                        : favoritedApps.map((app) => (
-                                              <AppTileCard
-                                                  key={app.project_id}
-                                                  app={app}
-                                                  systemApp={false}
-                                                  href={
-                                                      mode === 'Discoverable'
-                                                          ? `#/app/${app.project_id}/detail`
-                                                          : `#/app/${app.project_id}/view`
-                                                  }
-                                                  onAction={() => {
-                                                      if (
-                                                          mode ===
-                                                          'Discoverable'
-                                                      ) {
-                                                          navigate(
-                                                              `/app/${app.project_id}/detail`,
-                                                          );
-                                                      } else {
-                                                          navigate(
-                                                              `/app/${app.project_id}/view`,
-                                                          );
-                                                      }
-                                                  }}
-                                                  appType={app.project_type}
-                                                  isFavorite={isFavorited(
-                                                      app.project_id,
-                                                  )}
-                                                  favorite={() => {
-                                                      favoriteApp(app);
-                                                  }}
-                                              />
-                                          ))}
-                                </StyledSection>
-                            )}
+                        {mode != 'System' && favoritedApps.length > 0 ? (
+                            <StyledSection>
+                                {favoritedApps.map((app, i) => {
+                                    return (
+                                        <AppTileCard
+                                            key={i}
+                                            app={app}
+                                            systemApp={false}
+                                            href={
+                                                mode === 'Discoverable'
+                                                    ? `#/app/${app.project_id}/detail`
+                                                    : `#/app/${app.project_id}`
+                                            }
+                                            onAction={() => {
+                                                if (mode === 'Discoverable') {
+                                                    navigate(
+                                                        `/app/${app.project_id}/detail`,
+                                                    );
+                                                } else {
+                                                    navigate(
+                                                        `/app/${app.project_id}`,
+                                                    );
+                                                }
+                                            }}
+                                            appType={app.project_type}
+                                            isFavorite={isFavorited(
+                                                app.project_id,
+                                            )}
+                                            favorite={() => {
+                                                favoriteApp(app);
+                                            }}
+                                            isDiscoverable={mode !== 'Mine'}
+                                        />
+                                    );
+                                })}
+                            </StyledSection>
+                        ) : null}
 
                         {mode == 'System' && (
                             <StyledSectionLabel variant="subtitle1">


### PR DESCRIPTION
## Description
Previously two skeleton effects were loading. Now it is resolved

## Changes Made
1.Modified AppCatalogPage.tsx

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
    Go to App Landing Page -> reload the page -> You will see two skeleton effect before loading.
2. Expected outcomes
     You will be able to see only the correct skeleton effect before loading.

## Notes
<!-- Any further notes regarding changes -->