### PR TITLE
Added a default line height for h1 variant of text blocks 

### DIFF
--- a/libs/renderer/src/components/block-defaults/text-block/TextBlock.tsx
+++ b/libs/renderer/src/components/block-defaults/text-block/TextBlock.tsx
@@ -1,66 +1,68 @@
-import React, { CSSProperties, useEffect } from "react";
 import { observer } from "mobx-react-lite";
-
-import { useBlock, useTypeWriter, useBlocks } from "../../../hooks";
-import { BlockDef, BlockComponent, ListenerActions } from "../../../store";
+import React, { CSSProperties, useEffect } from "react";
+import { useBlock, useBlocks, useTypeWriter } from "../../../hooks";
+import { BlockComponent, BlockDef, ListenerActions } from "../../../store";
 import { showBlock } from "../../blocks/RendererEngine";
 
 export interface TextBlockDef extends BlockDef<"text"> {
-    widget: "text";
-    data: {
-        style: CSSProperties;
-        text: string;
-        variant?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
-        isStreaming: boolean;
-        show: string;
-    };
-    slots: never;
-    listeners: {
-        preProcess: {
-            type: "sync" | "async";
-            order: ListenerActions[];
-        };
-    };
+	widget: "text";
+	data: {
+		style: CSSProperties;
+		text: string;
+		variant?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
+		isStreaming: boolean;
+		show: string;
+	};
+	slots: never;
+	listeners: {
+		preProcess: {
+			type: "sync" | "async";
+			order: ListenerActions[];
+		};
+	};
 }
 
 export const TextBlock: BlockComponent = observer(({ id }) => {
-    // const { attrs, data } = useBlock<TextBlockDef>(id);
-    const block = useBlock<TextBlockDef>(id);
-    const state = useBlocks();
-    const { attrs, data, listeners } = block;
+	// const { attrs, data } = useBlock<TextBlockDef>(id);
+	const block = useBlock<TextBlockDef>(id);
+	const state = useBlocks();
+	const { attrs, data, listeners } = block;
 
-    const textContent =
-        typeof data.text == "string" ? data.text : JSON.stringify(data.text);
-    let displayTxt = useTypeWriter(data.isStreaming ? textContent : "");
+	const textContent =
+		typeof data.text == "string" ? data.text : JSON.stringify(data.text);
+	let displayTxt = useTypeWriter(data.isStreaming ? textContent : "");
 
-    if (!data.isStreaming) displayTxt = textContent;
+	if (!data.isStreaming) displayTxt = textContent;
 
-    useEffect(() => {
-        if (listeners.preProcess) {
-            listeners.preProcess();
-        }
-    }, []);
+	useEffect(() => {
+		if (listeners.preProcess) {
+			listeners.preProcess();
+		}
+	}, []);
 
-    // TODO: Why?
-    return showBlock(block, state)
-        ? React.createElement(
-              data.variant ? data.variant : "p",
-              {
-                  style: {
-                      ...data.style,
-                      marginBlockStart: "0px",
-                      marginBlockEnd: "0px",
-                  },
-                  ...attrs,
-              },
-              displayTxt,
-          )
-        : React.createElement("p", {
-              style: {
-                  ...data.style,
-                  marginBlockStart: "0px",
-                  marginBlockEnd: "0px",
-              },
-              ["data-block"]: id,
-          });
+	// TODO: Why?
+	return showBlock(block, state)
+		? React.createElement(
+				data.variant ? data.variant : "p",
+				{
+					style: {
+						...data.style,
+						...(data.variant === "h1"
+							? { lineHeight: "116.7%" }
+							: {}),
+						marginBlockStart: "0px",
+						marginBlockEnd: "0px",
+					},
+					...attrs,
+				},
+				displayTxt,
+			)
+		: React.createElement("p", {
+				style: {
+					...data.style,
+					marginBlockStart: "0px",
+					marginBlockEnd: "0px",
+				},
+				["data-block"]: id,
+			});
 });


### PR DESCRIPTION
## Description
This PR addresses the issue where the H1 variant in the TextBlock component displayed awkward line spacing when the title wrapped into multiple lines. The line height was too tight, leading to poor readability.

## Changes Made
- Applied a default line height of 116.7% (as per Material Design spec) to the H1 variant of the TextBlock component.
- Verified that all other text variants (H2, H3, Body1, etc.) already have appropriate line heights, so no changes were made to those.
- Setting the correct line height improves readability and consistency with Material Design typography standards.
<img width="816" height="217" alt="image" src="https://github.com/user-attachments/assets/ee4db286-6cb8-4195-b80b-8694caa1baea" />


## Notes
- i made only one change in TextBlock.tsx file which is : 
...(data.variant === "h1" ? { lineHeight: "116.7%" } : {}),

- if any other changes reflecting in this PR maybe they are linting issues or formatting issue. 
							