### PR TITLE
Fix: rename app to project

### DIFF
--- a/packages/playground/src/components/tools/ToolboxOverlay.tsx
+++ b/packages/playground/src/components/tools/ToolboxOverlay.tsx
@@ -237,7 +237,7 @@ export const ToolboxOverlay: React.FC<ToolboxOverlayProps> = (props) => {
 												>
 													<StyledItemImageHolder>
 														{tool.type ===
-															"APP" && (
+															"PROJECT" && (
 															<img
 																alt=""
 																src={`${ENDPOINT}${MODULE}/api/app-${tool.id}/appImage/download`}

--- a/packages/playground/src/components/tools/utility.ts
+++ b/packages/playground/src/components/tools/utility.ts
@@ -13,7 +13,7 @@ export const getToolbox = (item: Engine | App): Toolbox => {
 	// Type guard to check if item is App
 	if ("project_id" in item && "project_name" in item) {
 		id = item.project_id;
-		type = "APP";
+		type = "PROJECT";
 		name = item.project_name;
 	} else if ("app_id" in item && "app_name" in item) {
 		id = item.app_id;


### PR DESCRIPTION
## Description
the key should be "project" not "app"

## How to Test
Try creating a chat with tools now - it should work