### PR TITLE
feat(client): fixed pinning the sidebar event

### DIFF
--- a/packages/client/src/components/shared/NavbarHeader.tsx
+++ b/packages/client/src/components/shared/NavbarHeader.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 import { IconButton, Stack, styled, Typography } from "@semoss/ui";
 import { usePage, useRootStore } from "@/hooks";
 
-const StyledNavbarHeader = styled(Stack)(({ theme }) => ({
+const StyledNavbarHeader = styled(Stack)(() => ({
 	position: "relative",
 	background: "transparent",
 	zIndex: 0,
@@ -24,7 +24,7 @@ const StyledNavbarHeaderLink = styled(Link)(({ theme }) => ({
 	},
 }));
 
-const StyledIconButton = styled(IconButton)(({ theme }) => ({
+const StyledIconButton = styled(IconButton)(() => ({
 	borderRadius: "7.5px",
 	border: "0.938px solid #323232",
 }));
@@ -47,17 +47,14 @@ export const NavbarHeader = observer((props: NavbarHeaderProps) => {
 			justifyContent={"flex-start"}
 			spacing={2}
 		>
-			<StyledIconButton
-				size="small"
-				onMouseOver={() => page.openSidebar()}
-			>
+			<StyledIconButton size="small" onClick={() => page.openSidebar()}>
 				<MenuRounded fontSize="medium" />
 			</StyledIconButton>
 
 			{!logo ? (
 				<StyledNavbarHeaderLink to={"/"} aria-label={"Go Home"}>
 					{configStore.theme.logo ? (
-						<img src={configStore.theme.logo} />
+						<img src={configStore.theme.logo} alt="home" />
 					) : null}
 					<Typography variant="h6" sx={{ fontWeight: 700 }}>
 						{configStore.theme.name}

--- a/packages/client/src/components/shared/Sidebar.tsx
+++ b/packages/client/src/components/shared/Sidebar.tsx
@@ -89,13 +89,13 @@ const StyledSidebar = styled(Drawer)(() => ({
 	],
 }));
 
-const StyledSidebarContent = styled(Stack)(({ theme }) => ({
+const StyledSidebarContent = styled(Stack)(() => ({
 	flexDirection: "column",
 	width: "100%",
 	overflowY: "auto",
 }));
 
-const StyledSidebarFooter = styled(Stack)(({ theme }) => ({
+const StyledSidebarFooter = styled(Stack)(() => ({
 	overflowY: "hidden",
 }));
 
@@ -128,7 +128,7 @@ const StyledLink = styled(Link)(({ theme }) => ({
 	padding: theme.spacing(0.5, 0),
 }));
 
-const StyledSettingsArea = styled(Stack)(({ theme }) => ({
+const StyledSettingsArea = styled(Stack)(() => ({
 	flexDirection: "column",
 	width: "100%",
 	overflowY: "auto",
@@ -179,15 +179,6 @@ export const Sidebar: React.FC = observer(() => {
 			anchor="left"
 			open={page.sidebar.open}
 			onClose={closeSidebar}
-			PaperProps={{
-				onMouseLeave: () => {
-					// closes if it is not pinned
-					if (page.sidebar.pinned) {
-						return;
-					}
-					closeSidebar();
-				},
-			}}
 		>
 			<StyledNavHeader
 				direction={"row"}
@@ -215,6 +206,7 @@ export const Sidebar: React.FC = observer(() => {
 						<StyledListItemButton
 							selected={!!matchPath("/", pathname)}
 							dense={true}
+							onClick={closeSidebar}
 						>
 							<StyledListItemIcon>
 								<HomeIcon />
@@ -252,6 +244,7 @@ export const Sidebar: React.FC = observer(() => {
 										}
 										aria-label={r.text}
 										dense={true}
+										onClick={closeSidebar}
 									>
 										<StyledListItemIcon>
 											{r.icon}
@@ -273,6 +266,7 @@ export const Sidebar: React.FC = observer(() => {
 						<StyledListItemButton
 							selected={!!matchPath(`/settings/*`, pathname)}
 							dense={true}
+							onClick={closeSidebar}
 						>
 							<StyledListItemIcon>
 								<SettingsIcon />


### PR DESCRIPTION
## Description
Changed the sidebar open close behavior from **onHover and mouseLeave** to **onClick**. 

## Changes Made

- Open > replaced onHover event with onClick event
- Close > Removed onMouseLeave event and added onClick close for all list items present in the sidebar.
- Some additional biome fixes 

## How to Test

1. Sidebar should not open on hovering the top left burger icon anymore.
2. It should open on click of the burger icon.
3. The side bar will not close on mouse leave event.
4. It will close only if you
> Click on close icon
> - Click outside of sidebar
> - Click on any catalog item

## Notes
DEMO : https://github.com/SEMOSS/semoss-ui/issues/1719#issuecomment-3205795178