### PR TITLE
feat(client): privacy modal scroll issue fix

### DIFF
--- a/packages/client/src/components/cookies/PrivacyPreferenceCenterModal.tsx
+++ b/packages/client/src/components/cookies/PrivacyPreferenceCenterModal.tsx
@@ -11,6 +11,11 @@ import {
 } from "@semoss/ui";
 import { useRootStore } from "@/hooks";
 
+const StyledModal = styled(Modal)({
+	"& .MuiPaper-root": {
+		overflowY: "auto",
+	},
+});
 const StyledModalHeader = styled(Stack)(({ theme }) => ({
 	padding: theme.spacing(2),
 }));
@@ -87,7 +92,7 @@ export const PrivacyPreferenceCenterModal = (
 	}, [configStore.theme]);
 
 	return (
-		<Modal open={isOpen} fullWidth maxWidth="lg" onClose={onClose}>
+		<StyledModal open={isOpen} fullWidth maxWidth="lg" onClose={onClose}>
 			<StyledModalHeader
 				direction="row"
 				justifyContent="space-between"
@@ -143,6 +148,6 @@ export const PrivacyPreferenceCenterModal = (
 					Close
 				</Button>
 			</StyledFooter>
-		</Modal>
+		</StyledModal>
 	);
 };


### PR DESCRIPTION
## Description
Privacy modal popup was not scrollable to view full content.

## Changes Made
Added a fix (overflowY:auto) to the modal.

## How to Test

1. Open the application.
2. Navigate to the Settings page.
3. Click the Privacy Center button.
4. Attempt to scroll through the Privacy Notice document.
5. Observe the layout of the section contents.
6. The Privacy Notice document should be fully scrollable.

## Notes
DEMO: https://github.com/SEMOSS/community/issues/468#issuecomment-3322720849