### PR TITLE
feat(client): vector catalog files download payload fix

### DIFF
--- a/packages/client/src/components/settings/FileTable.tsx
+++ b/packages/client/src/components/settings/FileTable.tsx
@@ -352,7 +352,7 @@ export const FileTable = (props: FileTableProps) => {
             }
         });
 
-        const pixel = `META | VectorFileDownload(engine = "${id}", filenames=[${fileArray}]);`;
+        const pixel = `META | VectorFileDownload(engine = "${id}", fileNames=[${fileArray}]);`;
 
         monolithStore.runQuery(pixel).then((response) => {
             const output = response.pixelReturn[0].output,


### PR DESCRIPTION
## Description
The download reactor call on vector catalog is incorrect.

## Changes Made

- [ ] Right now, the button calls "META | VectorFileDownload ( engine = "e4b3e4fe-d0fb-4719-8a85-34cb88b16f41" , filenames = [ "052825 Meeting.txt" ] ) ;
- [ ] Change filenames to fileNames within button on vector catalog page

## How to Test

- Go to a vector catalog you have access to
- Select a file
- Click the download button
- See the file gets downloaded successfully

## Notes
<!-- Any further notes regarding changes -->