### PR TITLE
Fix HMR for Client Dependency Packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "semoss",
   "description": "SEMOSS Analytics Platform",
   "scripts": {
-    "prepare":"lefthook install",
+    "prepare": "lefthook install",
     "dev": "turbo run dev",
     "dev:client": "turbo run dev --filter=@semoss/client...",
     "dev:playground": "turbo run dev --filter=@semoss/playground...",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "semoss",
   "description": "SEMOSS Analytics Platform",
   "scripts": {
-    "prepare": "lefthook install",
+    "prepare":"lefthook install",
     "dev": "turbo run dev",
     "dev:client": "turbo run dev --filter=@semoss/client...",
     "dev:playground": "turbo run dev --filter=@semoss/playground...",

--- a/turbo.json
+++ b/turbo.json
@@ -1,38 +1,39 @@
 {
-    "$schema": "https://turborepo.com/schema.json",
-    "tasks": {
-        "build": {
-            "dependsOn": ["^build"],
-            "inputs": ["$TURBO_DEFAULT$", ".env*"],
-            "outputs": ["dist/**"]
-        },
-        "build:dev": {
-            "cache": false,
-            "dependsOn": ["^build:dev"],
-            "inputs": ["$TURBO_DEFAULT$", ".env*"],
-            "outputs": ["dist/**"]
-        },
-        "lint": {
-            "dependsOn": ["^lint"]
-        },
-        "format": {
-            "dependsOn": ["^format"]
-        },
-        "check-types": {
-            "dependsOn": ["^check-types"]
-        },
-        "dev": {
-            "inputs": ["$TURBO_DEFAULT$", ".env*"],
-            "cache": false,
-            "persistent": true
-        },
-        "test": {
-            "dependsOn": ["^test"],
-            "inputs": ["src/**/*.ts", "src/**/*/tsx"]
-        },
-        "test:watch": {
-          "cache": false,
-          "persistent": true
-        }
-    }
+	"$schema": "https://turborepo.com/schema.json",
+	"tasks": {
+		"build": {
+			"dependsOn": ["^build"],
+			"inputs": ["$TURBO_DEFAULT$", ".env*"],
+			"outputs": ["dist/**"]
+		},
+		"build:dev": {
+			"cache": false,
+			"dependsOn": ["^build:dev"],
+			"inputs": ["$TURBO_DEFAULT$", ".env*"],
+			"outputs": ["dist/**"]
+		},
+		"lint": {
+			"dependsOn": ["^lint"]
+		},
+		"format": {
+			"dependsOn": ["^format"]
+		},
+		"check-types": {
+			"dependsOn": ["^check-types"]
+		},
+		"dev": {
+			"dependsOn": ["^build:dev"],
+			"inputs": ["$TURBO_DEFAULT$", ".env*"],
+			"cache": false,
+			"persistent": true
+		},
+		"test": {
+			"dependsOn": ["^test"],
+			"inputs": ["src/**/*.ts", "src/**/*/tsx"]
+		},
+		"test:watch": {
+			"cache": false,
+			"persistent": true
+		}
+	}
 }


### PR DESCRIPTION
## Description
This pull request fixes an issue requiring packages to be individually built in order to show changes made within. For example, the platform team has been working within `libs/renderer`, and has been unable to view changes to their code without navigating to the renderer package and running the build script. This was especially problematic because they were reporting build times exceeding 7 minutes.

This pull request ensures that `turbo build:dev` is run on all dependency packages of the package running `turbo run dev`. This ensures that when the client's Vite dev server starts, all the libraries it imports (UI components, renderer, SDK) are already built and available in their dist folders, and thus enables HMR for all dependent packages once the initial dev script has completed.

## Changes Made
- Added `dependsOn: ["^build:dev"]` to dev script in turbo.json

## How to Test
1. Start client dev environment by running `pnpm run dev:client` from the root (SemossWeb/semoss-ui depending on your path configuration).
2. Wait for all packages to build. (Note: renderer takes several minutes to build.)
3. Open app and make a change in a dependency package's code.
4. Verify that changes are reflected in the app with HMR.

## Notes
- Initial build time is still quite long, as renderer takes exceedingly long to complete--as mentioned above, near 8 minutes on some machines. The dev scripts can be optimized with caching and running the builds concurrently as well. I will address this in a subsequent PR, as I want to keep the scope of this PR focused since it affects a large number of users and addresses a critical issue.
- There is still an existing issue with the dev script where there is a conflict between the client and playground. Basically, playground ends up superseding the client startup, so running `pnpm run dev` will result in the playground running on port 5174 and the client not running at all. I'll propose this change in a subsequent PR as well.