### PR TITLE
feat(client): added userdetails refresh and disable last author access change for admin mode 

### DIFF
--- a/packages/client/src/components/settings/MembersTable.tsx
+++ b/packages/client/src/components/settings/MembersTable.tsx
@@ -321,6 +321,7 @@ export const MembersTable = (props: MembersTableProps) => {
                   permission: 'OWNER',
               },
               status: 'SUCCESS',
+              refresh: () => null,
           };
 
     // TODO: NEEDS FIX ^
@@ -476,6 +477,7 @@ export const MembersTable = (props: MembersTableProps) => {
                 // refresh the members
                 getMembers.refresh();
                 allAuthorsResponse.refresh();
+                userDetails.refresh();
 
                 onChange();
             } else {
@@ -980,13 +982,13 @@ export const MembersTable = (props: MembersTableProps) => {
                                                                     value="Editor"
                                                                     label="Editor"
                                                                     disabled={
-                                                                        (isLastAuthor(
+                                                                        isLastAuthor(
                                                                             user,
                                                                         ) ||
-                                                                            (userPermission ===
-                                                                                'Editor' &&
-                                                                                user.permission ===
-                                                                                    'OWNER') ||
+                                                                        (((userPermission ===
+                                                                            'Editor' &&
+                                                                            user.permission ===
+                                                                                'OWNER') ||
                                                                             !configStore.isEngineOperationAvailable(
                                                                                 type,
                                                                                 'access',
@@ -996,20 +998,20 @@ export const MembersTable = (props: MembersTableProps) => {
                                                                             )
                                                                                 ?.priority >
                                                                                 2) &&
-                                                                        !adminMode
+                                                                            !adminMode)
                                                                     }
                                                                 />
                                                                 <RadioGroup.Item
                                                                     value="Read-Only"
                                                                     label="Read-Only"
                                                                     disabled={
-                                                                        (isLastAuthor(
+                                                                        isLastAuthor(
                                                                             user,
                                                                         ) ||
-                                                                            (userPermission ===
-                                                                                'Editor' &&
-                                                                                user.permission ===
-                                                                                    'OWNER') ||
+                                                                        (((userPermission ===
+                                                                            'Editor' &&
+                                                                            user.permission ===
+                                                                                'OWNER') ||
                                                                             !configStore.isEngineOperationAvailable(
                                                                                 type,
                                                                                 'access',
@@ -1022,7 +1024,7 @@ export const MembersTable = (props: MembersTableProps) => {
                                                                             readOnlyRestricted(
                                                                                 user,
                                                                             )) &&
-                                                                        !adminMode
+                                                                            !adminMode)
                                                                     }
                                                                 />
                                                             </RadioGroup>
@@ -1199,6 +1201,7 @@ export const MembersTable = (props: MembersTableProps) => {
                         // refresh
                         getMembers.refresh();
                         allAuthorsResponse.refresh();
+                        userDetails.refresh();
                     }
                 }}
             />

--- a/packages/client/src/components/settings/MembersTable.tsx
+++ b/packages/client/src/components/settings/MembersTable.tsx
@@ -324,9 +324,6 @@ export const MembersTable = (props: MembersTableProps) => {
               refresh: () => null,
           };
 
-    // TODO: NEEDS FIX ^
-    console.log('userDetails', userDetails);
-
     const allAuthorsResponse = useAPI(getAllAuthorsApi);
     const [allAuthors, setAllAuthors] = useState<SETTINGS_PROVISIONED_USER[]>(
         [],


### PR DESCRIPTION
## Description
added userdetails refresh and disable last author access change for admin mode 

## Changes Made
1. Added refresh of userdetails while member add and access change so that user access set correctly
2. Last author access can not be changed in admin mode

## How to Test
1. When access is getting changed, UI response:
   
![image](https://github.com/user-attachments/assets/def06b36-74ff-42f1-9a5a-da37de41fa56)


2. When Admin on, still last author access can not be changed

![image](https://github.com/user-attachments/assets/ad72582e-a7df-4b76-98bd-956eb3960d87)

