### PR TITLE
Revert Turbo Config Change

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,6 @@
 			"dependsOn": ["^check-types"]
 		},
 		"dev": {
-			"dependsOn": ["^build:dev"],
 			"inputs": ["$TURBO_DEFAULT$", ".env*"],
 			"cache": false,
 			"persistent": true


### PR DESCRIPTION
## Description
This pull request reverts the changes made to the turbo config ostensibly correcting issues with HMR [here](https://github.com/SEMOSS/semoss-ui/commit/77749ec45b509b3c4a339b35149a59ea1092e434). These changes were misattributed to the resolution of the issue discussed within that commit.

## Changes Made
- Revert turbo config `dependsOn` field.