### PR TITLE
Fixed to show same template app cards

### DIFF
--- a/packages/client/src/pages/app/CreateAppPage.tsx
+++ b/packages/client/src/pages/app/CreateAppPage.tsx
@@ -133,7 +133,11 @@ export const CreateAppPage = () => {
 							Start build with a template
 						</Typography>
 						<AppTemplates
-							randomCount={6}
+							/**
+							 * just commented this out for now,
+							 * to show all templates app cards, could be useful later
+							 */
+							// randomCount={6}
 							onUse={(t) => {
 								setNewAppOptions({
 									type: "blocks",


### PR DESCRIPTION
## Description
In this PR, i have fixed the issue related to same app cards not showing while exploring them through homepage and create new app section.

## Changes Made
- As of now i just commented the randomCount prop to AppTemplates to show same app cards.

<img width="501" height="244" alt="image" src="https://github.com/user-attachments/assets/53273fa6-dec6-40d1-86c5-4147569506c1" />


<img width="884" height="576" alt="image" src="https://github.com/user-attachments/assets/f7e0af58-941a-4153-8ed2-3936147f150c" />

<img width="889" height="547" alt="image" src="https://github.com/user-attachments/assets/29a74616-147c-4184-bf8f-75871ded9c31" />


## How to Test
<!-- Explain how reviewers can test your changes -->
- Go to Apps > Create New App > Scroll down to see same app cards

## Notes
<!-- Any further notes regarding changes -->