### PR TITLE
fix(renderer): slow build in libs/render

### DIFF
--- a/libs/renderer/src/hooks/useBlock.tsx
+++ b/libs/renderer/src/hooks/useBlock.tsx
@@ -43,7 +43,7 @@ interface useBlockReturn<D extends BlockDef = BlockDef> {
 	 * @param path - path of the data to set
 	 * @param value - value of the data to set
 	 */
-	setData: <P extends Paths<Block<D>["data"], 4>>(
+	setData: <P extends Paths<Block<D>["data"]>>(
 		path: P,
 		value: PathValue<D["data"], P>,
 		tempOverrideMode?: boolean,
@@ -53,7 +53,7 @@ interface useBlockReturn<D extends BlockDef = BlockDef> {
 	 * Dispatch a message to delete data
 	 * @param path - path of the data to delete
 	 */
-	deleteData: <P extends Paths<Block<D>["data"], 4>>(path: P) => void;
+	deleteData: <P extends Paths<Block<D>["data"]>>(path: P) => void;
 
 	/**
 	 * Upload a file to the insight
@@ -91,7 +91,7 @@ export const useBlock = <D extends BlockDef = BlockDef>(
 	 * @param value - value of the data to set
 	 */
 	const setData = useCallback(
-		<P extends Paths<Block<D>["data"], 4>>(
+		<P extends Paths<Block<D>["data"]>>(
 			path: P | null,
 			value: PathValue<Block<D>["data"], P>,
 			// TODO: will remove this; needed to update LLM blocks for now.
@@ -119,7 +119,7 @@ export const useBlock = <D extends BlockDef = BlockDef>(
 	 * @param path - path of the data to delete
 	 */
 	const deleteData = useCallback(
-		<P extends Paths<Block<D>["data"], 4>>(path: P | null): void => {
+		<P extends Paths<Block<D>["data"]>>(path: P | null): void => {
 			// ignore if static
 			if (state.mode === "static") {
 				return;

--- a/libs/renderer/src/types/types.d.ts
+++ b/libs/renderer/src/types/types.d.ts
@@ -8,7 +8,7 @@ export type Role =
 
 export interface PixelCommand {
 	type: string;
-	components: any[];
+	components: unknown[];
 	terminal?: boolean;
 	meta?: boolean;
 }
@@ -68,15 +68,72 @@ export type Prev = [
 	...0[],
 ];
 
-export type Paths<T, D extends number = 10> = [D] extends [never]
-	? never
-	: T extends object
+// ---------- helpers ----------
+type Keys<T> = Extract<keyof T, string | number>;
+type KeyStr<K> = K extends string | number ? `${K}` : never;
+type ChildKeys<T> = KeyStr<keyof T>;
+
+type IsObject<T> = T extends object ? true : false;
+
+// ---------- level builders ----------
+type L1<T> = KeyStr<Keys<T>>;
+
+type L2<T> = {
+	[K1 in Keys<T>]: IsObject<T[K1]> extends true
+		? `${KeyStr<K1>}.${ChildKeys<T[K1]>}`
+		: never;
+}[Keys<T>];
+
+type L3<T> = {
+	[K1 in Keys<T>]: IsObject<T[K1]> extends true
 		? {
-				[K in keyof T]-?: K extends string | number
-					? `${K}` | Join<K, Paths<T[K], Prev[D]>>
+				[K2 in Keys<T[K1]>]: IsObject<T[K1][K2]> extends true
+					? `${KeyStr<K1>}.${KeyStr<K2>}.${ChildKeys<T[K1][K2]>}`
 					: never;
-			}[keyof T]
-		: "";
+			}[Keys<T[K1]>]
+		: never;
+}[Keys<T>];
+
+type L4<T> = {
+	[K1 in Keys<T>]: IsObject<T[K1]> extends true
+		? {
+				[K2 in Keys<T[K1]>]: IsObject<T[K1][K2]> extends true
+					? {
+							[K3 in Keys<T[K1][K2]>]: IsObject<
+								T[K1][K2][K3]
+							> extends true
+								? `${KeyStr<K1>}.${KeyStr<K2>}.${KeyStr<K3>}.${ChildKeys<T[K1][K2][K3]>}`
+								: never;
+						}[Keys<T[K1][K2]>]
+					: never;
+			}[Keys<T[K1]>]
+		: never;
+}[Keys<T>];
+
+type L5<T> = {
+	[K1 in Keys<T>]: IsObject<T[K1]> extends true
+		? {
+				[K2 in Keys<T[K1]>]: IsObject<T[K1][K2]> extends true
+					? {
+							[K3 in Keys<T[K1][K2]>]: IsObject<
+								T[K1][K2][K3]
+							> extends true
+								? {
+										[K4 in Keys<T[K1][K2][K3]>]: IsObject<
+											T[K1][K2][K3][K4]
+										> extends true
+											? `${KeyStr<K1>}.${KeyStr<K2>}.${KeyStr<K3>}.${KeyStr<K4>}.${ChildKeys<T[K1][K2][K3][K4]>}`
+											: never;
+									}[Keys<T[K1][K2][K3]>]
+								: never;
+						}[Keys<T[K1][K2]>]
+					: never;
+			}[Keys<T[K1]>]
+		: never;
+}[Keys<T>];
+
+// ---------- exported ----------
+export type Paths<T> = L1<T> | L2<T> | L3<T> | L4<T> | L5<T>;
 
 export type PathValue<
 	T,


### PR DESCRIPTION
## Description
Optimized **Path** and **PathValue** type definitions in **types.d.ts** to reduce TypeScript type-checking time while preserving type safety.

## Changes Made

- Investigated slow type-checking performance using **--generateTrace** and Chrome DevTools.
- Identified recursive **Path** and **PathValue** types as a major contributor to delays.
- Optimized **types.d.ts** by replacing the recursive implementation of Paths with a **level-based approach (L1–L5)** that generates valid key paths up to 5 levels deep.
- This improved type-checking time from **233s → ~18s** while still maintaining type safety.

## How to Test
<!-- Explain how reviewers can test your changes -->

1. Run **npx tsc --extendedDiagnostics** from the **libs/renderer** package to verify type-checking performance and see where the compiler spends time.
2. Run **pnpm run build** from the root folder to check overall build time.

<img width="494" height="460" alt="image" src="https://github.com/user-attachments/assets/6a490355-3446-498a-9035-d23cdd5a5378" />

