### PR TITLE
Fixed redirect after catalog creation via zip

### DIFF
--- a/packages/client/src/components/import/ImportForm.tsx
+++ b/packages/client/src/components/import/ImportForm.tsx
@@ -506,7 +506,12 @@ export const ImportForm = (props) => {
 					return;
 				}
 
-				navigate(`/engine/${(steps[0].data as string).toUpperCase()}`);
+				notification.add({
+					color: "success",
+					message: `ZIP uploaded successfully`,
+				});
+
+				navigate(`/engine/${(steps[0].data as string).toLowerCase()}/${output.database_id}`);
 				return;
 			}
 			setFormLoading(false);


### PR DESCRIPTION
## Description
This pull request addresses an inconsistency in the catalog creation workflow. when creating a catalog via ZIP upload, no redirect occurred after a successful upload. This behavior was observed across all catalog types.

## Changes Made
- Modified the ZIP upload handler to capture the newly created catalog’s id and perform a redirect to its detail page after successful upload
- Added the successful toast message after zip upload which was missing earlier

https://github.com/user-attachments/assets/ba80d0af-ecc8-4b77-aa89-7e410cd3c0c3

## How to Test
1. Navigate to Model catalog page
2. Click on Add model button
3. Select ZIP from the model options
4. Browse and upload Model ZIP
5. Click on Create button
Observe

## Notes
<!-- Any further notes regarding changes -->