### PR TITLE
build(fix): search bar not clearing on navigation

### DIFF
--- a/packages/client/src/components/shared/Search.tsx
+++ b/packages/client/src/components/shared/Search.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { observer } from 'mobx-react-lite';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import Autocomplete from '@mui/material/Autocomplete';
 import Chip from '@mui/material/Chip';
@@ -187,6 +187,7 @@ interface SearchProps {
 export const Search = observer(({ renderInput }: SearchProps) => {
     // TODO: navigation should be done through callback
     const navigate = useNavigate();
+    const location = useLocation();
     const { configStore } = useRootStore();
     const searchValue = configStore.store.globalSearch || '';
     const [open, setOpen] = useState(false);
@@ -213,6 +214,11 @@ export const Search = observer(({ renderInput }: SearchProps) => {
             };
         });
     }
+   
+    useEffect(() => {
+     configStore.setGlobalSearch('');
+    }, [location?.pathname]);
+
     const handleInputChange = (event, newInputValue) => {
         configStore.setGlobalSearch(newInputValue);
     };
@@ -357,7 +363,8 @@ export const Search = observer(({ renderInput }: SearchProps) => {
                                     label: option.label,
                                     id: option.id,
                                     type: option.section,
-                                });
+                                }),
+                                configStore.setGlobalSearch(''); // Clear search after selection
                             }}
                         >
                             <CatalogItem


### PR DESCRIPTION
## Description
Once we search for anything in the global search, after navigation the search is not cleared. With this PR it is fixed.

## Changes Made
Using the useLocation from the react router, we will be able to get the current route with this we can clear the search. On every route change the search is cleared.

## How to Test

1. On start, search for an already created app/db/function, etc.
2. Navigate away and back.
3. After the search click on the app you want to open, the app opens in a new window. Come back to the window where the search was performed, the search will be cleared.

## Notes

- **Searched for a app** 
<img width="1127" height="718" alt="image" src="https://github.com/user-attachments/assets/8f7715a3-1cb9-439b-b69a-55846ecba63f" />


- **Then navigated to the App/db/function, etc.**

<img width="1031" height="324" alt="image" src="https://github.com/user-attachments/assets/8bee5b45-bc1b-4c7a-ba64-003b56d0422c" />


- **Searched for an App and clicked on the link to open the App.**

<img width="931" height="216" alt="image" src="https://github.com/user-attachments/assets/0212a19c-2c1c-4b94-a971-63ce2e320d3b" />


**Navigated back to the window where the search was performed, the search is cleared.**

<img width="1031" height="324" alt="image" src="https://github.com/user-attachments/assets/c3c40253-22a0-4d1e-976e-ff0340fe4542" />

