### PR TITLE
Fixed type errors on renderer lib with e-charts

### DIFF
--- a/libs/renderer/src/components/block-defaults/echart-visualization-block/variant/stack-chart/StackChart.tsx
+++ b/libs/renderer/src/components/block-defaults/echart-visualization-block/variant/stack-chart/StackChart.tsx
@@ -60,13 +60,13 @@ export const StackChart: BlockComponent = observer(({ id }) => {
 		yAxisColumn: { name: "", selector: "", width: undefined },
 		chartInstance: { setOption: null },
 	});
-	let fields = "",
-		xAxis = "",
-		yAxis = "",
-		category = "",
-		tooltip = "";
+	let fields: Record<string, any> = {};
+	let xAxis = "";
+	let yAxis = "";
+	let category = "";
+	let tooltip = "";
 	if (Object.hasOwn(data.option, "_state")) {
-		fields = data.option["_state"]["fields"];
+		fields = data.option["_state"]["fields"]; 
 		xAxis = fields["XAxis"];
 		yAxis = fields["YAxis"];
 		category = fields["category"];

--- a/libs/renderer/src/store/state/state.types.ts
+++ b/libs/renderer/src/store/state/state.types.ts
@@ -59,6 +59,7 @@ export type Variable =
 			to: string;
 			type: "cell"; // Specific case when type is 'cell'
 			cellId: string;
+			value?: any;
 	  };
 
 export type VariableWithId =


### PR DESCRIPTION
## Description
In this PR I have fixed type errors on renderer lib with e-charts.

## Changes Made
- added value?: any; in Variable type definition when type is cell in state.type.ts
- changed fields initialization from string to the object i.e., let fields: Record<string, any> = {}; in StackChart.tsx

## Fix
<img width="940" height="415" alt="image" src="https://github.com/user-attachments/assets/acf3a361-4a8d-4a35-afea-59874fce1359" />
