### PR TITLE
feat(client): add member button for dependency tab

### DIFF
--- a/packages/client/src/components/settings/DependencyList.tsx
+++ b/packages/client/src/components/settings/DependencyList.tsx
@@ -1,0 +1,189 @@
+import React, { useEffect, useState } from 'react';
+import { styled, Typography, Button, Box } from '@semoss/ui';
+import { usePixel } from '@/hooks';
+import { Add } from '@mui/icons-material';
+import { SETTINGS_ROLE } from './settings.types';
+import { MemberDependencyOverlay } from './MemberDependencyOverlay';
+
+interface DependencyListProps {
+    id: string;
+}
+
+// Interface for API response
+interface EngineData {
+    engine_id: string;
+    engine_name: string;
+    engine_type: string;
+    engine_subtype: string;
+    engine_date_created: string;
+    engine_discoverable: boolean;
+    engine_global: boolean;
+}
+
+interface User {
+    id: string;
+    type: string;
+    name: string;
+    email: string;
+    permission_granted_by_type: string;
+    permission_granted_by: string;
+    permission: string;
+    date_added: string;
+    usage_restriction?: string;
+    usage_frequency?: string;
+    max_tokens?: number;
+    max_response_time?: number;
+}
+
+const StyledUuidItem = styled('div')(({ theme }) => ({
+    padding: theme.spacing(2),
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    marginBottom: theme.spacing(1),
+    backgroundColor: theme.palette.background.paper,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    cursor: 'pointer',
+    transition: 'background-color 0.2s ease',
+    '&:hover': {
+        backgroundColor: theme.palette.action.hover,
+    },
+}));
+
+const StyledUuidList = styled('div')({
+    width: '100%',
+    maxHeight: '500px',
+    overflowY: 'auto',
+});
+
+const StyledAddMemberContainer = styled('div')({
+    display: 'flex',
+    padding: '10px 24px 10px 8px',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: '10px',
+});
+
+const StyledCenteredBox = styled(Box)({
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+});
+
+export const DependencyList = ({ id }: DependencyListProps) => {
+    const getProjectDependencies = usePixel<EngineData[]>(
+        `GetProjectDependencies(project="${id}", details=[true]);`,
+    );
+
+    /** Add Member State */
+    const [addMembersModal, setAddMembersModal] = useState<boolean>(false);
+    const [addModalUser, setAddModalUser] = useState<User | null>(null);
+
+    const openDependencyAddMembersModal = () => {
+        setAddModalUser(null); // reset user for add
+        setAddMembersModal(true);
+    };
+
+    const [userPermission, setUserPermission] =
+        useState<SETTINGS_ROLE>('Read-Only');
+
+    const handleEngineClick = (engineId: string) => {
+        const baseUrl = `${window.location.protocol}//${window.location.host}`;
+        const safeEngineId = encodeURIComponent(engineId);
+        const url = `${baseUrl}/SemossWeb/packages/client/dist/#/engine/storage/${safeEngineId}`;
+        window.open(url, '_blank');
+    };
+
+    return (
+        <div style={{ width: '100%' }}>
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    // marginBottom: 16,
+                }}
+            >
+                <Typography variant="h6" sx={{ mb: 2 }}>
+                    Dependencies
+                </Typography>
+                <StyledAddMemberContainer>
+                    <Button
+                        variant={'contained'}
+                        onClick={openDependencyAddMembersModal}
+                    >
+                        <StyledCenteredBox>
+                            <Add />
+                            Add Members
+                        </StyledCenteredBox>
+                    </Button>
+                </StyledAddMemberContainer>
+            </div>
+            <Typography variant="body2" sx={{ mb: 2 }}>
+                The following resources are associated with this application:
+            </Typography>
+
+            <StyledUuidList>
+                {getProjectDependencies.status === 'SUCCESS' &&
+                Array.isArray(getProjectDependencies.data) &&
+                getProjectDependencies.data.length > 0 ? (
+                    getProjectDependencies.data.map(
+                        (dependency: EngineData, index: number) => (
+                            <StyledUuidItem
+                                key={dependency.engine_id || index}
+                                role="button"
+                                tabIndex={0}
+                                onClick={() =>
+                                    handleEngineClick(dependency.engine_id)
+                                }
+                                onKeyPress={(e) => {
+                                    if (e.key === 'Enter')
+                                        handleEngineClick(dependency.engine_id);
+                                }}
+                            >
+                                <div>
+                                    <Typography
+                                        variant="subtitle2"
+                                        color="primary"
+                                    >
+                                        {dependency.engine_name} (
+                                        {dependency.engine_type})
+                                    </Typography>
+                                    <Typography
+                                        variant="body2"
+                                        color="secondary"
+                                    >
+                                        ID: {dependency.engine_id}
+                                    </Typography>
+                                </div>
+                            </StyledUuidItem>
+                        ),
+                    )
+                ) : getProjectDependencies.status === 'LOADING' ? (
+                    <Typography variant="body2" color="secondary">
+                        Loading dependencies...
+                    </Typography>
+                ) : getProjectDependencies.status === 'ERROR' ? (
+                    <Typography variant="body2" color="error">
+                        Error loading dependencies. Check console for details.
+                    </Typography>
+                ) : (
+                    <Typography variant="body2" color="secondary">
+                        No dependencies found for this application.
+                    </Typography>
+                )}
+                {/* Always render MemberDependencyOverlay, but control its open prop */}
+                <MemberDependencyOverlay
+                    id={id}
+                    open={addMembersModal}
+                    user={addModalUser}
+                    setAddModalUser={setAddModalUser}
+                    userPermission={userPermission}
+                    onClose={() => setAddMembersModal(false)}
+                />
+            </StyledUuidList>
+        </div>
+    );
+};

--- a/packages/client/src/components/settings/MemberDependencyOverlay.tsx
+++ b/packages/client/src/components/settings/MemberDependencyOverlay.tsx
@@ -1,0 +1,803 @@
+import { useEffect, useState } from 'react';
+import {
+    styled,
+    Button,
+    Modal,
+    RadioGroup,
+    Typography,
+    Autocomplete,
+    Box,
+    useNotification,
+    TextField,
+    IconButton,
+} from '@semoss/ui';
+
+import { ClearRounded } from '@mui/icons-material';
+
+import { useDebounceValue, useRootStore, useSettings } from '@/hooks';
+import { MembersAddOverlayUser } from './MembersAddOverlayUser';
+import { SETTINGS_ROLE } from './settings.types';
+import { usePixel } from '@/hooks';
+
+import { permissionPriorityMapper } from '@/utility/general';
+
+// Styled modal content to match MembersAddOverlay
+const StyledModal = styled(Modal.Content)(({ theme }) => ({
+    minWidth: '50rem',
+    maxWidth: '80rem',
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    boxSizing: 'border-box',
+}));
+
+const StyledOuterBox = styled('div')(({ theme }) => ({
+    flexShrink: '0',
+    display: 'flex',
+    flexDirection: 'column',
+    maxHeight: '300px',
+    overflow: 'auto',
+    border: '1px solid rgba(0, 0, 0, 0.12)',
+    borderRadius: '8px',
+    gap: theme.spacing(1),
+}));
+
+const AUTOCOMPLETE_LIMIT = 10;
+
+interface MemberDependencyOverlayProps {
+    /**
+     * Type of engine
+     */
+    // type: ALL_TYPES;
+
+    /**
+     * ID of the app or engine being edited
+     */
+    id: string;
+
+    /**
+     * Track if the model is open or close
+     */
+    open: boolean;
+
+    /**
+     * User we want to edit
+     */
+    user?: User;
+
+    /**
+     * Details of the current logged-in user (from MembersTable)
+     */
+    userData?: User;
+
+    /**
+     * Set Edit user to null
+     *
+     */
+    setAddModalUser?: React.Dispatch<React.SetStateAction<User>>;
+
+    /**
+     * User permission of the app or engine being edited
+     */
+    userPermission: SETTINGS_ROLE;
+
+    /**
+     * Called on close
+     *
+     * @returns - method that is called onClose
+     */
+    onClose: (success: boolean) => void;
+
+    /**
+     * Called on close
+     *
+     * @returns - method that is called onClose
+     */
+    onChange?: () => void;
+}
+
+interface User {
+    id: string;
+    type: string;
+    name: string;
+    email: string;
+    permission_granted_by_type: string;
+    permission_granted_by: string;
+    permission: string;
+    date_added: string;
+    usage_restriction?: string;
+    usage_frequency?: string;
+    max_tokens?: number;
+    max_response_time?: number;
+}
+
+export const MemberDependencyOverlay = (
+    // Add member to engine with selected permission
+    props: MemberDependencyOverlayProps,
+) => {
+    const {
+        // type,
+        id,
+        open = false,
+        userPermission,
+        onClose = () => null,
+        user,
+        setAddModalUser,
+        onChange = () => null,
+        userData,
+    } = props;
+    const { monolithStore, configStore } = useRootStore();
+    const notification = useNotification();
+    const { adminMode } = useSettings();
+
+    /** Add Member State */
+    const [selectedMember, setSelectedMember] = useState<User | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [users, setUsers] = useState<User[]>([]);
+    const [isScrollBottom, setIsScrollBottom] = useState(false);
+    const [search, setSearch] = useState<string>('');
+    const [offset, setOffset] = useState(0);
+    const [hasMore, setHasMore] = useState(true);
+    const [searchLoading, setSearchLoading] = useState(false);
+    const [renderedMembers, setRenderedMembers] = useState([]);
+
+    // Reset state when modal is opened or closed
+    useEffect(() => {
+        if (open) {
+            setSelectedMember(null);
+            setPendingPermissions({});
+            setUserDependencies([]);
+            setUserNoAccess([]);
+            setEnginePermissions({});
+            setRenderedMembers([]);
+            setSearch('');
+            setOffset(0);
+            setHasMore(true);
+        }
+    }, [open]);
+
+    // Get all dependencies for the opened app using usePixel
+    const getProjectDependencies = usePixel<any[]>(
+        `GetProjectDependencies(project="${id}", details=[true]);`,
+    );
+    const allDependencies = getProjectDependencies?.data || [];
+    const [userDependencies, setUserDependencies] = useState<string[]>([]);
+    const [userNoAccess, setUserNoAccess] = useState<string[]>([]);
+    const [enginePermissions, setEnginePermissions] = useState<
+        Record<string, string>
+    >({});
+    const [checkingAccess, setCheckingAccess] = useState(false);
+
+    useEffect(() => {
+        if (!selectedMember || !allDependencies.length) {
+            setUserDependencies([]);
+            setUserNoAccess([]);
+            return;
+        }
+        setCheckingAccess(true);
+        // Inline checkUserDependencies logic
+        (async () => {
+            const hasAccess = [];
+            const noAccess = [];
+            const permissions = {};
+            for (const dep of allDependencies) {
+                try {
+                    let users = [];
+                    // Engine (DATABASE, STORAGE, MODEL, VECTOR, FUNCTION, etc.)
+                    const result = await monolithStore.getEngineUsers(
+                        adminMode,
+                        dep.engine_id,
+                        '',
+                        '',
+                        0,
+                        1000,
+                    );
+                    users = result?.members || [];
+                    const userObj = users.find(
+                        (u) => u.id === selectedMember.id,
+                    );
+                    if (userObj) {
+                        hasAccess.push(dep.engine_id);
+                        permissions[dep.engine_id] =
+                            userObj.permission || 'Read-Only';
+                    } else {
+                        noAccess.push(dep.engine_id);
+                    }
+                } catch {
+                    noAccess.push(dep.engine_id);
+                }
+            }
+            setUserDependencies(hasAccess);
+            setUserNoAccess(noAccess);
+            setEnginePermissions(permissions);
+            setCheckingAccess(false);
+        })();
+    }, [selectedMember, allDependencies, adminMode]);
+
+    // debounce the input
+    const debouncedSearch = useDebounceValue(search);
+
+    const [infiniteOn, setInfiniteOn] = useState(true);
+
+    const [pendingPermissions, setPendingPermissions] = useState<
+        Record<string, string>
+    >({});
+
+    const [loggedInUserEnginePermissions, setLoggedInUserEnginePermissions] =
+        useState<Record<string, string>>({});
+
+    useEffect(() => {
+        if (!allDependencies.length) {
+            setLoggedInUserEnginePermissions({});
+            return;
+        }
+        const fetchPermissions = async () => {
+            const perms: Record<string, string> = {};
+            await Promise.all(
+                allDependencies.map(async (dep) => {
+                    try {
+                        const res = await monolithStore.getUserEnginePermission(
+                            dep.engine_id,
+                        );
+                        perms[dep.engine_id] = res?.permission || '';
+                    } catch {
+                        perms[dep.engine_id] = '';
+                    }
+                }),
+            );
+            setLoggedInUserEnginePermissions(perms);
+        };
+        fetchPermissions();
+    }, [allDependencies, monolithStore]);
+    console.log('loggedInUserEnginePermissions', loggedInUserEnginePermissions);
+
+    const nearBottom = (target: EventTarget | null) => {
+        if (
+            !target ||
+            typeof (target as unknown as { scrollHeight: number })
+                .scrollHeight !== 'number'
+        )
+            return false;
+        const el = target as unknown as {
+            scrollHeight: number;
+            scrollTop: number;
+            clientHeight: number;
+        };
+        const diff = Math.round(el.scrollHeight - el.scrollTop);
+        return diff - 25 <= el.clientHeight;
+    };
+
+    useEffect(() => {
+        if (!open) return;
+
+        const cancelled = false;
+        setSearchLoading(true);
+
+        const fetchUsers = async () => {
+            try {
+                let all = [];
+                const [noCred, cred] = await Promise.all([
+                    monolithStore.getProjectUsersNoCredentials(
+                        adminMode,
+                        id,
+                        AUTOCOMPLETE_LIMIT,
+                        offset,
+                        debouncedSearch || '',
+                    ),
+                    monolithStore.getProjectUsers(
+                        adminMode,
+                        id,
+                        debouncedSearch || '',
+                        '', // permission
+                        offset,
+                        AUTOCOMPLETE_LIMIT,
+                    ),
+                ]);
+                all = [...(noCred?.data || []), ...(cred?.members || [])];
+                if (!cancelled) {
+                    if (all.length < AUTOCOMPLETE_LIMIT) setInfiniteOn(false);
+
+                    if (
+                        renderedMembers.length >= AUTOCOMPLETE_LIMIT &&
+                        offset > 0
+                    ) {
+                        setRenderedMembers((prev) => [...prev, ...all]);
+                        setUsers((prev) => [...prev, ...all]);
+                    } else {
+                        setRenderedMembers(all);
+                        setUsers(all);
+                    }
+                    setSearchLoading(false);
+                }
+            } catch (e) {
+                if (!cancelled) {
+                    notification.add({
+                        color: 'error',
+                        message: String(e),
+                    });
+                    setSearchLoading(false);
+                }
+            }
+        };
+
+        fetchUsers();
+    }, [open, debouncedSearch, offset, adminMode, id]);
+
+    return (
+        <Modal open={open} maxWidth="lg">
+            <Modal.Title>Add Members to Dependency</Modal.Title>
+            <StyledModal>
+                {!selectedMember && (
+                    <Autocomplete
+                        label="Search"
+                        loading={loading}
+                        multiple={false}
+                        freeSolo={false}
+                        filterOptions={(x) => x}
+                        options={users}
+                        includeInputInList={true}
+                        ListboxProps={{
+                            onScroll: ({ target }) =>
+                                setIsScrollBottom(nearBottom(target)),
+                        }}
+                        value={selectedMember}
+                        inputValue={search}
+                        getOptionLabel={(option) =>
+                            typeof option === 'string' ? option : option.name
+                        }
+                        isOptionEqualToValue={(option, value) =>
+                            typeof option === 'object' &&
+                            option !== null &&
+                            'id' in option &&
+                            typeof value === 'object' &&
+                            value !== null &&
+                            'id' in value &&
+                            option.id === value.id
+                        }
+                        onInputChange={(event, newValue) => {
+                            setSearch(newValue || '');
+                            setOffset(0);
+                            setUsers([]);
+                            setHasMore(true);
+                        }}
+                        onChange={(event, newValue) => {
+                            if (
+                                typeof newValue === 'object' &&
+                                newValue !== null &&
+                                'id' in newValue
+                            ) {
+                                setSelectedMember(newValue as User);
+                            } else {
+                                setSelectedMember(null);
+                            }
+                        }}
+                        renderOption={(props, option) => {
+                            if (
+                                typeof option === 'object' &&
+                                option !== null &&
+                                'id' in option
+                            ) {
+                                return (
+                                    <li key={option.id} {...props}>
+                                        <div
+                                            style={{
+                                                width: '100%',
+                                                overflow: 'hidden',
+                                            }}
+                                        >
+                                            <MembersAddOverlayUser
+                                                name={option.name}
+                                                id={option.id}
+                                                email={option.email}
+                                                type={option.type}
+                                            />
+                                        </div>
+                                    </li>
+                                );
+                            }
+                            return null;
+                        }}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                variant="outlined"
+                                placeholder="Search users"
+                                InputProps={{
+                                    ...params.InputProps,
+                                    startAdornment: null,
+                                }}
+                            />
+                        )}
+                    />
+                )}
+
+                {/* Show selected user under search bar */}
+                {selectedMember && (
+                    <StyledOuterBox>
+                        <MembersAddOverlayUser
+                            key={selectedMember.id}
+                            name={selectedMember.name}
+                            id={selectedMember.id}
+                            email={selectedMember.email}
+                            type={selectedMember.type}
+                            action={
+                                <IconButton
+                                    size="small"
+                                    onClick={() => {
+                                        setSelectedMember(null);
+                                    }}
+                                >
+                                    <ClearRounded fontSize="small" />
+                                </IconButton>
+                            }
+                        />
+                    </StyledOuterBox>
+                )}
+
+                {/* Show dependencies access info if a user is selected */}
+                {selectedMember && (
+                    <Box sx={{ mt: 4 }}>
+                        <Typography variant="h6">Dependency Access</Typography>
+                        {checkingAccess ? (
+                            <Typography variant="body2">
+                                Checking access...
+                            </Typography>
+                        ) : (
+                            <Box>
+                                <Box>
+                                    <Typography
+                                        variant="subtitle1"
+                                        sx={{ mb: 2 }}
+                                    >
+                                        Has Access
+                                    </Typography>
+                                    <Box
+                                        sx={{
+                                            display: 'flex',
+                                            flexDirection: 'column',
+                                            gap: 2,
+                                        }}
+                                    >
+                                        {allDependencies
+                                            .filter((dep) =>
+                                                userDependencies.includes(
+                                                    dep.engine_id,
+                                                ),
+                                            )
+                                            .map((dep) => (
+                                                <Box
+                                                    key={dep.engine_id}
+                                                    sx={{
+                                                        display: 'flex',
+                                                        alignItems: 'center',
+                                                        gap: 2,
+                                                        mb: 1,
+                                                        p: 1,
+                                                        border: '1px solid #e0e0e0',
+                                                        borderRadius: '8px',
+                                                        background: '#f9f9f9',
+                                                    }}
+                                                >
+                                                    <Typography
+                                                        variant="body1"
+                                                        sx={{
+                                                            fontWeight: 500,
+                                                            minWidth: 120,
+                                                        }}
+                                                    >
+                                                        {dep.engine_name ||
+                                                            dep.engine_id}
+                                                    </Typography>
+                                                    <RadioGroup
+                                                        row
+                                                        value={
+                                                            pendingPermissions[
+                                                                dep.engine_id
+                                                            ] ||
+                                                            (enginePermissions[
+                                                                dep.engine_id
+                                                            ] === 'OWNER'
+                                                                ? 'Author'
+                                                                : enginePermissions[
+                                                                      dep
+                                                                          .engine_id
+                                                                  ] === 'EDIT'
+                                                                ? 'Editor'
+                                                                : enginePermissions[
+                                                                      dep
+                                                                          .engine_id
+                                                                  ] ===
+                                                                  'READ_ONLY'
+                                                                ? 'Read-Only'
+                                                                : '')
+                                                        }
+                                                        sx={{ ml: 2 }}
+                                                        onChange={(e) => {
+                                                            setPendingPermissions(
+                                                                (prev) => ({
+                                                                    ...prev,
+                                                                    [dep.engine_id]:
+                                                                        e.target
+                                                                            .value,
+                                                                }),
+                                                            );
+                                                        }}
+                                                    >
+                                                        <RadioGroup.Item
+                                                            value="Author"
+                                                            label="Author"
+                                                            disabled={
+                                                                permissionPriorityMapper(
+                                                                    loggedInUserEnginePermissions[
+                                                                        dep
+                                                                            .engine_id
+                                                                    ],
+                                                                ).priority >
+                                                                    1 &&
+                                                                !adminMode
+                                                            }
+                                                        />
+                                                        <RadioGroup.Item
+                                                            value="Editor"
+                                                            label="Editor"
+                                                            disabled={
+                                                                (loggedInUserEnginePermissions[
+                                                                    dep
+                                                                        .engine_id
+                                                                ] === 'EDIT' &&
+                                                                    enginePermissions[
+                                                                        dep
+                                                                            .engine_id
+                                                                    ] ===
+                                                                        'OWNER') ||
+                                                                (permissionPriorityMapper(
+                                                                    loggedInUserEnginePermissions[
+                                                                        dep
+                                                                            .engine_id
+                                                                    ],
+                                                                ).priority >
+                                                                    2 &&
+                                                                    !adminMode)
+                                                            }
+                                                        />
+                                                        <RadioGroup.Item
+                                                            value="Read-Only"
+                                                            label="Read-Only"
+                                                            disabled={
+                                                                (loggedInUserEnginePermissions[
+                                                                    dep
+                                                                        .engine_id
+                                                                ] === 'EDIT' &&
+                                                                    enginePermissions[
+                                                                        dep
+                                                                            .engine_id
+                                                                    ] ===
+                                                                        'OWNER') ||
+                                                                (permissionPriorityMapper(
+                                                                    loggedInUserEnginePermissions[
+                                                                        dep
+                                                                            .engine_id
+                                                                    ],
+                                                                ).priority >=
+                                                                    3 &&
+                                                                    !adminMode)
+                                                            }
+                                                        />
+                                                    </RadioGroup>
+                                                </Box>
+                                            ))}
+                                    </Box>
+                                </Box>
+                                <Box sx={{ mt: 4 }}>
+                                    <Typography
+                                        variant="subtitle1"
+                                        sx={{ mb: 2 }}
+                                    >
+                                        No Access
+                                    </Typography>
+                                    <Box
+                                        sx={{
+                                            display: 'flex',
+                                            flexDirection: 'column',
+                                            gap: 2,
+                                        }}
+                                    >
+                                        {allDependencies
+                                            .filter((dep) =>
+                                                userNoAccess.includes(
+                                                    dep.engine_id,
+                                                ),
+                                            )
+                                            .map((dep) => (
+                                                <Box
+                                                    key={dep.engine_id}
+                                                    sx={{
+                                                        display: 'flex',
+                                                        alignItems: 'center',
+                                                        gap: 2,
+                                                        mb: 1,
+                                                        p: 1,
+                                                        border: '1px solid #f0f0f0',
+                                                        borderRadius: '8px',
+                                                        background: '#fff',
+                                                    }}
+                                                >
+                                                    <Typography
+                                                        variant="body1"
+                                                        sx={{
+                                                            fontWeight: 500,
+                                                            minWidth: 120,
+                                                        }}
+                                                    >
+                                                        {dep.engine_name ||
+                                                            dep.engine_id}
+                                                    </Typography>
+                                                    <RadioGroup
+                                                        row
+                                                        value={
+                                                            pendingPermissions[
+                                                                dep.engine_id
+                                                            ] || ''
+                                                        }
+                                                        sx={{ ml: 2 }}
+                                                        onChange={(e) => {
+                                                            setPendingPermissions(
+                                                                (prev) => ({
+                                                                    ...prev,
+                                                                    [dep.engine_id]:
+                                                                        e.target
+                                                                            .value,
+                                                                }),
+                                                            );
+                                                        }}
+                                                    >
+                                                        <RadioGroup.Item
+                                                            value="Author"
+                                                            label="Author"
+                                                            disabled={
+                                                                permissionPriorityMapper(
+                                                                    loggedInUserEnginePermissions[
+                                                                        dep
+                                                                            .engine_id
+                                                                    ],
+                                                                ).priority >
+                                                                    1 &&
+                                                                !adminMode
+                                                            }
+                                                        />
+                                                        <RadioGroup.Item
+                                                            value="Editor"
+                                                            label="Editor"
+                                                            disabled={
+                                                                permissionPriorityMapper(
+                                                                    loggedInUserEnginePermissions[
+                                                                        dep
+                                                                            .engine_id
+                                                                    ],
+                                                                ).priority >
+                                                                    2 &&
+                                                                !adminMode
+                                                            }
+                                                        />
+                                                        <RadioGroup.Item
+                                                            value="Read-Only"
+                                                            label="Read-Only"
+                                                            disabled={
+                                                                permissionPriorityMapper(
+                                                                    loggedInUserEnginePermissions[
+                                                                        dep
+                                                                            .engine_id
+                                                                    ],
+                                                                ).priority >=
+                                                                    3 &&
+                                                                !adminMode
+                                                            }
+                                                        />
+                                                    </RadioGroup>
+                                                </Box>
+                                            ))}
+                                    </Box>
+                                </Box>
+                            </Box>
+                        )}
+                    </Box>
+                )}
+            </StyledModal>
+            <Modal.Actions>
+                <Button variant="outlined" onClick={() => onClose(false)}>
+                    Cancel
+                </Button>
+                <Button
+                    variant="contained"
+                    color="primary"
+                    disabled={!selectedMember}
+                    onClick={async () => {
+                        if (!selectedMember) return;
+                        let success = true;
+                        const failedCalls: string[] = [];
+                        for (const [engineId, permission] of Object.entries(
+                            pendingPermissions,
+                        )) {
+                            const backendPermission =
+                                permission === 'Author'
+                                    ? 'OWNER'
+                                    : permission === 'Editor'
+                                    ? 'EDIT'
+                                    : permission === 'Read-Only'
+                                    ? 'READ_ONLY'
+                                    : permission;
+                            const userObj = [
+                                {
+                                    userid: selectedMember.id,
+                                    permission: backendPermission,
+                                },
+                            ];
+                            let response;
+                            if (userDependencies.includes(engineId)) {
+                                // Update permission
+                                response =
+                                    await monolithStore.editEngineUserPermissions(
+                                        adminMode,
+                                        engineId,
+                                        userObj,
+                                    );
+                            } else {
+                                // Add user to engine
+                                response =
+                                    await monolithStore.addEngineUserPermissions(
+                                        adminMode,
+                                        engineId,
+                                        userObj,
+                                    );
+                            }
+                            if (response?.data?.success) {
+                                // Only update local state for successful calls
+                                if (!userDependencies.includes(engineId)) {
+                                    setUserDependencies((prev) => [
+                                        ...prev,
+                                        engineId,
+                                    ]);
+                                    setUserNoAccess((prev) =>
+                                        prev.filter((id) => id !== engineId),
+                                    );
+                                }
+                                setEnginePermissions((prev) => ({
+                                    ...prev,
+                                    [engineId]: backendPermission,
+                                }));
+                            } else {
+                                success = false;
+                                const depObj = allDependencies.find(
+                                    (dep) => dep.engine_id === engineId,
+                                );
+                                const engineName =
+                                    depObj?.engine_name || engineId;
+                                failedCalls.push(
+                                    `${engineName} (${permission})`,
+                                );
+                            }
+                        }
+                        if (success) {
+                            notification.add({
+                                color: 'success',
+                                message: 'Permissions updated successfully.',
+                            });
+                            if (onChange) onChange();
+                            onClose(true);
+                        } else {
+                            notification.add({
+                                color: 'error',
+                                message: `Error updating permissions for: ${failedCalls.join(
+                                    ', ',
+                                )}`,
+                            });
+                        }
+                    }}
+                >
+                    Add
+                </Button>
+            </Modal.Actions>
+        </Modal>
+    );
+};


### PR DESCRIPTION
## Description
Add Member Button for changing and giving access for dependent engines to members

## Changes Made
1. It will show a Add Member button in the dependency tab
2. On Click it will open MemberDependencyOverlay to search users
3. on choosing a member, it will show all the engines with labels which have access and which doesn't
4.User can give access or change access for the engines


## How to Test
<img width="1919" height="958" alt="Screenshot 2025-07-18 181054" src="https://github.com/user-attachments/assets/f6a4b494-8fcb-4b8b-be92-0d675ec5c20d" />
<img width="1912" height="895" alt="Screenshot 2025-07-18 181131" src="https://github.com/user-attachments/assets/5c147dc2-e398-41de-96c9-89aa4710661b" />
<img width="1919" height="903" alt="Screenshot 2025-07-18 181312" src="https://github.com/user-attachments/assets/a370e341-3ce4-4da9-a9c6-97b561c6ab94" />





