### PR TITLE
Add Port to Playground Server Configuration

### DIFF
--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig(({ mode }) => {
 			commonjsOptions: { transformMixedEsModules: true },
 		},
 		server: {
+			port: 5174,
 			proxy: {
 				[MODULE]: {
 					target: ENDPOINT,


### PR DESCRIPTION
## Description
This pull request specifies the port for the playground server in its configuration file in order to prevent it from interfering with the client server when running `pnpm run dev`.

## Changes Made
- Added `port: 5174` to the `server` object in the playground Vite configuration file.

## How to Test
1. Run `pnpm run dev` from the app root.
2. Wait for all packages to build. (This can take several minutes).
3. Verify that the client server is running (http://localhost:5173/SemossWeb/packages/client/dist/#)
4. Verify that the playground server is running (http://localhost:5174/#/new)