### PR TITLE
Removed eye icon since the functionality is not there

### DIFF
--- a/packages/client/src/components/app/BrowseTempateTitleCard.tsx
+++ b/packages/client/src/components/app/BrowseTempateTitleCard.tsx
@@ -296,13 +296,13 @@ export const BrowseTemplateTileCard = (props: BrowseTemplateTileCardProps) => {
 	return (
 		<StyledMainDiv>
 			<StyledTileCard disabled>
-				<StyledContainer>
+				{/* <StyledContainer>
 					<StyledOverlayContent>
 						<StyledIconButton size="small" color="default">
 							<img src={RemoveRedEyeFilled}></img>
 						</StyledIconButton>
 					</StyledOverlayContent>
-				</StyledContainer>
+				</StyledContainer> */}
 				<Link
 					href={href}
 					rel="noopener noreferrer"


### PR DESCRIPTION
## Description
This PR ensures the eye icon has been removed since the functionality is not there.

## Changes Made
- Removed the eye icon from the browse templates since the functionality is not there.
- Just commented the code as of now, can be uncommented when functionality is there.

## Before
<img width="684" height="415" alt="image" src="https://github.com/user-attachments/assets/556ed44c-ee8f-4a4e-b0cd-193f24a4fdb6" />

## After 
<img width="707" height="580" alt="image" src="https://github.com/user-attachments/assets/1f945ea0-6585-4564-b6b3-6e0fb33c426f" />


## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->