### PR TITLE
feat(client): csv tab enable

### DIFF
--- a/packages/client/src/pages/import/ImportPageContent.tsx
+++ b/packages/client/src/pages/import/ImportPageContent.tsx
@@ -577,21 +577,14 @@ export const ImportPageContent: React.FC<ImportPageContentProps> = ({
 																		setSteps(
                                                                             [
                                                                                 ...steps,
-                                                                                stage.name ===
-                                                                                'CSV'
-                                                                                    ? {
-                                                                                          id: `${kv[0]}.${stage.name}`,
-                                                                                          title: 'Upload Csv',
-                                                                                          description: `To configure the database, set up the necessary connection parameters such as Database name,Description and Tags in the configuration file.
-                                                                                    Ensure proper indexing and security measures are in place for optimal performance and protection.`,
-                                                                                          data: stage.fields,
-                                                                                      }
-                                                                                    : {
-                                                                                          id: `${kv[0]}.${stage.name}`,
-                                                                                          title: stage.name,
-                                                                                          description: `Fill out  details in order to add  to catalog`,
-                                                                                          data: stage.fields,
-                                                                                      },
+                                                                                 {
+                                                                                    id: `${kv[0]}.${stage.name}`,
+                                                                                    title: stage.name === 'csv' ?  `Upload ${stage.name}` : stage.name,
+                                                                                    description: `Fill out ${
+                                                                                        stage.name
+                                                                                    } details in order to add ${steps[0].data.toLowerCase()} to catalog`,
+                                                                                    data: stage.fields,
+                                                                                },
 																			],
 																			steps.length +
 																				1,

--- a/packages/client/src/pages/import/ImportPageContent.tsx
+++ b/packages/client/src/pages/import/ImportPageContent.tsx
@@ -575,16 +575,23 @@ export const ImportPageContent: React.FC<ImportPageContentProps> = ({
 																		!stage.disable
 																	) {
 																		setSteps(
-																			[
-																				...steps,
-																				{
-																					id: `${kv[0]}.${stage.name}`,
-																					title: stage.name,
-																					description: `Fill out ${
-																						stage.name
-																					} details in order to add ${steps[0].data.toLowerCase()} to catalog`,
-																					data: stage.fields,
-																				},
+                                                                            [
+                                                                                ...steps,
+                                                                                stage.name ===
+                                                                                'CSV'
+                                                                                    ? {
+                                                                                          id: `${kv[0]}.${stage.name}`,
+                                                                                          title: 'Upload Csv',
+                                                                                          description: `To configure the database, set up the necessary connection parameters such as Database name,Description and Tags in the configuration file.
+                                                                                    Ensure proper indexing and security measures are in place for optimal performance and protection.`,
+                                                                                          data: stage.fields,
+                                                                                      }
+                                                                                    : {
+                                                                                          id: `${kv[0]}.${stage.name}`,
+                                                                                          title: stage.name,
+                                                                                          description: `Fill out  details in order to add  to catalog`,
+                                                                                          data: stage.fields,
+                                                                                      },
 																			],
 																			steps.length +
 																				1,

--- a/packages/client/src/pages/import/import.constants.ts
+++ b/packages/client/src/pages/import/import.constants.ts
@@ -9093,22 +9093,29 @@ export const CONNECTION_OPTIONS = {
 			},
 			{
 				name: "CSV",
-				disable: true,
+				disable: false,
 				icon: CSV,
 				fields: [
-					// baseUpload
-					// PredictDataTypes
-					{
-						fieldName: "ZIP",
-						label: "Zip File",
-						defaultValue: null,
-						options: {
-							component: "file-upload",
-						},
-						disabled: true,
-						rules: { required: true },
-					},
-				],
+                    {
+                        fieldName: 'CSV',
+                        label: 'CSV File',
+                        defaultValue: null,
+                        options: {
+                            component: 'CSV-file-upload',
+                            accept: '.csv',
+                        },
+                        disabled: false,
+                        rules: {
+                            required: true,
+                            validate: {
+                                isCSV: (file: File) =>
+                                    file && file.name.endsWith('.csv')
+                                        ? true
+                                        : 'Only CSV files are allowed.',
+                            },
+                        },
+                    },
+                ],
 			},
 			{
 				name: "Excel",


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This is to enable the Csv Database file upload in the Add database .

## Changes Made
<!-- List the key changes made in this PR -->

1) Enabled Csv File upload in the Add database page .
2)  Different Description for Csv and for other .

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Navigate to Add database in Database engine .
2. Click on the Csv Tab it will will navigate you to Add Csv Db Page.

## Notes
<!-- Any further notes regarding changes -->

The design has been handled in different Ticket .
This Ticket is only implemented for Csv as instructed by @ppatel9703 .