### PR TITLE
Fixed filter selection issue in search functionality

### DIFF
--- a/packages/client/src/components/shared/Search.tsx
+++ b/packages/client/src/components/shared/Search.tsx
@@ -253,11 +253,24 @@ export const Search = observer(({ renderInput }: SearchProps) => {
 	};
 
 	const handleCategoryToggle = (category) => {
-		setSelectedCategories((prev) =>
-			prev.some((c) => c.name === category.name)
-				? prev.filter((c) => c.name !== category.name)
-				: [...prev, category],
-		);
+		setSelectedCategories((prev) => {
+			// If selecting "All", deselect everything else
+			if (category.name === "All") {
+				return [{ name: "All", type: "" }];
+			}
+			// If "All" is already selected, remove it and add the new category
+			if (prev.some((c) => c.name === "All")) {
+				return [category];
+			}
+			// Toggle the category
+			if (prev.some((c) => c.name === category.name)) {
+				// Remove the category
+				return prev.filter((c) => c.name !== category.name);
+			} else {
+				// Add the category
+				return [...prev, category];
+			}
+		}); 
 	};
 
 	const limitOptionsPerGroup = (options, maxPerGroup = 3) => {


### PR DESCRIPTION
## Description
In this PR, I have fixed the issue related to filter selection in search functionality. before, both the "All" filter and the newly selected filter remain active which is not expected behavior.

## Changes Made
-  I have refactor the handle logic of toggling between categories.
- "All" is never selected with any other category.
- Selecting any other category removes "All".
- Selecting "All" removes all other categories. 

<img width="532" height="348" alt="image" src="https://github.com/user-attachments/assets/0ff365c8-8183-49fd-9d59-97dfea9e2da1" />

<img width="589" height="489" alt="image" src="https://github.com/user-attachments/assets/1b76a570-ce0f-4076-83d3-33b65092a56a" />


## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->