### PR TITLE
Fixed discoverable blank page issue 

### DIFF
--- a/packages/client/src/pages/app/AppCatalogPage.tsx
+++ b/packages/client/src/pages/app/AppCatalogPage.tsx
@@ -536,7 +536,7 @@ export const AppCatalogPage = observer((): JSX.Element => {
 												isDiscoverable={mode !== "Mine"}
 												href={
 													mode === "Discoverable"
-														? `#/app/${app.project_id}/detail`
+														? `#/app/${app.project_id}`
 														: `#/app/${app.project_id}/view`
 												}
 												onAction={() => {
@@ -544,7 +544,7 @@ export const AppCatalogPage = observer((): JSX.Element => {
 														mode === "Discoverable"
 													) {
 														navigate(
-															`/app/${app.project_id}/detail`,
+															`/app/${app.project_id}`,
 														);
 													} else {
 														navigate(


### PR DESCRIPTION
## Description
In this PR I have fixed the issue related to the discoverable app accessing issue.
Earlier discoverable apps redirects to the route = "/app/detail" with no content/blank page. 
Now I have changed the navigation to app only where user can see the app details along with request access control.

## Changes Made
<img width="1905" height="870" alt="image" src="https://github.com/user-attachments/assets/8a852ae3-c406-4d2d-8336-03f548a1a0f0" />
<img width="1911" height="871" alt="image" src="https://github.com/user-attachments/assets/c8f141f8-2324-4f7a-85a9-3979d9b51d18" />


## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->