### PR TITLE
Fixed styling in add apps modal

### DIFF
--- a/packages/client/src/components/teams/TeamProjectsTable.tsx
+++ b/packages/client/src/components/teams/TeamProjectsTable.tsx
@@ -245,6 +245,8 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [searchLoading, setSearchLoading] = useState(false);
 
+    const [projectImageMap, setProjectImageMap] = useState<Record<string, string>>({});
+
     const nearBottom = (
         target: {
             scrollHeight?: number;
@@ -602,10 +604,23 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
         200,
     );
 
-    const getRandomImage = () => {
+    const getRandomImageForProject = useCallback((projectId: string) => {
+        if (projectImageMap[projectId]) {
+            return projectImageMap[projectId];
+        }
         const randomIndex = Math.floor(Math.random() * projectImages.length);
-        return projectImages[randomIndex];
-    };
+        const newImage = projectImages[randomIndex];
+        
+        // Only update state if we don't have an image for this project
+        if (!projectImageMap[projectId]) {
+            setProjectImageMap(prev => ({
+                ...prev,
+                [projectId]: newImage
+            }));
+        }
+        
+        return newImage;
+    }, [projectImageMap]);
 
     return (
         <StyledProjectContent>
@@ -1001,7 +1016,7 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                                                                         'cover',
                                                                 },
                                                             }}
-                                                            src={getRandomImage()}
+                                                            src={getRandomImageForProject(project.project_id)}
                                                         />
                                                     </Box>
                                                 </Box>

--- a/packages/client/src/components/teams/TeamProjectsTable.tsx
+++ b/packages/client/src/components/teams/TeamProjectsTable.tsx
@@ -11,7 +11,6 @@ import {
     Autocomplete,
     Card,
     Box,
-    Chip,
     Avatar,
     Search,
     Stack,
@@ -29,6 +28,10 @@ import { AxiosResponse } from 'axios';
 
 import { SETTINGS_ROLE } from '@/components/settings/settings.types';
 import { useRootStore } from '@/hooks';
+import codeApp2 from '@/assets/img/code_app_2.png';
+import codeApp3 from '@/assets/img/code_app_3.png';
+import codeApp4 from '@/assets/img/code_app_4.png';
+import codeApp5 from '@/assets/img/code_app_5.png';
 
 const colors = [
     '#22A4FF',
@@ -39,6 +42,8 @@ const colors = [
     '#22A4FF',
     '#4CAF50',
 ];
+
+const projectImages = [codeApp2, codeApp3, codeApp4, codeApp5];
 
 const UserInfoTableCell = styled(Table.Cell)({
     display: 'flex',
@@ -169,6 +174,13 @@ const StyledModalContentText = styled(Modal.ContentText)({
 
 const StyledCard = styled(Card)({
     borderRadius: '12px',
+});
+
+const StyledModal = styled(Modal)({
+    '& .MuiPaper-root': {
+        borderRadius: '12px',
+        padding: '24px',
+    },
 });
 
 // maps for permissions,
@@ -590,6 +602,11 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
         200,
     );
 
+    const getRandomImage = () => {
+        const randomIndex = Math.floor(Math.random() * projectImages.length);
+        return projectImages[randomIndex];
+    };
+
     return (
         <StyledProjectContent>
             <StyledProjectInnerContent>
@@ -867,12 +884,14 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                     </StyledNonProjectsContainer>
                 )}
             </StyledProjectInnerContent>
-            <Modal open={addProjectModal} maxWidth="lg">
-                <Modal.Title>Add App</Modal.Title>
+            <StyledModal open={addProjectModal} maxWidth="lg">
+                <Modal.Title>
+                    <Typography variant="h6">Add Projects</Typography>
+                </Modal.Title>
                 <Modal.Content sx={{ width: '50rem' }}>
                     <StyledModalContentText>
                         <Autocomplete
-                            label="Select App"
+                            label="Select Project"
                             loading={searchLoading}
                             multiple={true}
                             freeSolo={false}
@@ -921,15 +940,6 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                         {selectedNonCredentialedProjects &&
                             selectedNonCredentialedProjects.map(
                                 (project, idx) => {
-                                    const space =
-                                        project.project_name.indexOf(' ');
-                                    const initial = project.project_name
-                                        ? space > -1
-                                            ? `${project.project_name[0].toUpperCase()}${project.project_name[
-                                                  space + 1
-                                              ].toUpperCase()}`
-                                            : project.project_name[0].toUpperCase()
-                                        : project.project_id[0].toUpperCase();
                                     return (
                                         <Box
                                             key={idx}
@@ -984,14 +994,15 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                                                                 display: 'flex',
                                                                 width: '50px',
                                                                 height: '50px',
-                                                                fontSize:
-                                                                    '24px',
-                                                                backgroundColor:
-                                                                    project.color,
+                                                                '& img': {
+                                                                    width: '100%',
+                                                                    height: '100%',
+                                                                    objectFit:
+                                                                        'cover',
+                                                                },
                                                             }}
-                                                        >
-                                                            {initial}
-                                                        </Avatar>
+                                                            src={getRandomImage()}
+                                                        />
                                                     </Box>
                                                 </Box>
                                                 <Card.Header
@@ -1025,20 +1036,20 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                                                                     opacity: 0.9,
                                                                     fontSize:
                                                                         '11px',
-                                                                    //height:'20px',
                                                                     width: '70%',
                                                                     gap: '4px',
                                                                 }}
                                                             >
                                                                 {`Project ID: `}
-                                                                <Chip
-                                                                    label={
+                                                                <Typography
+                                                                    variant="body2"
+                                                                    component="span"
+                                                                >
+                                                                    {
                                                                         project.project_id
                                                                     }
-                                                                    size="small"
-                                                                />
+                                                                </Typography>
                                                             </span>
-                                                            {`• `}
                                                         </Box>
                                                     }
                                                     action={
@@ -1084,9 +1095,10 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                                 pb: '12px',
                                 fontWeight: 'bold',
                                 fontSize: '16',
+                                color: '#000',
                             }}
                         >
-                            Permissions
+                            Project access
                         </Typography>
                         <Box
                             sx={{
@@ -1280,7 +1292,7 @@ export const TeamProjectsTable = (props: ProjectsTableProps) => {
                         Save
                     </Button>
                 </Modal.Actions>
-            </Modal>
+            </StyledModal>
             <Modal open={deleteProjectModal} maxWidth="md">
                 <Modal.Title>
                     <Typography variant="h6">Are you sure?</Typography>

--- a/packages/client/src/components/teams/TeamTileCard.tsx
+++ b/packages/client/src/components/teams/TeamTileCard.tsx
@@ -118,6 +118,17 @@ const StyledModalContentText = styled(Modal.ContentText)({
     marginTop: '12px',
 });
 
+const StyledDeleteModal = styled(Modal)({
+    '& .MuiPaper-root': {
+        width: '600px'
+    }
+});
+
+const StyledDeleteButton = styled(Button)({
+    fontWeight: 500,
+    padding: '6px 16px'
+});
+
 interface TeamCardProps {
     /** ID of team */
     id: string;
@@ -505,7 +516,7 @@ export const TeamTileCard = (props: TeamCardProps) => {
                     </Popover>
                 </StyledActionContainer>
             </StyledTileCard>
-            <Modal open={deleteModal}>
+            <StyledDeleteModal open={deleteModal}>
                 <StyledModalTitle>
                     <Typography sx={{ color: '#000000DE' }} variant="h6">
                         Delete Team
@@ -516,7 +527,7 @@ export const TeamTileCard = (props: TeamCardProps) => {
                 </StyledModalTitle>
                 <Modal.Content>
                     <Typography sx={{ color: '#000000DE' }} variant="body1">
-                        Are you sure you want to delete group {id}
+                        Are you sure you want to delete group: {id}
                     </Typography>
                 </Modal.Content>
                 <Modal.Actions
@@ -529,15 +540,15 @@ export const TeamTileCard = (props: TeamCardProps) => {
                     >
                         Cancel
                     </Button>
-                    <Button
+                    <StyledDeleteButton
                         variant="contained"
                         color={'error'}
                         onClick={() => deleteGroup()}
                     >
                         Delete
-                    </Button>
+                    </StyledDeleteButton>
                 </Modal.Actions>
-            </Modal>
+            </StyledDeleteModal>
             <Modal open={addMembersModal} maxWidth="lg">
                 <StyledModalTitle>
                     <Typography sx={{ color: '#000000DE' }} variant="h6">


### PR DESCRIPTION
## Description
This PR fix the styling of Add apps modal described in the below ticket: 
https://github.com/orgs/SEMOSS/projects/39/views/1?sliceBy%5Bvalue%5D=US+-+COR&filterQuery=&pane=issue&itemId=120051880&issue=SEMOSS%7Csemoss-ui%7C1527

## Changes Made
1. Made a few changes related to verbiage. 
2. For each app card - changed the avatar having initial of the project name to the generic image (after discussion with Sarah and Arash). The generic image used are taken from 
https://github.com/SEMOSS/semoss-ui/blob/222e5107058f8a38a9d46a79dd7db6638d64800f/packages/client/src/assets/img/code_app_4.png
3. Changed some styling like border radius and padding.
4. Removed chip and change it to normal typography text. 

## How to Test
1. On the teams permission page, select any card.
2. Click on add projects, a modal should open which has the above changes. 

<img width="862" height="780" alt="image" src="https://github.com/user-attachments/assets/a17f0f9f-1c81-4ff1-bb5f-36477de9d73c" />
