### PR TITLE
fix(client): show help icon on home page

### DIFF
--- a/packages/client/src/components/shared/Page.tsx
+++ b/packages/client/src/components/shared/Page.tsx
@@ -1,5 +1,6 @@
 import { observer } from "mobx-react-lite";
 import { Container, styled } from "@semoss/ui";
+import { Help } from "@/components/help";
 import { Navbar } from "./Navbar";
 import { PlatformMessages } from "./PlatformMessages";
 import { Sidebar } from "./Sidebar";
@@ -52,6 +53,7 @@ export const Page: React.FC<PageProps> = observer(({ children }) => {
 				</StyledInner>
 			</StyledContent>
 			<PlatformMessages />
+			<Help/>
 		</StyledPage>
 	);
 });


### PR DESCRIPTION
## Description
Show the help icon component on the landing page

## Changes Made
Called the help icon component in Page.tsx

## How to Test

1. Navigate to homepage
2. Check if help icon is visible