### PR TITLE
feat(client): breadcrumb from app details re-route to app catalog

### DIFF
--- a/packages/client/src/pages/app/AppDetailPage.tsx
+++ b/packages/client/src/pages/app/AppDetailPage.tsx
@@ -587,7 +587,7 @@ export const AppDetailPage = () => {
 				<InnerContainer>
 					<Breadcrumbs separator="/">
 						<Breadcrumbs.Item
-							href={`../../..`}
+							href="#/app"
 							underline="none"
 							color="inherit"
 							variant="body1"


### PR DESCRIPTION
## Description
The breadcrumb from app details re-route to go back to the app catalog.

## How to Test
1. Go to app catalog
2. Click view details for an app
3. Click on "App Catalog" in the breadcrumbs