### PR TITLE
build(importform): run validate on blur event for catelog name

### DIFF
--- a/packages/client/src/components/import/ImportForm.tsx
+++ b/packages/client/src/components/import/ImportForm.tsx
@@ -99,6 +99,7 @@ export const ImportForm = (props) => {
 		setValue,
 		getValues,
 		setError,
+		trigger,
 		formState: { isValid },
 	} = useForm({
 		mode: "onSubmit",
@@ -111,6 +112,7 @@ export const ImportForm = (props) => {
 		lastFocussedField: "",
 		lastFocussedValue: "",
 		lastValidatedValue: "",
+		runValidate: false,
 	});
 
 	/** Used to Trigger useEffect anytime these vals change */
@@ -743,10 +745,9 @@ export const ImportForm = (props) => {
 															fieldVal,
 														) => {
 															if (
-																_lastField
+																!_lastField
 																	.current
-																	.lastValidatedValue ===
-																fieldVal
+																	.runValidate
 															)
 																return true;
 
@@ -756,7 +757,8 @@ export const ImportForm = (props) => {
 																	_lastField
 																		.current
 																		.lastFocussedField ===
-																	val.fieldName
+																	val.fieldName &&
+																	_lastField.current.lastValidatedValue !== fieldVal
 																) {
 																	validStatus =
 																		validateFormField(
@@ -766,8 +768,7 @@ export const ImportForm = (props) => {
 																}
 																return validStatus;
 															} finally {
-																_lastField.current.lastValidatedValue =
-																	fieldVal;
+																_lastField.current.runValidate = false;
 															}
 														},
 													}
@@ -851,8 +852,15 @@ export const ImportForm = (props) => {
 																		val.fieldName,
 																	lastFocussedValue:
 																		field.value,
+																	lastValidatedValue: field.value
 																};
 														},
+														onBlur: () => {
+															if(val.rules?.custom){
+																_lastField.current.runValidate = true;
+																trigger(val.fieldName);
+															} 
+														}
 													}}
 													{...field}
 												></TextField>


### PR DESCRIPTION
## Description
Updating catelog name checks to be done at on blur from the catelog name field and not on other fields/other fields on blur event.

## Changes Made
Checked for last updated value and last focused field to ensure that when catelog name is changed and after the onBlur event is completed, then api call will trigger

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Click on any tile under connections other than zip upload
2. Add the catelog name and check if api call is happening while typing.
3. In other fields, while typing check if any other API call is happening or not.
4. Or in case of onBlur event in any fields other than Catelog name is happening or not

## Notes
<!-- Any further notes regarding changes -->