### PR TITLE
bug(client): label name changed

### DIFF
--- a/packages/client/src/pages/engine/engine.constants.ts
+++ b/packages/client/src/pages/engine/engine.constants.ts
@@ -8,14 +8,14 @@ import { ModelBrain } from "@/assets/img/ModelBrain";
 import type { ENGINE_TYPES, Role } from "@/types";
 import { EngineFilePage } from "./EngineFilePage";
 import { EngineMetadataPage } from "./EngineMetadataPage";
+import { EngineModelChatPage } from "./EngineModelChatPage";
 import { EngineOverviewPage } from "./EngineOverviewPage";
 import { EngineQAPage } from "./EngineQAPage";
 import { EngineSettingsPage } from "./EngineSettingsPage";
+import { EngineSmssPage } from "./EngineSmssPage";
 // import { EngineQueryDataPage } from './EngineQueryDataPage';
 // import { EngineReplaceDataPage } from './EngineReplaceDataPage';
-import { EngineUsagePage } from './EngineUsagePage';
-import { EngineSmssPage } from './EngineSmssPage';
-import { EngineModelChatPage } from './EngineModelChatPage';
+import { EngineUsagePage } from "./EngineUsagePage";
 
 export const ENGINE_ROUTES: {
 	/** Name of the route */
@@ -97,11 +97,11 @@ export const ENGINE_ROUTES: {
 				restrict: false,
 			},
 			{
-                name: 'Chat',
-                path: 'chat',
-                component: EngineModelChatPage,
-                restrict: ['EDIT', 'OWNER', 'READ_ONLY'],
-            },
+				name: "Chat",
+				path: "chat",
+				component: EngineModelChatPage,
+				restrict: ["EDIT", "OWNER", "READ_ONLY"],
+			},
 			{
 				name: "Usage",
 				path: "usage",
@@ -241,8 +241,8 @@ export const ENGINE_ROUTES: {
 				restrict: ["EDIT", "OWNER", "READ_ONLY"],
 			},
 			{
-				name: "Settings",
-				path: "settings",
+				name: "Access Control",
+				path: "access-control",
 				component: EngineSettingsPage,
 				restrict: ["EDIT", "OWNER"],
 			},


### PR DESCRIPTION
## Description
Settings Tab in Storage Catalog Should Be Access Control

## Changes Made

- Changed the Label from "Settings" to "Access Control"
- Updated the path 

## How to Test

1. Navigate to Storage Catalog
2. Create a new storage entry in the storage catalog.
3. Navigate to the created storage.
4. Observe that the tab is label changed from "Settings" to "Access Control".
