### PR TITLE
feat(client): Data Variable Section in Button block settings and Set Data Variable Listener Action

### DIFF
--- a/libs/renderer/src/components/block-defaults/button-block/ButtonBlock.tsx
+++ b/libs/renderer/src/components/block-defaults/button-block/ButtonBlock.tsx
@@ -37,6 +37,7 @@ export interface ButtonBlockDef extends BlockDef<"button"> {
 		color: "primary" | "secondary" | "success" | "warning" | "error";
 		show: string;
 		type: "button" | "submit" | "reset";
+		dataVariable?: string;
 	};
 	listeners: {
 		onClick: {
@@ -73,9 +74,19 @@ export const ButtonBlock: BlockComponent = observer(({ id }) => {
 				type={data?.type}
 				sx={{
 					...data.style,
-				}}
-				onClick={() => {
-					listeners.onClick();
+				}}	
+				data-value={data.dataVariable}
+				onClick={(event) => {
+					listeners.onClick((action) => {
+						const value = event.currentTarget?.getAttribute("data-value");
+						return {
+							...action,
+							payload: {
+								...action.payload,
+								value,
+							},
+						};
+					});
 				}}
 			>
 				<StyledLabel loading={data?.loading}>{data.label}</StyledLabel>

--- a/libs/renderer/src/store/state/state.actions.ts
+++ b/libs/renderer/src/store/state/state.actions.ts
@@ -49,6 +49,7 @@ export enum ActionMessages {
 	DISPATCH_OUTPUTS_EVENT = "DISPATCH_OUTPUTS_EVENT",
 	DISPATCH_OPEN_EVENT = "DISPATCH_OPEN_EVENT",
 	RUN_MARKDOWN_CELL = "RUN_MARKDOWN_CELL",
+	SET_DATA_VARIABLE = "SET_DATA_VARIABLE",
 }
 
 export type Actions =
@@ -78,7 +79,8 @@ export type Actions =
 	| RenameVariableAction
 	| EditVariableAction
 	| DeleteVariableAction
-	| SetSheetExecutionOrderAction;
+	| SetSheetExecutionOrderAction
+	| SetDataVariableAction;
 
 
 /**
@@ -340,6 +342,7 @@ export interface RunQueryAction extends Action {
 	message: ActionMessages.RUN_QUERY;
 	payload: {
 		queryId: string;
+		value:string; 
 	};
 }
 
@@ -358,4 +361,12 @@ export interface RunMarkdownCellAction extends Action {
 		cellId: string;
 		marked: boolean;
 	};
+}
+
+export interface SetDataVariableAction extends Action {
+    message: ActionMessages.SET_DATA_VARIABLE;
+    payload: {
+        id: string; 				
+    	value: string;           
+	}
 }

--- a/libs/renderer/src/store/state/state.actions.ts
+++ b/libs/renderer/src/store/state/state.actions.ts
@@ -342,7 +342,6 @@ export interface RunQueryAction extends Action {
 	message: ActionMessages.RUN_QUERY;
 	payload: {
 		queryId: string;
-		value:string; 
 	};
 }
 

--- a/libs/renderer/src/store/state/state.constants.ts
+++ b/libs/renderer/src/store/state/state.constants.ts
@@ -37,4 +37,5 @@ export const ACTIONS_DISPLAY = {
 	[ActionMessages.DISPATCH_EVENT]: "Dispatch Event",
 	[ActionMessages.DISPATCH_OUTPUTS_EVENT]: "Dispatch App Outputs",
 	[ActionMessages.DISPATCH_OPEN_EVENT]: "Navigate",
+	[ActionMessages.SET_DATA_VARIABLE]: "Set Data Variable",
 };

--- a/libs/renderer/src/store/state/state.store.ts
+++ b/libs/renderer/src/store/state/state.store.ts
@@ -518,7 +518,7 @@ export class StateStore {
 			 * --------------------------------------------------
 			 */
 			else if (ActionMessages.RUN_QUERY === action.message) {
-				const { queryId } = action.payload;
+				const { queryId, value } = action.payload;
 
 				return this.runQuery(queryId);
 			} else if (ActionMessages.RUN_CELL === action.message) {
@@ -541,7 +541,20 @@ export class StateStore {
 				const { destinationType, destination } = action.payload;
 
 				this.dispatchOpenEvent(destinationType, destination);
-			}
+			}else if (
+				ActionMessages.SET_DATA_VARIABLE === action.message
+			) {
+				const { id, value } = action.payload;
+				const from = this.variables[id];
+				if (from) {
+					const to = {
+						...from,
+						value,
+					};
+					this.editVariable(id, from, to);
+				}
+				
+    		}
 		} catch (e) {
 			console.error(e);
 		}
@@ -555,7 +568,7 @@ export class StateStore {
 	dispatchEventAction = async (action: Actions, type: "sync" | "async") => {
 		try {
 			if (ActionMessages.RUN_QUERY === action.message) {
-				const { queryId } = action.payload;
+				const { queryId,value } = action.payload;
 
 				const run = () =>
 					new Promise(async (resolve) => {
@@ -588,7 +601,20 @@ export class StateStore {
 				const { destinationType, destination } = action.payload;
 
 				this.dispatchOpenEvent(destinationType, destination);
-			}
+			}else if (
+				ActionMessages.SET_DATA_VARIABLE === action.message
+			) {
+				const { id, value} = action.payload;
+				const from = this.variables[id];
+				if (from) {
+					const to = {
+						...from,
+						value,
+					};
+					this.editVariable(id, from, to);
+				}
+				
+    		}
 		} catch (e) {
 			console.error(e);
 		}

--- a/libs/renderer/src/store/state/state.store.ts
+++ b/libs/renderer/src/store/state/state.store.ts
@@ -518,7 +518,7 @@ export class StateStore {
 			 * --------------------------------------------------
 			 */
 			else if (ActionMessages.RUN_QUERY === action.message) {
-				const { queryId, value } = action.payload;
+				const { queryId } = action.payload;
 
 				return this.runQuery(queryId);
 			} else if (ActionMessages.RUN_CELL === action.message) {
@@ -568,7 +568,7 @@ export class StateStore {
 	dispatchEventAction = async (action: Actions, type: "sync" | "async") => {
 		try {
 			if (ActionMessages.RUN_QUERY === action.message) {
-				const { queryId,value } = action.payload;
+				const { queryId } = action.payload;
 
 				const run = () =>
 					new Promise(async (resolve) => {

--- a/libs/renderer/src/store/state/state.types.ts
+++ b/libs/renderer/src/store/state/state.types.ts
@@ -7,6 +7,7 @@ import type {
 	DispatchOutputsEventAction,
 	RunCellAction,
 	RunQueryAction,
+	SetDataVariableAction,
 } from "./state.actions";
 
 export type SerializedState = {
@@ -262,7 +263,8 @@ export type ListenerActions =
 	| DispatchEventAction
 	| DispatchOutputsEventAction
 	| RunCellAction
-	| DispatchOpenEventAction;
+	| DispatchOpenEventAction
+	| SetDataVariableAction;
 
 /**
  * Cell Definition

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/button-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/button-block/config.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from "react";
 import {
 	InputSettings,
 	QuerySelectionSettings,
+	QueryInputSettings,
 	SelectInputSettings,
 } from "../../settings";
 import { BLOCK_TYPE_ACTION } from "../block-defaults.constants";
@@ -65,6 +66,17 @@ export const config: BlockSettingsConfig = {
 					),
 				},
 			],
+		},
+		{
+			name: "Data Variable",
+			children: [
+				   {
+					   description: "Data Variable",
+					   render: ({ id }) => (
+						   <QueryInputSettings id={id} label="Data Variable" path="dataVariable" />
+					   ),
+				   },
+			   ],
 		},
 		{
 			name: "Conditional",

--- a/packages/client/src/components/blocks-workspace/blocks/settings/ListenerActionOverlay.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/settings/ListenerActionOverlay.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import {
 	ActionMessages,
+	useBlocks,
 	type BlockDef,
 	type ListenerActions,
 } from "@semoss/renderer";
@@ -34,6 +35,7 @@ export const ListenerActionOverlay = observer(
 	<D extends BlockDef = BlockDef>(props: ActionOverlayProps<D>) => {
 		const { id, type, listener, actionIdx = -1, onClose } = props;
 		const { listeners, setListener } = useBlockSettings(id);
+		const { state } = useBlocks();
 
 		const isNewAction = actionIdx === -1;
 		const existingAction =
@@ -115,6 +117,7 @@ export const ListenerActionOverlay = observer(
 							queryId={queryId}
 							destinationType={destinationType}
 							pages={pages}
+							variables={state.variables}
 						/>
 					</Stack>
 				</Modal.Content>

--- a/packages/client/src/components/blocks-workspace/blocks/settings/ListenerSettings.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/settings/ListenerSettings.tsx
@@ -246,6 +246,8 @@ export const ListenerSettings = observer(
 				} else if (item.payload["destinationType"]) {
 					if (item.payload["destination"])
 						display = item.payload["destination"];
+				} else if (item.message === "SET_DATA_VARIABLE" && item.payload["id"]) {
+						display = item.payload["id"];
 				} else {
 					if (item.payload["name"]) {
 						display = item.payload["name"];

--- a/packages/client/src/components/blocks-workspace/blocks/settings/block-events/ActionFormFields.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/settings/block-events/ActionFormFields.tsx
@@ -3,6 +3,7 @@ import { BlockEventNameSelector } from "./BlockEventNameSelector";
 import { CellIdSelector } from "./CellIdSelector";
 import { QueryIdSelector } from "./QueryIdSelector";
 import { RedirectDestinationSelector } from "./RedirectDestinationSelector";
+import { VariableIdSelector } from "./VariableIdSelector";
 
 interface ActionFormFieldsProps {
 	message: ActionMessages;
@@ -13,6 +14,7 @@ interface ActionFormFieldsProps {
 	queryId: string;
 	destinationType: string;
 	pages: any[];
+	variables: any;
 }
 
 export const ActionFormFields = ({
@@ -24,7 +26,8 @@ export const ActionFormFields = ({
 	queryId,
 	destinationType,
 	pages,
-}: ActionFormFieldsProps) => {
+	variables,
+	}: ActionFormFieldsProps) => {
 	const renderFields = () => {
 		switch (message) {
 			case ActionMessages.RUN_QUERY:
@@ -61,6 +64,13 @@ export const ActionFormFields = ({
 
 			case ActionMessages.DISPATCH_OUTPUTS_EVENT:
 				return null;
+
+			case ActionMessages.SET_DATA_VARIABLE:
+				return (
+					<>
+						<VariableIdSelector control={control} variables={variables || []} />
+					</>
+				);
 
 			default:
 				return null;

--- a/packages/client/src/components/blocks-workspace/blocks/settings/block-events/ActionTypeSelector.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/settings/block-events/ActionTypeSelector.tsx
@@ -34,6 +34,7 @@ export const ActionTypeSelector = ({
 						ActionMessages.DISPATCH_EVENT,
 						ActionMessages.DISPATCH_OUTPUTS_EVENT,
 						ActionMessages.DISPATCH_OPEN_EVENT,
+						ActionMessages.SET_DATA_VARIABLE
 					].map((action, index) => (
 						<Select.Item key={index} value={action}>
 							{ACTIONS_DISPLAY[action]}

--- a/packages/client/src/components/blocks-workspace/blocks/settings/block-events/VariableIdSelector.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/settings/block-events/VariableIdSelector.tsx
@@ -1,0 +1,41 @@
+import { Controller } from "react-hook-form";
+import { Select } from "@semoss/ui";
+import { toJS } from "mobx";
+
+interface VariableIdSelectorProps {
+    control: any;
+    variables: any[];
+    label?: string;
+}
+
+export const VariableIdSelector = ({
+    control,
+    variables,
+    label = "Variable",
+}: VariableIdSelectorProps) => {
+    console.log('VariableIdSelector variables:', variables);
+    let variableEntries = [];
+    if (Array.isArray(variables)) {
+        variableEntries = variables.map((v, idx) => [v.id || v.name || idx, v]);
+    } else if (variables && typeof variables === 'object') {
+        variableEntries = Object.entries(variables);
+    }
+    return (
+        <Controller
+            name="payload.id"
+            control={control}
+            render={({ field }) => (
+                <Select
+                    label={label}
+                    value={field.value || ""}
+                    onChange={field.onChange}
+                >
+                    {variableEntries.map(([key, variable]) => (
+                        <Select.Item key={key} value={key}>
+                            {key}
+                        </Select.Item>
+                    ))}
+                </Select>
+            )}
+        />
+    )};

--- a/packages/client/src/components/blocks-workspace/blocks/settings/block-events/utils.ts
+++ b/packages/client/src/components/blocks-workspace/blocks/settings/block-events/utils.ts
@@ -24,6 +24,10 @@ export const getDefaultFormValues = (
 			message: ActionMessages.DISPATCH_OPEN_EVENT,
 			payload: { destinationType: "", destination: "" },
 		},
+		[ActionMessages.SET_DATA_VARIABLE]: {
+			message: ActionMessages.SET_DATA_VARIABLE,
+			payload: { id: ""},
+		},
 	};
 
 	return formConfigs[message] || formConfigs[ActionMessages.RUN_QUERY];
@@ -44,6 +48,8 @@ export const validateForm = (
 			return !!payload.destinationType && !!payload.destination;
 		case ActionMessages.DISPATCH_OUTPUTS_EVENT:
 			return true;
+		case ActionMessages.SET_DATA_VARIABLE:
+			return !!payload.id;
 		default:
 			return false;
 	}


### PR DESCRIPTION
## Description
1. Created a Data Variable section in button block settings that have a placeholder to add responses of notebook, cell, variable or normal string and sets it as Data Variable for that button block
2. Added SET_DATA_VARIABLE listener action. It asks to select an existing variable and sets the value of data variable of the current block to the selected variable.

## How to Test
1. Data Variable 
    
<img width="512" height="802" alt="image" src="https://github.com/user-attachments/assets/9e294905-d90d-404f-84c1-1248299e6b6f" />

2. Set Data Variable

<img width="1919" height="881" alt="image" src="https://github.com/user-attachments/assets/2795231a-f994-45fe-8854-89c1aad122a1" />

