### PR TITLE
fix(client): remove old ui jobs from new ui

### DIFF
--- a/packages/client/src/pages/jobs/JobsPage.tsx
+++ b/packages/client/src/pages/jobs/JobsPage.tsx
@@ -81,66 +81,72 @@ export function JobsPage() {
 			.then((response) => {
 				const type = response.pixelReturn[0].operationType[0];
 
-				if (type.indexOf("ERROR") > -1) {
-					notification.add({
-						color: "error",
-						message:
-							"Something went wrong. Jobs could not be retrieved.",
-					});
-				} else {
-					const pixelJobs: Record<string, PixelReturnJob> =
-						response.pixelReturn[0].output;
-					const jobs: Job[] = Object.values(pixelJobs).map((job) => {
-						// ui state is a legacy construct, this may not exist
-						let uiState: JobUIState;
-						try {
-							if (job.uiState) {
-								uiState = JSON.parse(job.uiState);
-							}
-						} catch (e) {
-							console.log(e);
-						}
+                if (type.indexOf('ERROR') > -1) {
+                    notification.add({
+                        color: 'error',
+                        message:
+                            'Something went wrong. Jobs could not be retrieved.',
+                    });
+                } else {
+                    const pixelJobs: Record<string, PixelReturnJob> =
+                        response.pixelReturn[0].output;
+                    const jobs: Job[] = [];
+                    Object.values(pixelJobs).forEach((job) => {
+                        // Job group is undefined for jobs made in the old ui
+                        if (!job.jobGroup || job.jobGroup === 'undefined') {
+                            // skip jobs made on the old ui since they aren't backwards compatable
+                            return;
+                        }
+                        // ui state is a legacy construct, this may not exist
+                        let uiState: JobUIState;
+                        try {
+                            if (job.uiState) {
+                                uiState = JSON.parse(job.uiState);
+                            }
+                        } catch (e) {
+                            console.log(e);
+                        }
 
-						let sendEmailJob: SendEmailJob;
-						if (job.recipe) {
-							sendEmailJob = convertSendEmailRecipeToJob(
-								job.recipe,
-							);
-						}
-						return {
-							id: job.jobId,
-							name: job.jobName,
-							type: "Custom",
-							cronExpression: job.cronExpression,
-							timeZone: job.cronTz,
-							tags: (job?.jobTags ?? "")
-								.split(",")
-								.filter((tag) => !!tag),
-							lastRun: job.PREV_FIRE_TIME,
-							nextRun: job.NEXT_FIRE_TIME,
-							ownerId: job.USER_ID,
-							isActive: job.NEXT_FIRE_TIME !== "INACTIVE",
-							group: job.jobGroup,
-							pixel: job.recipe,
-							smtpHost: sendEmailJob?.smtpHost,
-							smtpPort: sendEmailJob?.smtpPort,
-							subject: sendEmailJob?.subject,
-							jobType: uiState?.jobType,
-							to: (sendEmailJob?.to ?? "")
-								.split(",")
-								.filter((to) => !!to),
-							cc: (sendEmailJob?.cc ?? "")
-								.split(",")
-								.filter((cc) => !!cc),
-							bcc: (sendEmailJob?.bcc ?? "")
-								.split(",")
-								.filter((bcc) => !!bcc),
-							from: sendEmailJob?.from,
-							message: sendEmailJob?.message,
-							username: sendEmailJob?.username,
-							password: sendEmailJob?.password,
-						};
-					});
+                        let sendEmailJob: SendEmailJob;
+                        if (job.recipe) {
+                            sendEmailJob = convertSendEmailRecipeToJob(
+                                job.recipe,
+                            );
+                        }
+                        jobs.push({
+                            id: job.jobId,
+                            name: job.jobName,
+                            type: 'Custom',
+                            cronExpression: job.cronExpression,
+                            timeZone: job.cronTz,
+                            tags: (job?.jobTags ?? '')
+                                .split(',')
+                                .filter((tag) => !!tag),
+                            lastRun: job.PREV_FIRE_TIME,
+                            nextRun: job.NEXT_FIRE_TIME,
+                            ownerId: job.USER_ID,
+                            isActive: job.NEXT_FIRE_TIME !== 'INACTIVE',
+                            group: job.jobGroup,
+                            pixel: job.recipe,
+                            smtpHost: sendEmailJob?.smtpHost,
+                            smtpPort: sendEmailJob?.smtpPort,
+                            subject: sendEmailJob?.subject,
+                            jobType: uiState?.jobType,
+                            to: (sendEmailJob?.to ?? '')
+                                .split(',')
+                                .filter((to) => !!to),
+                            cc: (sendEmailJob?.cc ?? '')
+                                .split(',')
+                                .filter((cc) => !!cc),
+                            bcc: (sendEmailJob?.bcc ?? '')
+                                .split(',')
+                                .filter((bcc) => !!bcc),
+                            from: sendEmailJob?.from,
+                            message: sendEmailJob?.message,
+                            username: sendEmailJob?.username,
+                            password: sendEmailJob?.password,
+                        });
+                    });
 
 					setJobs(jobs);
 				}

--- a/packages/client/src/pages/jobs/job.utils.ts
+++ b/packages/client/src/pages/jobs/job.utils.ts
@@ -144,22 +144,27 @@ export function convertDeltaToRuntimeString(duration) {
 }
 
 export function convertSendEmailRecipeToJob(recipe: string): SendEmailJob {
-	if (!recipe.includes("SendEmail")) {
-		return;
-	}
-	const recipeMatches: RegExpMatchArray = recipe.match(/(?<=\().*/g);
-	if (recipeMatches.length === 0) {
-		return;
-	}
-	let cleanedRecipe: string = recipeMatches[0];
-	cleanedRecipe = cleanedRecipe.replaceAll(/[([\];)]/g, "");
-	cleanedRecipe = cleanedRecipe.replaceAll(",,", ",");
-	cleanedRecipe = cleanedRecipe.replaceAll("=", "':");
-	cleanedRecipe = cleanedRecipe.replaceAll("', ", "', '");
-	cleanedRecipe = cleanedRecipe.replaceAll("'", '"');
-	cleanedRecipe = `{"${cleanedRecipe}}`;
-	const job: SendEmailJob = JSON.parse(cleanedRecipe);
-	return job;
+    if (!recipe.includes('SendEmail')) {
+        return;
+    }
+    const recipeMatches: RegExpMatchArray = recipe.match(/(?<=\().*/g);
+    if (recipeMatches.length === 0) {
+        return;
+    }
+    let cleanedRecipe: string = recipeMatches[0];
+    cleanedRecipe = cleanedRecipe.replaceAll(/[\(\[\]\;\)]/g, '');
+    cleanedRecipe = cleanedRecipe.replaceAll(',,', ',');
+    cleanedRecipe = cleanedRecipe.replaceAll('=', "':");
+    cleanedRecipe = cleanedRecipe.replaceAll("', ", "', '");
+    cleanedRecipe = cleanedRecipe.replaceAll("'", '"');
+    cleanedRecipe = `{"${cleanedRecipe}}`;
+    try {
+        const job: SendEmailJob = JSON.parse(cleanedRecipe);
+        return job;
+    } catch (e) {
+        // skip a bad email job
+        return;
+    }
 }
 
 export function getEncodeByJobType(builder: JobBuilder) {


### PR DESCRIPTION
## Description
Filter out all the jobs created in the old ui from the new ui so we can recreate them in the jobs scheduler

## Changes Made
Filter out based on invalid job group
fix a json parsing issue with old and new jobs that would break the entire job list

## How to Test
1. create job in old ui
2. open new ui and see that the job doesn't appear

## Notes
N/A