### PR TITLE
1957 remaining members not visible after deleting team settings

### DIFF
--- a/packages/client/src/components/settings/UserTable.tsx
+++ b/packages/client/src/components/settings/UserTable.tsx
@@ -1,7 +1,6 @@
 import { Add, Delete, Edit } from "@mui/icons-material";
-import CopyAllIcon from "@mui/icons-material/CopyAll";
 import SearchIcon from "@mui/icons-material/Search";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useDebouncedValue } from "@semoss/sdk/react";
 import {
 	Avatar,
@@ -9,7 +8,6 @@ import {
 	Box,
 	Button,
 	Checkbox,
-	Grid,
 	IconButton,
 	Popover,
 	Search,
@@ -167,6 +165,8 @@ const StyledNoUsersDiv = styled("div")(({ theme }) => ({
 	alignItems: "center",
 }));
 
+const StyledTableDiv = styled("div")({});
+
 const formatValue = (input: string) => {
 	if (input !== undefined) {
 		const mappings: Record<string, string> = {
@@ -250,11 +250,11 @@ export const UserTable = (props: UserTableProps) => {
 	const isLoading =
 		getUsers.status === "INITIAL" || getUsers.status === "LOADING";
 	const renderedMembers =
-		getUsers.status === "SUCCESS" ? getUsers.data["users"] : [];
+		getUsers.status === "SUCCESS" ? getUsers.data?.users : [];
 	const totalUsers =
-		getUsers.status === "SUCCESS" ? getUsers.data["totalUsers"] : 0;
+		getUsers.status === "SUCCESS" ? getUsers.data?.totalUsers : 0;
 	const hasUsers =
-		getUsers.status === "SUCCESS" && getUsers.data["totalUsers"] > 0;
+		getUsers.status === "SUCCESS" && getUsers.data?.totalUsers > 0;
 
 	/**
 	 * Update a user
@@ -503,7 +503,7 @@ export const UserTable = (props: UserTableProps) => {
 							</LoadingScreen>
 						</StyledMemberLoading>
 					) : (
-						<>
+						<StyledTableDiv>
 							{hasUsers ? (
 								<StyledMemberTable>
 									<Table.Head>
@@ -825,7 +825,7 @@ export const UserTable = (props: UserTableProps) => {
 									</Button>
 								</StyledNoUsersDiv>
 							)}
-						</>
+						</StyledTableDiv>
 					)}
 				</StyledTableContainer>
 			</StyledMemberInnerContent>

--- a/packages/client/src/components/settings/UserTable.tsx
+++ b/packages/client/src/components/settings/UserTable.tsx
@@ -371,8 +371,6 @@ export const UserTable = (props: UserTableProps) => {
 						});
 
 						onChange();
-						// refresh the users
-						getUsers.refresh();
 					} else {
 						notification.add({
 							color: "error",
@@ -388,6 +386,8 @@ export const UserTable = (props: UserTableProps) => {
 			}
 		} finally {
 			setSelectedMembers([]);
+			// refresh the users
+			getUsers.refresh();
 		}
 	};
 	/**

--- a/packages/client/src/components/teams/TeamMembersTable.tsx
+++ b/packages/client/src/components/teams/TeamMembersTable.tsx
@@ -1,8 +1,7 @@
 import { Add, ClearRounded, DeleteRounded } from "@mui/icons-material";
-import { AxiosResponse } from "axios";
+import type { AxiosResponse } from "axios";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
-import { debounced } from "@semoss/sdk/react";
 import {
 	Autocomplete,
 	Avatar,
@@ -248,9 +247,14 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 	const filteredNonCredentialedUsers = Array.from(
 		new Map(
 			nonCredentialedUsers
-				.filter((user) => !allTeamMembers.some((member) => member.userid === user.id))
-				.map((user) => [user.id, user])
-		).values()
+				.filter(
+					(user) =>
+						!allTeamMembers.some(
+							(member) => member.userid === user.id,
+						),
+				)
+				.map((user) => [user.id, user]),
+		).values(),
 	);
 
 	const { watch, setValue } = useForm<{
@@ -270,7 +274,7 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 	 */
 	useEffect(() => {
 		filter();
-	}, [groupId, count, membersPage, searchFilter,rowsPerPage]);
+	}, [groupId, count, membersPage, searchFilter, rowsPerPage]);
 	useEffect(() => {
 		if (isScrollBottom) {
 			if (canCollect) {
@@ -425,7 +429,7 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 				color: "success",
 				message: `Successfully removed users`,
 			});
-			setCount(count + 1);
+			setCount((prevCount) => {return prevCount + 1;});
 			setDeleteMembersModal(false);
 			setSelectedMembers([]);
 		}
@@ -517,7 +521,7 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 				setTeamMembers(data);
 				setHasMembers(data?.length > 0);
 			});
-	}, [count, membersPage, searchFilter,rowsPerPage]);
+	}, [count, membersPage, searchFilter, rowsPerPage]);
 
 	const filterUsersTwo = useCallback(() => {
 		monolithStore
@@ -530,7 +534,7 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 			.then((data) => {
 				setMemberCount(data.length);
 				setAllTeamMembers(data);
-        	});
+			});
 	}, [count, membersPage, searchFilter]);
 
 	const filter = () => {
@@ -538,11 +542,10 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 		filterUsersTwo();
 	};
 
-	const debouncedFilterTeams = debounced(filter, 400);
+	// const debouncedFilterTeams = debounced(filter, 400);
 
 	const handleInputChange = (newInputValue) => {
 		setValue("SEARCH_FILTER", newInputValue);
-		debouncedFilterTeams();
 	};
 
 	return (
@@ -550,7 +553,7 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 			<StyledMemberInnerContent>
 				{(teamMembers && teamMembers.length > 0) ||
 				memberCount > 0 ||
-				hasMembers ? (
+				hasMembers || searchFilter ? (
 					<StyledTableContainer>
 						<StyledTableTitleContainer>
 							<StyledTableTitleDiv>Members</StyledTableTitleDiv>
@@ -562,8 +565,7 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 											variant={"circular"}
 											max={5}
 											total={
-												teamMembers &&
-												teamMembers.length
+												teamMembers?.length
 											}
 										>
 											{Avatars.map((el) => {
@@ -651,8 +653,7 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 								</Table.Row>
 							</Table.Head>
 							<Table.Body>
-								{teamMembers &&
-									teamMembers.map((user, i) => {
+								{teamMembers.length > 0 ? teamMembers?.map((user, i) => {
 										let isSelected = false;
 
 										if (user) {
@@ -772,7 +773,12 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 												</Table.Row>
 											);
 										}
-									})}
+									}) : (
+										<Table.Row key={'no-members-found'}>
+													<Table.Cell colSpan={5} align="center">No Members found.</Table.Cell>
+										</Table.Row>
+									)
+								}
 							</Table.Body>
 							<Table.Footer>
 								<Table.Row>
@@ -785,7 +791,9 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 											setSelectedMembers([]);
 										}}
 										onRowsPerPageChange={(e) => {
-											setRowsPerPage(parseInt(e.target.value, 10));
+											setRowsPerPage(
+												parseInt(e.target.value, 10),
+											);
 											setMembersPage(1);
 										}}
 										page={membersPage - 1}
@@ -866,8 +874,7 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 							}}
 						/>
 
-						{selectedNonCredentialedUsers &&
-							selectedNonCredentialedUsers.map((user, idx) => {
+						{selectedNonCredentialedUsers?.map((user, idx) => {
 								const space = user.name.indexOf(" ");
 								const initial = user.name
 									? space > -1
@@ -878,7 +885,7 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 									: user.id[0].toUpperCase();
 								return (
 									<Box
-										key={idx}
+										key={`${user.name} - ${idx}`}
 										sx={{
 											display: "flex",
 											justifyContent: "left",

--- a/packages/client/src/components/teams/TeamMembersTable.tsx
+++ b/packages/client/src/components/teams/TeamMembersTable.tsx
@@ -653,7 +653,8 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 								</Table.Row>
 							</Table.Head>
 							<Table.Body>
-								{teamMembers.length > 0 ? teamMembers?.map((user, i) => {
+								{Array.isArray(teamMembers) && teamMembers.length > 0 ? 
+									(teamMembers?.map((user, i) => {
 										let isSelected = false;
 
 										if (user) {
@@ -773,7 +774,7 @@ export const TeamMembersTable = (props: MembersTableProps) => {
 												</Table.Row>
 											);
 										}
-									}) : (
+									})) : (
 										<Table.Row key={'no-members-found'}>
 													<Table.Cell colSpan={5} align="center">No Members found.</Table.Cell>
 										</Table.Row>


### PR DESCRIPTION
## Description
This PR fixes when a user tries to search for a user and deletes the same user from list. After deleting, it shows no members found ui. yet there are other records available, out of the search keyword. So if no records matched, there should be no members found message in the table.

## Changes Made
Fixed user search based delete, and then showing no members found row, while search keyword doesn't matched with any records

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Go to Settings -> Team Settings -> select a team and go into it.
2. Choose members from team by searching with a keyword.
3. check all the filtered team members and then click delete selected.
4. Confirm the popup and wait for the table. it should now show No members found.

## Notes
<!-- Any further notes regarding changes -->