### PR TITLE
fix: update default time to use new correct zone mapping

### DIFF
--- a/packages/client/src/pages/jobs/JobsPage.tsx
+++ b/packages/client/src/pages/jobs/JobsPage.tsx
@@ -606,7 +606,7 @@ export function JobsPage() {
 									pixel: "",
 									tags: [],
 									cronExpression: "0 0 12 * * *",
-									cronTz: "Eastern Standard Time",
+									cronTz: "US/Eastern",
 									smtpHost: "",
 									smtpPort: "",
 									subject: "",


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
The time zone was getting defaulted to GMT even though it said Eastern

## Changes Made
<!-- List the key changes made in this PR -->
updated the default time zone to match the updated time zone list option
## How to Test
<!-- Explain how reviewers can test your changes -->


1. click create new job
2. fill out only the pixel
3. press save
4. should no longer save as GMT but to US/Eastern

## Notes
<!-- Any further notes regarding changes -->