### PR TITLE
fix(client): render delete text dynamically

### DIFF
--- a/packages/client/src/components/settings/SettingsTiles.tsx
+++ b/packages/client/src/components/settings/SettingsTiles.tsx
@@ -3,18 +3,18 @@ import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import type { AxiosResponse } from "axios";
 import { useEffect, useState } from "react";
 import {
-  Alert,
-  Box,
-  Button,
-  Grid,
-  Modal,
-  Paper,
-  Stack,
-  Switch,
-  styled,
-  Tooltip,
-  Typography,
-  useNotification,
+	Alert,
+	Box,
+	Button,
+	Grid,
+	Modal,
+	Paper,
+	Stack,
+	Switch,
+	styled,
+	Tooltip,
+	Typography,
+	useNotification,
 } from "@semoss/ui";
 import databaseIcon from "@/assets/img/databaseIcon.png";
 import { LoadingScreen } from "@/components/ui";
@@ -23,526 +23,559 @@ import type { ALL_TYPES } from "@/types";
 import { formatToDataTestId } from "@/utility";
 
 const StyledAlert = styled(Alert, {
-  shouldForwardProp: (prop) => prop !== "setBounds",
+	shouldForwardProp: (prop) => prop !== "setBounds",
 })<{ setBounds?: boolean }>(({ theme, setBounds }) => ({
-  width: "100%",
-  height: "100%",
-  display: "flex",
-  padding: "16px",
-  alignItems: "flex-start",
-  gap: "16px",
-  flex: "1 0 0",
-  alignSelf: "stretch",
-  borderRadius: "12px",
-  color: theme.palette.text.primary,
-  background: theme.palette.background.paper,
-  border: `1px solid ${theme.palette.secondary.main}`,
-  ".MuiAlert-action": {
-    paddingRight: "8px",
-  },
-  ...(setBounds && {
-    height: theme.spacing(13),
-    width: "600px",
-  }),
+	width: "100%",
+	height: "100%",
+	display: "flex",
+	padding: "16px",
+	alignItems: "flex-start",
+	gap: "16px",
+	flex: "1 0 0",
+	alignSelf: "stretch",
+	borderRadius: "12px",
+	color: theme.palette.text.primary,
+	background: theme.palette.background.paper,
+	border: `1px solid ${theme.palette.secondary.main}`,
+	".MuiAlert-action": {
+		paddingRight: "8px",
+	},
+	...(setBounds && {
+		height: theme.spacing(13),
+		width: "600px",
+	}),
 }));
 
 const StyledGrid = styled(Grid)(() => ({
-  flex: "1",
+	flex: "1",
 }));
 
 const StyledWidth = () => ({
-  width: "100%",
+	width: "100%",
 });
 
 const StyledBlock = styled(Box)({
-  display: "flex",
-  alignItems: "flex-start",
-  gap: "8px",
+	display: "flex",
+	alignItems: "flex-start",
+	gap: "8px",
 });
 
 const StyledIcon = styled("span")(({ theme }) => ({
-  color: theme.palette.secondary.dark,
-  width: "20px",
-  height: "20px",
-  "& svg": {
-    fontSize: theme.typography.pxToRem(16),
-    width: "20px",
-    height: "20px",
-  },
+	color: theme.palette.secondary.dark,
+	width: "20px",
+	height: "20px",
+	"& svg": {
+		fontSize: theme.typography.pxToRem(16),
+		width: "20px",
+		height: "20px",
+	},
 }));
 
 interface SettingsTilesProps {
-  /**
-   * Type of setting
-   */
-  type: ALL_TYPES;
+	/**
+	 * Type of setting
+	 */
+	type: ALL_TYPES;
 
-  /**
-   * Id of the setting
-   */
-  id: string;
+	/**
+	 * Id of the setting
+	 */
+	id: string;
 
-  /**
-   * Name of the setting
-   */
-  name: string;
+	/**
+	 * Name of the setting
+	 */
+	name: string;
 
-  /**
-   * Callback that is fired on delete
-   * @returns
-   */
-  onDelete?: () => void;
+	/**
+	 * Callback that is fired on delete
+	 * @returns
+	 */
+	onDelete?: () => void;
 
-  /**
-   * Condensed View
-   */
-  condensed?: boolean;
+	/**
+	 * Condensed View
+	 */
+	condensed?: boolean;
 
-  /**
-   * diection: stack tiles vertically or horizontally
-   */
-  direction?: "column" | "row";
+	/**
+	 * diection: stack tiles vertically or horizontally
+	 */
+	direction?: "column" | "row";
 }
 
 export const SettingsTiles = (props: SettingsTilesProps) => {
-  const { id, type, name, condensed, onDelete, direction = "column" } = props;
+	const { id, type, name, condensed, onDelete, direction = "column" } = props;
 
-  const { monolithStore, configStore } = useRootStore();
-  const notification = useNotification();
-  const { adminMode } = useSettings();
+	const { monolithStore, configStore } = useRootStore();
+	const notification = useNotification();
+	const { adminMode } = useSettings();
 
-  const [deleteModal, setDeleteModal] = useState(false);
-  const [discoverable, setDiscoverable] = useState(true);
-  const [global, setGlobal] = useState(true);
-  const [loading, setLoading] = useState(false);
+	const [deleteModal, setDeleteModal] = useState(false);
+	const [discoverable, setDiscoverable] = useState(true);
+	const [global, setGlobal] = useState(true);
+	const [loading, setLoading] = useState(false);
 
-  const engineInfo = usePixel(
-    type === "DATABASE" ||
-      type === "STORAGE" ||
-      type === "MODEL" ||
-      type === "VECTOR" ||
-      type === "FUNCTION"
-      ? adminMode
-        ? `AdminEngineInfo(engine='${id}');`
-        : `EngineInfo(engine='${id}');`
-      : type === "APP"
-      ? adminMode
-        ? `AdminProjectInfo(project='${id}')`
-        : `ProjectInfo(project='${id}')`
-      : ""
-  );
+	const engineInfo = usePixel(
+		type === "DATABASE" ||
+			type === "STORAGE" ||
+			type === "MODEL" ||
+			type === "VECTOR" ||
+			type === "FUNCTION"
+			? adminMode
+				? `AdminEngineInfo(engine='${id}');`
+				: `EngineInfo(engine='${id}');`
+			: type === "APP"
+				? adminMode
+					? `AdminProjectInfo(project='${id}')`
+					: `ProjectInfo(project='${id}')`
+				: "",
+	);
 
-  useEffect(() => {
-    // pixel call to get pending members
-    if (engineInfo.status !== "SUCCESS" || !engineInfo.data) {
-      return;
-    }
+	useEffect(() => {
+		// pixel call to get pending members
+		if (engineInfo.status !== "SUCCESS" || !engineInfo.data) {
+			return;
+		}
 
-    if (
-      type === "DATABASE" ||
-      type === "STORAGE" ||
-      type === "MODEL" ||
-      type === "VECTOR" ||
-      type === "FUNCTION"
-    ) {
-      const data = engineInfo.data as {
-        database_global: boolean;
-        database_discoverable: boolean;
-      };
+		if (
+			type === "DATABASE" ||
+			type === "STORAGE" ||
+			type === "MODEL" ||
+			type === "VECTOR" ||
+			type === "FUNCTION"
+		) {
+			const data = engineInfo.data as {
+				database_global: boolean;
+				database_discoverable: boolean;
+			};
 
-      setDiscoverable(data.database_discoverable);
-      setGlobal(data.database_global);
-    } else if (type === "APP") {
-      const data = engineInfo.data as {
-        project_global: boolean;
-        project_discoverable: boolean;
-      };
+			setDiscoverable(data.database_discoverable);
+			setGlobal(data.database_global);
+		} else if (type === "APP") {
+			const data = engineInfo.data as {
+				project_global: boolean;
+				project_discoverable: boolean;
+			};
 
-      setDiscoverable(data.project_discoverable);
-      setGlobal(data.project_global);
-    }
-  }, [engineInfo.status, engineInfo.data]);
+			setDiscoverable(data.project_discoverable);
+			setGlobal(data.project_global);
+		}
+	}, [engineInfo.status, engineInfo.data]);
 
-  /**
-   * Delete the item
-   */
-  const deleteWorkflow = async () => {
-    try {
-      // start the loading screen
-      setLoading(true);
+	/**
+	 * Delete the item
+	 */
+	const deleteWorkflow = async () => {
+		try {
+			// start the loading screen
+			setLoading(true);
 
-      // run the pixel
-      const response = await monolithStore.runQuery(
-        type === "DATABASE" ||
-          type === "STORAGE" ||
-          type === "MODEL" ||
-          type === "VECTOR" ||
-          type === "FUNCTION"
-          ? `DeleteEngine(engine=['${id}']);`
-          : type === "APP"
-          ? `DeleteProject(project=['${id}']);`
-          : ""
-      );
+			// run the pixel
+			const response = await monolithStore.runQuery(
+				type === "DATABASE" ||
+					type === "STORAGE" ||
+					type === "MODEL" ||
+					type === "VECTOR" ||
+					type === "FUNCTION"
+					? `DeleteEngine(engine=['${id}']);`
+					: type === "APP"
+						? `DeleteProject(project=['${id}']);`
+						: "",
+			);
 
-      const operationType = response.pixelReturn[0].operationType;
-      const output = response.pixelReturn[0].output;
+			const operationType = response.pixelReturn[0].operationType;
+			const output = response.pixelReturn[0].output;
 
-      if (operationType.indexOf("ERROR") === -1) {
-        notification.add({
-          color: "success",
-          message: `Successfully deleted ${name}`,
-        });
+			if (operationType.indexOf("ERROR") === -1) {
+				notification.add({
+					color: "success",
+					message: `Successfully deleted ${name}`,
+				});
 
-        // go back to page before
-        onDelete();
-      } else {
-        notification.add({
-          color: "error",
-          message: output,
-        });
-      }
-    } catch (e) {
-      notification.add({
-        color: "error",
-        message: String(e),
-      });
-    } finally {
-      // stop the loading screen
-      setLoading(false);
-    }
-  };
+				// go back to page before
+				onDelete();
+			} else {
+				notification.add({
+					color: "error",
+					message: output,
+				});
+			}
+		} catch (e) {
+			notification.add({
+				color: "error",
+				message: String(e),
+			});
+		} finally {
+			// stop the loading screen
+			setLoading(false);
+		}
+	};
 
-  /**
-   * @name changeDiscoverable
-   */
-  const changeDiscoverable = async () => {
-    try {
-      // start the loading screen
-      setLoading(true);
+	/**
+	 * @name changeDiscoverable
+	 */
+	const changeDiscoverable = async () => {
+		try {
+			// start the loading screen
+			setLoading(true);
 
-      let response: AxiosResponse<{ success: boolean }> | null = null;
-      if (
-        type === "DATABASE" ||
-        type === "STORAGE" ||
-        type === "MODEL" ||
-        type === "VECTOR" ||
-        type === "FUNCTION"
-      ) {
-        response = await monolithStore.setEngineVisiblity(
-          adminMode,
-          id,
-          !discoverable
-        );
-      } else if (type === "APP") {
-        response = await monolithStore.setProjectVisiblity(
-          adminMode,
-          id,
-          !discoverable
-        );
-      }
+			let response: AxiosResponse<{ success: boolean }> | null = null;
+			if (
+				type === "DATABASE" ||
+				type === "STORAGE" ||
+				type === "MODEL" ||
+				type === "VECTOR" ||
+				type === "FUNCTION"
+			) {
+				response = await monolithStore.setEngineVisiblity(
+					adminMode,
+					id,
+					!discoverable,
+				);
+			} else if (type === "APP") {
+				response = await monolithStore.setProjectVisiblity(
+					adminMode,
+					id,
+					!discoverable,
+				);
+			}
 
-      // ignore if there is no response
-      if (!response) {
-        return;
-      }
+			// ignore if there is no response
+			if (!response) {
+				return;
+			}
 
-      if (response.data.success || response.data) {
-        setDiscoverable(!discoverable);
-        notification.add({
-          color: "success",
-          message: `Successfully made ${name} ${
-            discoverable ? "undiscoverable" : "discoverable"
-          }`,
-        });
-      } else {
-        notification.add({
-          color: "error",
-          message: `Error making ${name} ${
-            discoverable ? "undiscoverable" : "discoverable"
-          }`,
-        });
-      }
-    } catch (e) {
-      notification.add({
-        color: "error",
-        message: String(e),
-      });
-    } finally {
-      // stop the loading screen
-      setLoading(false);
-    }
-  };
+			if (response.data.success || response.data) {
+				setDiscoverable(!discoverable);
+				notification.add({
+					color: "success",
+					message: `Successfully made ${name} ${
+						discoverable ? "undiscoverable" : "discoverable"
+					}`,
+				});
+			} else {
+				notification.add({
+					color: "error",
+					message: `Error making ${name} ${
+						discoverable ? "undiscoverable" : "discoverable"
+					}`,
+				});
+			}
+		} catch (e) {
+			notification.add({
+				color: "error",
+				message: String(e),
+			});
+		} finally {
+			// stop the loading screen
+			setLoading(false);
+		}
+	};
 
-  /**
-   * @name changeGlobal
-   */
-  const changeGlobal = async () => {
-    try {
-      // start the loading screen
-      setLoading(true);
+	/**
+	 * @name changeGlobal
+	 */
+	const changeGlobal = async () => {
+		try {
+			// start the loading screen
+			setLoading(true);
 
-      let response: AxiosResponse<{ success: boolean }> | null = null;
-      if (
-        type === "DATABASE" ||
-        type === "STORAGE" ||
-        type === "MODEL" ||
-        type === "VECTOR" ||
-        type === "FUNCTION"
-      ) {
-        response = await monolithStore.setEngineGlobal(adminMode, id, !global);
-      } else if (type === "APP") {
-        response = await monolithStore.setProjectGlobal(adminMode, id, !global);
-      }
+			let response: AxiosResponse<{ success: boolean }> | null = null;
+			if (
+				type === "DATABASE" ||
+				type === "STORAGE" ||
+				type === "MODEL" ||
+				type === "VECTOR" ||
+				type === "FUNCTION"
+			) {
+				response = await monolithStore.setEngineGlobal(
+					adminMode,
+					id,
+					!global,
+				);
+			} else if (type === "APP") {
+				response = await monolithStore.setProjectGlobal(
+					adminMode,
+					id,
+					!global,
+				);
+			}
 
-      // ignore if there is no response
-      if (!response) {
-        return;
-      }
+			// ignore if there is no response
+			if (!response) {
+				return;
+			}
 
-      if (response.data.success) {
-        setGlobal(!global);
+			if (response.data.success) {
+				setGlobal(!global);
 
-        notification.add({
-          color: "success",
-          message: `Successfully made ${name} ${
-            global ? "non-global" : "global"
-          }`,
-        });
-      } else {
-        notification.add({
-          color: "error",
-          message: `Error making ${name} ${global ? "non-global" : "global"}`,
-        });
-      }
-    } catch (e) {
-      notification.add({
-        color: "error",
-        message: String(e),
-      });
-    } finally {
-      // stop the loading screen
-      setLoading(false);
-    }
-  };
+				notification.add({
+					color: "success",
+					message: `Successfully made ${name} ${
+						global ? "non-global" : "global"
+					}`,
+				});
+			} else {
+				notification.add({
+					color: "error",
+					message: `Error making ${name} ${global ? "non-global" : "global"}`,
+				});
+			}
+		} catch (e) {
+			notification.add({
+				color: "error",
+				message: String(e),
+			});
+		} finally {
+			// stop the loading screen
+			setLoading(false);
+		}
+	};
 
-  /** LOADING */
-  if (loading) {
-    return <LoadingScreen.Trigger description="Deleting..." />;
-  }
+	/** LOADING */
+	if (loading) {
+		return <LoadingScreen.Trigger description="Deleting..." />;
+	}
 
-  if (condensed) {
-    return (
-      <Paper sx={StyledWidth}>
-        <Stack direction={direction}>
-          <StyledAlert
-            setBounds={direction === "column"}
-            sx={StyledWidth}
-            icon={false}
-            action={
-              <Switch
-                title={global ? `Make ${name} private` : `Make ${name} public`}
-                checked={!global}
-                disabled={
-                  !configStore.isEngineOperationAvailable(type, "public")
-                }
-                data-testid={formatToDataTestId(
+	if (condensed) {
+		return (
+			<Paper sx={StyledWidth}>
+				<Stack direction={direction}>
+					<StyledAlert
+						setBounds={direction === "column"}
+						sx={StyledWidth}
+						icon={false}
+						action={
+							<Switch
+								title={
+									global
+										? `Make ${name} private`
+										: `Make ${name} public`
+								}
+								checked={!global}
+								disabled={
+									!configStore.isEngineOperationAvailable(
+										type,
+										"public",
+									)
+								}
+								data-testid={formatToDataTestId(
 									`settingsTiles-make-${name}-public-private-switch`,
 								)}
-                onChange={() => {
-                  changeGlobal();
-                }}
-              ></Switch>
-            }
-          >
-            <Alert.Title>
-              <StyledBlock>
-                {/* Single Lock Icon on the left */}
-                <StyledIcon>
-                  <LockIcon />
-                </StyledIcon>
+								onChange={() => {
+									changeGlobal();
+								}}
+							></Switch>
+						}
+					>
+						<Alert.Title>
+							<StyledBlock>
+								{/* Single Lock Icon on the left */}
+								<StyledIcon>
+									<LockIcon />
+								</StyledIcon>
 
-                {/* Text Stack on the right */}
-                <Box>
-                  <Typography variant="body1" fontWeight="500">
-                    Private
-                  </Typography>
-                  <Typography variant="body2">
-                    No one outside of the specified member group can access
-                  </Typography>
-                </Box>
-              </StyledBlock>
-            </Alert.Title>
-          </StyledAlert>
-          {global ? (
-            <Tooltip
-              title={`An ${name} does not need to be discoverable and public.`}
-              placement="top"
-            >
-              <StyledAlert
-                setBounds={direction === "column"}
-                sx={StyledWidth}
-                icon={false}
-                action={
-                  <Switch
-                    title={
-                      discoverable
-                        ? `Make ${name} non-discoverable`
-                        : `Make ${name} discoverable`
-                    }
-                    disabled={
-                      global ||
-                      !configStore.isEngineOperationAvailable(
-                        type,
-                        "discoverable"
-                      )
-                    }
-                    data-testid={formatToDataTestId(
+								{/* Text Stack on the right */}
+								<Box>
+									<Typography
+										variant="body1"
+										fontWeight="500"
+									>
+										Private
+									</Typography>
+									<Typography variant="body2">
+										No one outside of the specified member
+										group can access
+									</Typography>
+								</Box>
+							</StyledBlock>
+						</Alert.Title>
+					</StyledAlert>
+					{global ? (
+						<Tooltip
+							title={`An ${name} does not need to be discoverable and public.`}
+							placement="top"
+						>
+							<StyledAlert
+								setBounds={direction === "column"}
+								sx={StyledWidth}
+								icon={false}
+								action={
+									<Switch
+										title={
+											discoverable
+												? `Make ${name} non-discoverable`
+												: `Make ${name} discoverable`
+										}
+										disabled={
+											global ||
+											!configStore.isEngineOperationAvailable(
+												type,
+												"discoverable",
+											)
+										}
+										data-testid={formatToDataTestId(
 											`settingsTiles-${name}-makeDiscoverable-switch`,
 										)}
-                    checked={!discoverable}
-                    onChange={() => {
-                      changeDiscoverable();
-                    }}
-                  ></Switch>
-                }
-              >
-                <Alert.Title>
-                  <StyledBlock>
-                    {/* Single Lock Icon on the left */}
-                    <StyledIcon>
-                      <VisibilityOffIcon />
-                    </StyledIcon>
-                    {/* Text Stack on the right */}
-                    <Box>
-                      <Typography variant="body1" fontWeight="500">
-                        Non Discoverable
-                      </Typography>
-                      <Typography variant="body2">
-                        Users cannot request access to this database if private
-                      </Typography>
-                    </Box>
-                  </StyledBlock>
-                </Alert.Title>
-              </StyledAlert>
-            </Tooltip>
-          ) : (
-            <StyledAlert
-              setBounds={direction === "column"}
-              sx={StyledWidth}
-              icon={false}
-              data-testid={formatToDataTestId(
+										checked={!discoverable}
+										onChange={() => {
+											changeDiscoverable();
+										}}
+									></Switch>
+								}
+							>
+								<Alert.Title>
+									<StyledBlock>
+										{/* Single Lock Icon on the left */}
+										<StyledIcon>
+											<VisibilityOffIcon />
+										</StyledIcon>
+										{/* Text Stack on the right */}
+										<Box>
+											<Typography
+												variant="body1"
+												fontWeight="500"
+											>
+												Non Discoverable
+											</Typography>
+											<Typography variant="body2">
+												{`Allow users that do not currently have access to the ${name} to discover the ${name}, view ${name} details, and request access.`}
+											</Typography>
+										</Box>
+									</StyledBlock>
+								</Alert.Title>
+							</StyledAlert>
+						</Tooltip>
+					) : (
+						<StyledAlert
+							setBounds={direction === "column"}
+							sx={StyledWidth}
+							icon={false}
+							data-testid={formatToDataTestId(
 								`settingsTiles-${name}-makeDiscoverable-switch`,
 							)}
-              action={
-                <Switch
-                  title={
-                    discoverable
-                      ? `Make ${name} non-discoverable`
-                      : `Make ${name} discoverable`
-                  }
-                  data-testid={formatToDataTestId(
+							action={
+								<Switch
+									title={
+										discoverable
+											? `Make ${name} non-discoverable`
+											: `Make ${name} discoverable`
+									}
+									data-testid={formatToDataTestId(
 										`settingsTiles-${name}-makeDiscoverable-switch`,
 									)}
-                  disabled={
-                    global ||
-                    !configStore.isEngineOperationAvailable(
-                      type,
-                      "discoverable"
-                    )
-                  }
-                  checked={!discoverable}
-                  onChange={() => {
-                    changeDiscoverable();
-                  }}
-                ></Switch>
-              }
-            >
-              <Alert.Title>
-                <StyledBlock>
-                  {/* Single Lock Icon on the left */}
-                  <StyledIcon>
-                    <VisibilityOffIcon />
-                  </StyledIcon>
+									disabled={
+										global ||
+										!configStore.isEngineOperationAvailable(
+											type,
+											"discoverable",
+										)
+									}
+									checked={!discoverable}
+									onChange={() => {
+										changeDiscoverable();
+									}}
+								></Switch>
+							}
+						>
+							<Alert.Title>
+								<StyledBlock>
+									{/* Single Lock Icon on the left */}
+									<StyledIcon>
+										<VisibilityOffIcon />
+									</StyledIcon>
 
-                  {/* Text Stack on the right */}
-                  <Box>
-                    <Typography variant="body1" fontWeight="500">
-                      Non Discoverable
-                    </Typography>
-                    <Typography variant="body2">
-                      Users cannot request access to this database if private
-                    </Typography>
-                  </Box>
-                </StyledBlock>
-              </Alert.Title>
-            </StyledAlert>
-          )}
-          <StyledAlert
-            setBounds={direction === "column"}
-            sx={StyledWidth}
-            icon={false}
-            action={
-              <Button
-                variant="contained"
-                color="error"
-                disabled={
-                  !configStore.isEngineOperationAvailable(type, "delete")
-                }
-                data-testid={formatToDataTestId(
+									{/* Text Stack on the right */}
+									<Box>
+										<Typography
+											variant="body1"
+											fontWeight="500"
+										>
+											Non Discoverable
+										</Typography>
+										<Typography variant="body2">
+											{`Allow users that do not currently have access to the ${name} to discover the ${name}, view ${name} details, and request access.`}
+										</Typography>
+									</Box>
+								</StyledBlock>
+							</Alert.Title>
+						</StyledAlert>
+					)}
+					<StyledAlert
+						setBounds={direction === "column"}
+						sx={StyledWidth}
+						icon={false}
+						action={
+							<Button
+								variant="contained"
+								color="error"
+								disabled={
+									!configStore.isEngineOperationAvailable(
+										type,
+										"delete",
+									)
+								}
+								data-testid={formatToDataTestId(
 									`settingsTiles-${name}-delete-btn`,
 								)}
-                onClick={() => setDeleteModal(true)}
-              >
-                Delete
-              </Button>
-            }
-          >
-            <Alert.Title>
-              <StyledBlock>
-                {/* Single Lock Icon on the left */}
-                <img
-                  src={databaseIcon}
-                  alt="Database Icon"
-                  style={{
-                    width: "22px",
-                    height: "22px",
-                    marginTop: "2px",
-                  }}
-                />
+								onClick={() => setDeleteModal(true)}
+							>
+								Delete
+							</Button>
+						}
+					>
+						<Alert.Title>
+							<StyledBlock>
+								{/* Single Lock Icon on the left */}
+								<img
+									src={databaseIcon}
+									alt="Database Icon"
+									style={{
+										width: "22px",
+										height: "22px",
+										marginTop: "2px",
+									}}
+								/>
 
-                {/* Text Stack on the right */}
-                <Box>
-                  <Typography variant="body1" fontWeight="500">
-                    Delete Database
-                  </Typography>
-                  <Typography variant="body2">
-                    Users cannot request access to this database if private
-                  </Typography>
-                </Box>
-              </StyledBlock>
-            </Alert.Title>
-          </StyledAlert>
-          <Modal open={deleteModal}>
-            <Modal.Title>Are you sure?</Modal.Title>
-            <Modal.Content>
-              This action is irreversable. This will permanentely delete this{" "}
-              {name}.
-            </Modal.Content>
-            <Modal.Actions>
-              <Button onClick={() => setDeleteModal(false)}>Cancel</Button>
-              <Button
-                color={"error"}
-                variant={"contained"}
-                data-testid={formatToDataTestId(
+								{/* Text Stack on the right */}
+								<Box>
+									<Typography
+										variant="body1"
+										fontWeight="500"
+									>
+										{`Delete ${type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()}`}
+									</Typography>
+									<Typography variant="body2">
+										{`Delete ${name} from catalog.`}
+									</Typography>
+								</Box>
+							</StyledBlock>
+						</Alert.Title>
+					</StyledAlert>
+					<Modal open={deleteModal}>
+						<Modal.Title>Are you sure?</Modal.Title>
+						<Modal.Content>
+							This action is irreversable. This will permanentely
+							delete this {name}.
+						</Modal.Content>
+						<Modal.Actions>
+							<Button onClick={() => setDeleteModal(false)}>
+								Cancel
+							</Button>
+							<Button
+								color={"error"}
+								variant={"contained"}
+								data-testid={formatToDataTestId(
 									`settingsTiles-${name}-confirmDelete-btn`,
 								)}
-                onClick={() => deleteWorkflow()}
-              >
-                Delete
-              </Button>
-            </Modal.Actions>
-          </Modal>
-          {/* <StyledAlert
+								onClick={() => deleteWorkflow()}
+							>
+								Delete
+							</Button>
+						</Modal.Actions>
+					</Modal>
+					{/* <StyledAlert
                         setBounds={direction === 'column'}
                         sx={{ width: '100%' }}
                         icon={false}
@@ -581,229 +614,255 @@ export const SettingsTiles = (props: SettingsTilesProps) => {
                             </Button>
                         </Modal.Actions>
                     </Modal> */}
-        </Stack>
-      </Paper>
-    );
-  } else {
-    return (
-      <StyledGrid container spacing={3}>
-        <Grid item xs={direction === "row" ? 4 : 12}>
-          <StyledAlert
-            setBounds={direction === "column"}
-            icon={false}
-            action={
-              <Switch
-                title={global ? `Make ${name} private` : `Make ${name} public`}
-                checked={!global}
-                disabled={
-                  !configStore.isEngineOperationAvailable(type, "public")
-                }
-                data-testid={formatToDataTestId(
-                  `settingsTiles-make-${name}-public-private-switch`
-                )}
-                onChange={() => {
-                  changeGlobal();
-                }}
-              ></Switch>
-            }
-          >
-            <Alert.Title>
-              <StyledBlock>
-                {/* Single Lock Icon on the left */}
-                <StyledIcon>
-                  <LockIcon />
-                </StyledIcon>
+				</Stack>
+			</Paper>
+		);
+	} else {
+		return (
+			<StyledGrid container spacing={3}>
+				<Grid item xs={direction === "row" ? 4 : 12}>
+					<StyledAlert
+						setBounds={direction === "column"}
+						icon={false}
+						action={
+							<Switch
+								title={
+									global
+										? `Make ${name} private`
+										: `Make ${name} public`
+								}
+								checked={!global}
+								disabled={
+									!configStore.isEngineOperationAvailable(
+										type,
+										"public",
+									)
+								}
+								data-testid={formatToDataTestId(
+									`settingsTiles-make-${name}-public-private-switch`,
+								)}
+								onChange={() => {
+									changeGlobal();
+								}}
+							></Switch>
+						}
+					>
+						<Alert.Title>
+							<StyledBlock>
+								{/* Single Lock Icon on the left */}
+								<StyledIcon>
+									<LockIcon />
+								</StyledIcon>
 
-                {/* Text Stack on the right */}
-                <Box>
-                  <Typography variant="body1" fontWeight="500">
-                    Private
-                  </Typography>
-                  <Typography variant="body2">
-                    No one outside of the specified member group can access
-                  </Typography>
-                </Box>
-              </StyledBlock>
-            </Alert.Title>
-          </StyledAlert>
-        </Grid>
-        {global ? (
-          <Tooltip
-            title={`An ${name} does not need to be discoverable and public.`}
-            placement="top"
-          >
-            <Grid item xs={direction === "row" ? 4 : 12}>
-              <StyledAlert
-                setBounds={direction === "column"}
-                icon={false}
-                action={
-                  <Switch
-                    disabled={
-                      global ||
-                      !configStore.isEngineOperationAvailable(
-                        type,
-                        "discoverable"
-                      )
-                    }
-                    title={
-                      discoverable
-                        ? `Make ${name} non-discoverable`
-                        : `Make ${name} discoverable`
-                    }
-                    checked={!discoverable}
-                    data-testid={formatToDataTestId(
-                      `settingsTiles-${name}-makeDiscoverable-switch`
-                    )}
-                    onChange={() => {
-                      changeDiscoverable();
-                    }}
-                  ></Switch>
-                }
-              >
-                <Alert.Title>
-                  <StyledBlock>
-                    {/* Single Lock Icon on the left */}
-                    <StyledIcon>
-                      <VisibilityOffIcon />
-                    </StyledIcon>
+								{/* Text Stack on the right */}
+								<Box>
+									<Typography
+										variant="body1"
+										fontWeight="500"
+									>
+										Private
+									</Typography>
+									<Typography variant="body2">
+										No one outside of the specified member
+										group can access
+									</Typography>
+								</Box>
+							</StyledBlock>
+						</Alert.Title>
+					</StyledAlert>
+				</Grid>
+				{global ? (
+					<Tooltip
+						title={`An ${name} does not need to be discoverable and public.`}
+						placement="top"
+					>
+						<Grid item xs={direction === "row" ? 4 : 12}>
+							<StyledAlert
+								setBounds={direction === "column"}
+								icon={false}
+								action={
+									<Switch
+										disabled={
+											global ||
+											!configStore.isEngineOperationAvailable(
+												type,
+												"discoverable",
+											)
+										}
+										title={
+											discoverable
+												? `Make ${name} non-discoverable`
+												: `Make ${name} discoverable`
+										}
+										checked={!discoverable}
+										data-testid={formatToDataTestId(
+											`settingsTiles-${name}-makeDiscoverable-switch`,
+										)}
+										onChange={() => {
+											changeDiscoverable();
+										}}
+									></Switch>
+								}
+							>
+								<Alert.Title>
+									<StyledBlock>
+										{/* Single Lock Icon on the left */}
+										<StyledIcon>
+											<VisibilityOffIcon />
+										</StyledIcon>
 
-                    {/* Text Stack on the right */}
-                    <Box>
-                      <Typography variant="body1" fontWeight="500">
-                        Non Discoverable
-                      </Typography>
-                      <Typography variant="body2">
-                        Users cannot request access to this database if private
-                      </Typography>
-                    </Box>
-                  </StyledBlock>
-                </Alert.Title>
-              </StyledAlert>
-            </Grid>
-          </Tooltip>
-        ) : (
-          <Grid item xs={direction === "row" ? 4 : 12}>
-            <StyledAlert
-              setBounds={direction === "column"}
-              icon={false}
-              action={
-                <Switch
-                  disabled={
-                    global ||
-                    !configStore.isEngineOperationAvailable(
-                      type,
-                      "discoverable"
-                    )
-                  }
-                  title={
-                    discoverable
-                      ? `Make ${name} non-discoverable`
-                      : `Make ${name} discoverable`
-                  }
-                  checked={!discoverable}
-                  data-testid={formatToDataTestId(
+										{/* Text Stack on the right */}
+										<Box>
+											<Typography
+												variant="body1"
+												fontWeight="500"
+											>
+												Non Discoverable
+											</Typography>
+											<Typography variant="body2">
+												{`Allow users that do not currently have access to the ${name} to discover the ${name}, view ${name} details, and request access.`}
+											</Typography>
+										</Box>
+									</StyledBlock>
+								</Alert.Title>
+							</StyledAlert>
+						</Grid>
+					</Tooltip>
+				) : (
+					<Grid item xs={direction === "row" ? 4 : 12}>
+						<StyledAlert
+							setBounds={direction === "column"}
+							icon={false}
+							action={
+								<Switch
+									disabled={
+										global ||
+										!configStore.isEngineOperationAvailable(
+											type,
+											"discoverable",
+										)
+									}
+									title={
+										discoverable
+											? `Make ${name} non-discoverable`
+											: `Make ${name} discoverable`
+									}
+									checked={!discoverable}
+									data-testid={formatToDataTestId(
 										`settingsTiles-${name}-makeDiscoverable-switch`,
 									)}
-                  onChange={() => {
-                    changeDiscoverable();
-                  }}
-                ></Switch>
-              }
-            >
-              <Alert.Title>
-                <StyledBlock>
-                  {/* Single Lock Icon on the left */}
-                  <StyledIcon>
-                    <VisibilityOffIcon />
-                  </StyledIcon>
+									onChange={() => {
+										changeDiscoverable();
+									}}
+								></Switch>
+							}
+						>
+							<Alert.Title>
+								<StyledBlock>
+									{/* Single Lock Icon on the left */}
+									<StyledIcon>
+										<VisibilityOffIcon />
+									</StyledIcon>
 
-                  {/* Text Stack on the right */}
-                  <Box>
-                    <Typography variant="body1" fontWeight="500">
-                      Non Discoverable
-                    </Typography>
-                    <Typography variant="body2">
-                      Users cannot request access to this database if private
-                    </Typography>
-                  </Box>
-                </StyledBlock>
-              </Alert.Title>
-            </StyledAlert>
-          </Grid>
-        )}
-        {onDelete ? (
-          <Grid item xs={direction === "row" ? 4 : 12}>
-            <StyledAlert
-              setBounds={direction === "column"}
-              icon={false}
-              action={
-                <Button
-                  variant="contained"
-                  color="error"
-                  onClick={() => setDeleteModal(true)}
-                  data-testid={formatToDataTestId(
+									{/* Text Stack on the right */}
+									<Box>
+										<Typography
+											variant="body1"
+											fontWeight="500"
+										>
+											Non Discoverable
+										</Typography>
+										<Typography variant="body2">
+											{`Allow users that do not currently have access to the ${name} to discover the ${name}, view ${name} details, and request access.`}
+										</Typography>
+									</Box>
+								</StyledBlock>
+							</Alert.Title>
+						</StyledAlert>
+					</Grid>
+				)}
+				{onDelete ? (
+					<Grid item xs={direction === "row" ? 4 : 12}>
+						<StyledAlert
+							setBounds={direction === "column"}
+							icon={false}
+							action={
+								<Button
+									variant="contained"
+									color="error"
+									onClick={() => setDeleteModal(true)}
+									data-testid={formatToDataTestId(
 										`settingsTiles-${name}-delete-btn`,
 									)}
-                  disabled={
-                    !configStore.isEngineOperationAvailable(type, "delete")
-                  }
-                >
-                  Delete
-                </Button>
-              }
-            >
-              <Alert.Title>
-                <StyledBlock>
-                  {/* Single Lock Icon on the left */}
-                  <img
-                    src={databaseIcon}
-                    alt="Database Icon"
-                    style={{
-                      width: 18,
-                      height: 18,
-                      marginTop: "2px",
-                    }}
-                  />
+									disabled={
+										!configStore.isEngineOperationAvailable(
+											type,
+											"delete",
+										)
+									}
+								>
+									Delete
+								</Button>
+							}
+						>
+							<Alert.Title>
+								<StyledBlock>
+									{/* Single Lock Icon on the left */}
+									<img
+										src={databaseIcon}
+										alt="Database Icon"
+										style={{
+											width: 18,
+											height: 18,
+											marginTop: "2px",
+										}}
+									/>
 
-                  {/* Text Stack on the right */}
-                  <Box>
-                    <Typography variant="body1" fontWeight="500">
-                      Delete Database
-                    </Typography>
-                    <Typography variant="body2">
-                      Users cannot request access to this database if private
-                    </Typography>
-                  </Box>
-                </StyledBlock>
-              </Alert.Title>
-            </StyledAlert>
-            <Modal open={deleteModal}>
-              <Modal.Title>Are you sure?</Modal.Title>
-              <Modal.Content>
-                This action is irreversable. This will permanentely delete this{" "}
-                {name}.
-              </Modal.Content>
-              <Modal.Actions>
-                <Button 
-                  onClick={() => setDeleteModal(false)} 
-                  data-testid={formatToDataTestId(
+									{/* Text Stack on the right */}
+									<Box>
+										<Typography
+											variant="body1"
+											fontWeight="500"
+										>
+											{`Delete ${type.charAt(0).toUpperCase() + type.slice(1).toLowerCase()}`}
+										</Typography>
+										<Typography variant="body2">
+											{`Delete ${name} from catalog.`}
+										</Typography>
+									</Box>
+								</StyledBlock>
+							</Alert.Title>
+						</StyledAlert>
+						<Modal open={deleteModal}>
+							<Modal.Title>Are you sure?</Modal.Title>
+							<Modal.Content>
+								This action is irreversable. This will
+								permanentely delete this {name}.
+							</Modal.Content>
+							<Modal.Actions>
+								<Button
+									onClick={() => setDeleteModal(false)}
+									data-testid={formatToDataTestId(
 										`settingsTiles-${name}-confirmCancel-btn`,
-									)}>Cancel</Button>
-                <Button
-                  color={"error"}
-                  variant={"contained"}
-                  data-testid={formatToDataTestId(
+									)}
+								>
+									Cancel
+								</Button>
+								<Button
+									color={"error"}
+									variant={"contained"}
+									data-testid={formatToDataTestId(
 										`settingsTiles-${name}-confirmDelete-btn`,
 									)}
-                  onClick={() => deleteWorkflow()}
-                >
-                  Delete
-                </Button>
-              </Modal.Actions>
-            </Modal>
-          </Grid>
-        ) : null}
-        {/* <Grid item>
+									onClick={() => deleteWorkflow()}
+								>
+									Delete
+								</Button>
+							</Modal.Actions>
+						</Modal>
+					</Grid>
+				) : null}
+				{/* <Grid item>
                     <StyledAlert
                         setBounds={direction === 'column'}
                         icon={false}
@@ -845,7 +904,7 @@ export const SettingsTiles = (props: SettingsTilesProps) => {
                         </Modal.Actions>
                     </Modal>
                 </Grid> */}
-      </StyledGrid>
-    );
-  }
+			</StyledGrid>
+		);
+	}
 };

--- a/packages/client/src/components/settings/SettingsTiles.tsx
+++ b/packages/client/src/components/settings/SettingsTiles.tsx
@@ -440,7 +440,7 @@ export const SettingsTiles = (props: SettingsTilesProps) => {
 												Non Discoverable
 											</Typography>
 											<Typography variant="body2">
-												{`Allow users that do not currently have access to the ${name} to discover the ${name}, view ${name} details, and request access.`}
+												{`Users cannot discover ${name}, view its details, or request access when it is non-discoverable.`}
 											</Typography>
 										</Box>
 									</StyledBlock>
@@ -495,7 +495,7 @@ export const SettingsTiles = (props: SettingsTilesProps) => {
 											Non Discoverable
 										</Typography>
 										<Typography variant="body2">
-											{`Allow users that do not currently have access to the ${name} to discover the ${name}, view ${name} details, and request access.`}
+											{`Users cannot discover ${name}, view its details, or request access when it is non-discoverable.`}
 										</Typography>
 									</Box>
 								</StyledBlock>
@@ -720,7 +720,7 @@ export const SettingsTiles = (props: SettingsTilesProps) => {
 												Non Discoverable
 											</Typography>
 											<Typography variant="body2">
-												{`Allow users that do not currently have access to the ${name} to discover the ${name}, view ${name} details, and request access.`}
+												{`Users cannot discover ${name}, view its details, or request access when it is non-discoverable.`}
 											</Typography>
 										</Box>
 									</StyledBlock>
@@ -773,7 +773,7 @@ export const SettingsTiles = (props: SettingsTilesProps) => {
 											Non Discoverable
 										</Typography>
 										<Typography variant="body2">
-											{`Allow users that do not currently have access to the ${name} to discover the ${name}, view ${name} details, and request access.`}
+											{`Users cannot discover ${name}, view its details, or request access when it is non-discoverable.`}
 										</Typography>
 									</Box>
 								</StyledBlock>


### PR DESCRIPTION
## Description
Previously, the "Delete Database" option was displayed across all engine types, regardless of context. This has been updated to dynamically render the appropriate delete option based on the type.

## Changes Made
File Modified: SettingsTiles.tsx

## How to Test
1. Open any engine type (App, Model, Database, Vector, or Function).
2. Navigate to the Settings section.
3. Verify that the delete option is displayed correctly for the selected engine type.

Old:
<img width="1903" height="1066" alt="image" src="https://github.com/user-attachments/assets/dfc8e8d7-a949-466f-90f8-53bb666a1aa1" />

Updated: 
<img width="987" height="442" alt="image" src="https://github.com/user-attachments/assets/d14a9ab6-e312-4c32-968d-efe3b7bc3c27" />


