### PR TITLE
feat(client): team permission  edit and add behaviour for teams

### DIFF
--- a/packages/client/src/components/teams/AddTeamModal.tsx
+++ b/packages/client/src/components/teams/AddTeamModal.tsx
@@ -191,65 +191,64 @@ export const AddTeamModal = (props: AddTeamModalProps) => {
 		if (isEdit) {
 			// Logic for editing the team
 			try {
-				const response = await monolithStore.editTeam(
-					data.TEAM_NAME,
-					data.TEAM_DESCRIPTION,
-					data.TEAM_TYPE,
-					previousTeamName,
-					previousType,
-				);
-				if (response.status === 200 && response.data) {
-					onClose({
-						id: data.TEAM_NAME,
-						type: data.TEAM_TYPE,
-						description: data.TEAM_DESCRIPTION,
-						previousTeamName: previousTeamName,
-					});
-					reset();
-					notification.add({
-						color: "success",
-						message: "Successfully updated team",
-					});
-				} else {
-					throw new Error("Failed to update team");
-				}
-			} catch (e) {
+				   const response = await monolithStore.editTeam(
+					   data.TEAM_NAME,
+					   data.TEAM_DESCRIPTION,
+					   data.TEAM_TYPE,
+					   previousTeamName,
+				   );
+				   if (response.status === 200 && response.data) {
+					   onClose({
+						   id: data.TEAM_NAME,
+						   type: data.TEAM_TYPE,
+						   description: data.TEAM_DESCRIPTION,
+						   previousTeamName: previousTeamName,
+					   });
+					   reset();
+					   notification.add({
+						   color: "success",
+						   message: "Successfully updated team",
+					   });
+				   } else {
+					   throw new Error("Failed to update team");
+				   }
+			   } catch (e) {
 				console.error(e);
-				notification.add({
-					color: "error",
+				   notification.add({
+					   color: "error",
 					message: "Error updating team",
-				});
-			}
+				   });
+			   }
 		} else {
 			// Logic for creating a new team
 			try {
-				const response = await monolithStore.addTeam(
-					data.TEAM_NAME,
-					data.TEAM_DESCRIPTION,
-					data.TEAM_TYPE,
-				);
-				if (response.status === 200 && response.data) {
-					onClose({
-						id: data.TEAM_NAME,
-						type: data.TEAM_TYPE,
-						description: data.TEAM_DESCRIPTION,
-					});
-					reset();
-					notification.add({
-						color: "success",
-						message: "Successfully added group",
-					});
-					navigate(encodeURIComponent(data.TEAM_NAME));
-				} else {
-					throw new Error("Failed to add team");
-				}
-			} catch (e) {
-				console.error(e);
-				notification.add({
-					color: "error",
+				   const response = await monolithStore.addTeam(
+					   data.TEAM_NAME,
+					   data.TEAM_DESCRIPTION,
+					   data.TEAM_TYPE,
+				   );
+				   if (response.status === 200 && response.data) {
+					   onClose({
+						   id: data.TEAM_NAME,
+						   type: data.TEAM_TYPE,
+						   description: data.TEAM_DESCRIPTION,
+					   });
+					   reset();
+					   notification.add({
+						   color: "success",
+						   message: "Successfully added group",
+					   });
+					navigate(`${encodeURIComponent(data.TEAM_TYPE)}/${encodeURIComponent(data.TEAM_NAME)}`);
+				   } else {
+					   throw new Error("Failed to add team");
+				   }
+			   } catch (e) {
+				   console.error(e);
+				   notification.add({
+					   color: "error",
 					message: "Error adding team",
-				});
-			}
+				   });
+			   }
 		}
 	});
 
@@ -287,12 +286,9 @@ export const AddTeamModal = (props: AddTeamModalProps) => {
 											label={"Type*"}
 											fullWidth={true}
 											error={!!error}
-											value={
-												field.value ? field.value : ""
-											}
-											onChange={(value) =>
-												field.onChange(value)
-											}
+											value={field.value ? field.value : ""}
+											onChange={(value) => field.onChange(value)}
+											disabled={isEdit}
 										>
 											{loginTypes
 												.sort()
@@ -372,15 +368,10 @@ export const AddTeamModal = (props: AddTeamModalProps) => {
 										<>
 											<TextField
 												label="Name*"
-												value={
-													field.value
-														? field.value
-														: ""
-												}
-												onChange={(value) =>
-													field.onChange(value)
-												}
+												value={field.value ? field.value : ""}
+												onChange={(value) => field.onChange(value)}
 												fullWidth={true}
+												disabled={isEdit && selectedTeamType !== "CUSTOM"}
 											/>
 											{selectedTeamType !== "CUSTOM" &&
 											selectedTeamType !== "" ? (
@@ -406,13 +397,12 @@ export const AddTeamModal = (props: AddTeamModalProps) => {
 									return (
 										<TextField
 											label="Description"
-											value={
-												field.value ? field.value : ""
-											}
-											onChange={(value) =>
-												field.onChange(value)
-											}
+											value={field.value ? field.value : ""}
+											onChange={(value) => field.onChange(value)}
 											fullWidth={true}
+											multiline
+											minRows={2}
+											maxRows={6}
 										/>
 									);
 								}}

--- a/packages/client/src/stores/monolith/monolith.store.ts
+++ b/packages/client/src/stores/monolith/monolith.store.ts
@@ -1092,7 +1092,7 @@ export class MonolithStore {
 			},
 		});
 
-		return response;
+		   return response;
 	}
 
 	/**
@@ -1107,7 +1107,6 @@ export class MonolithStore {
 		description: string,
 		type?: string,
 		previousTeamName?: string,
-		previousType?: string,
 	) {
 		let url = `${Env.MODULE}/api/auth/admin/`,
 			postData = "";
@@ -1117,16 +1116,14 @@ export class MonolithStore {
 		postData += "groupId=" + encodeURIComponent(previousTeamName);
 		postData += "&newGroupId=" + encodeURIComponent(groupId);
 		postData += "&newDescription=" + encodeURIComponent(description);
-		postData += "&type=" + encodeURIComponent(previousType);
-		postData += "&newType=" + encodeURIComponent(type);
-
-		const response = await axios.post<{ success: boolean }>(url, postData, {
+		postData += "&type=" + encodeURIComponent(type);
+			const response = await axios.post<{ success: boolean }>(url, postData, {
 			headers: {
 				"content-type": "application/x-www-form-urlencoded",
 			},
-		});
+			});
 
-		return response;
+		   return response;
 	}
 
 	/**


### PR DESCRIPTION
## Changes Made
1. Corrected URL so that after adding a team, it goes into team details page
2. Type change is disable in edit 
3. Only for custom type, in edit, name can be changed and for other types name can not be changed.
4. Description field is now vertically increases with increase of content

## How to Test
1. Go to Settings and do Admin On
2. Go to Team Permission settings, user can see the changes by adding or editing a team