### PR TITLE
Auto-execute tools when LLM 

### DIFF
--- a/packages/playground/src/components/room/RoomInput.tsx
+++ b/packages/playground/src/components/room/RoomInput.tsx
@@ -371,27 +371,29 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 					>
 						{ENABLE_ATTACHMENT && (
 							<Tooltip title={"Attach Document"} placement="top">
-								<IconButton
-									size={"small"}
-									type="button"
-									color="default"
-									aria-label="Attach Documents"
-									disabled={isDisabled || isLoading}
-									onClick={() => {
-										fileRef.current?.click();
-									}}
-								>
-									<Badge
-										color={"primary"}
-										variant="dot"
-										invisible={files.length === 0}
+								<span>
+									<IconButton
+										size={"small"}
+										type="button"
+										color="default"
+										aria-label="Attach Documents"
+										disabled={isDisabled || isLoading}
+										onClick={() => {
+											fileRef.current?.click();
+										}}
 									>
-										<AttachFileRounded
-											color={"inherit"}
-											fontSize="medium"
-										/>
-									</Badge>
-								</IconButton>
+										<Badge
+											color={"primary"}
+											variant="dot"
+											invisible={files.length === 0}
+										>
+											<AttachFileRounded
+												color={"inherit"}
+												fontSize="medium"
+											/>
+										</Badge>
+									</IconButton>
+								</span>
 							</Tooltip>
 						)}
 						{actions}

--- a/packages/playground/src/constants.ts
+++ b/packages/playground/src/constants.ts
@@ -2,3 +2,7 @@ export const MODEL_KEY = "SMSS-SELECTED-MODEL";
 
 export const TOKEN_LENGTH = null;
 export const TEMPERATURE = 0.3;
+
+export const MCP_EXECUTION_AUTO = "auto";
+export const MCP_EXECUTION_ASK = "ask";
+export const MCP_EXECUTION_DISABLED = "disabled";

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -155,7 +155,7 @@ paramValues=[${JSON.stringify({
 		inputMessage.addChild(responseMessage);
 
 		// start running tools if there are any
-		this.startToolExecution();
+		responseMessage.startToolExecution();
 	};
 
 	/**
@@ -275,6 +275,11 @@ paramValues=[${JSON.stringify({
 	 */
 	private runToolExecution = async (): Promise<void> => {
 		const room = this.room;
+
+		console.log({
+			toolExecutionIdx: this.toolExecutionIdx,
+			tools: this.tools,
+		});
 
 		// skip if the index is out of bounds
 		if (

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -34,7 +34,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 		/** meta data from the tool */
 		_meta: {
 			map: {
-				autoExecute: boolean;
+				SMSS_MCP_EXECUTION: "auto" | "ask" | "disabled";
 				SMSS_PROJECT_NAME: string;
 				SMSS_PROJECT_ID: string;
 			};
@@ -84,8 +84,8 @@ export class ResponseMessageStore extends AbstractMessageStore {
 				id: t.id,
 				_meta: {
 					map: {
+						// SMSS_MCP_EXECUTION: "auto",
 						...t._meta.map,
-						autoExecute: false,
 					},
 				},
 				title: t.title,
@@ -109,6 +109,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 	 */
 	runMessage = async (inputMessage: InputMessageStore): Promise<void> => {
 		const room = this.room;
+		console.log("running message from response store", inputMessage);
 
 		// connect to the parent
 		this.addChild(inputMessage);
@@ -151,6 +152,7 @@ paramValues=[${JSON.stringify({
 			output.responseMessage,
 		) as ResponseMessageStore;
 		inputMessage.addChild(responseMessage);
+		console.log("response message created", responseMessage);
 
 		// start running tools if there are any
 		this.startToolExecution();
@@ -274,6 +276,8 @@ paramValues=[${JSON.stringify({
 	private runToolExecution = async (): Promise<void> => {
 		const room = this.room;
 
+		console.log("running tool execution at index", this.toolExecutionIdx);
+
 		// skip if the index is out of bounds
 		if (
 			this.toolExecutionIdx < 0 ||
@@ -286,11 +290,13 @@ paramValues=[${JSON.stringify({
 		if (!tool) {
 			return;
 		}
+		console.log(tool);
 
 		// only run if it is set to auto execute
-		if (!tool._meta.map.autoExecute) {
+		if (tool._meta.map.SMSS_MCP_EXECUTION !== "auto") {
 			return;
 		}
+		console.log("auto executing tool", tool.name);
 
 		// wait for the pixel to run
 		const response = await room.runRoomPixel<[string]>(

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -1,4 +1,5 @@
 import { makeObservable, observable, runInAction } from "mobx";
+import { MCP_EXECUTION_ASK, MCP_EXECUTION_AUTO } from "@/constants";
 import type {
 	InputToolExecPixelMessage,
 	PixelMessage,
@@ -84,7 +85,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 				id: t.id,
 				_meta: {
 					map: {
-						// SMSS_MCP_EXECUTION: "auto",
+						SMSS_MCP_EXECUTION: MCP_EXECUTION_ASK,
 						...t._meta.map,
 					},
 				},
@@ -109,7 +110,6 @@ export class ResponseMessageStore extends AbstractMessageStore {
 	 */
 	runMessage = async (inputMessage: InputMessageStore): Promise<void> => {
 		const room = this.room;
-		console.log("running message from response store", inputMessage);
 
 		// connect to the parent
 		this.addChild(inputMessage);
@@ -152,7 +152,6 @@ paramValues=[${JSON.stringify({
 			output.responseMessage,
 		) as ResponseMessageStore;
 		inputMessage.addChild(responseMessage);
-		console.log("response message created", responseMessage);
 
 		// start running tools if there are any
 		this.startToolExecution();
@@ -276,8 +275,6 @@ paramValues=[${JSON.stringify({
 	private runToolExecution = async (): Promise<void> => {
 		const room = this.room;
 
-		console.log("running tool execution at index", this.toolExecutionIdx);
-
 		// skip if the index is out of bounds
 		if (
 			this.toolExecutionIdx < 0 ||
@@ -290,13 +287,11 @@ paramValues=[${JSON.stringify({
 		if (!tool) {
 			return;
 		}
-		console.log(tool);
 
 		// only run if it is set to auto execute
-		if (tool._meta.map.SMSS_MCP_EXECUTION !== "auto") {
+		if (tool._meta.map.SMSS_MCP_EXECUTION !== MCP_EXECUTION_AUTO) {
 			return;
 		}
-		console.log("auto executing tool", tool.name);
 
 		// wait for the pixel to run
 		const response = await room.runRoomPixel<[string]>(

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -276,11 +276,6 @@ paramValues=[${JSON.stringify({
 	private runToolExecution = async (): Promise<void> => {
 		const room = this.room;
 
-		console.log({
-			toolExecutionIdx: this.toolExecutionIdx,
-			tools: this.tools,
-		});
-
 		// skip if the index is out of bounds
 		if (
 			this.toolExecutionIdx < 0 ||

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -2,6 +2,7 @@ import { makeObservable, observable, runInAction } from "mobx";
 import { MCP_EXECUTION_ASK, MCP_EXECUTION_AUTO } from "@/constants";
 import type {
 	InputToolExecPixelMessage,
+	McpExecution,
 	PixelMessage,
 	ResponseTextPixelMessage,
 	ResponseToolPixelMessage,
@@ -35,7 +36,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 		/** meta data from the tool */
 		_meta: {
 			map: {
-				SMSS_MCP_EXECUTION: "auto" | "ask" | "disabled";
+				SMSS_MCP_EXECUTION: McpExecution;
 				SMSS_PROJECT_NAME: string;
 				SMSS_PROJECT_ID: string;
 			};

--- a/packages/playground/src/stores/message/root-message.store.ts
+++ b/packages/playground/src/stores/message/root-message.store.ts
@@ -93,7 +93,7 @@ paramValues=[${JSON.stringify({
 
 		// start running tools if there are any
 		if (responseMessage.type === "RESPONSE") {
-			// responseMessage.startToolExecution();
+			responseMessage.startToolExecution();
 		}
 
 		return responseMessage;

--- a/packages/playground/src/stores/message/root-message.store.ts
+++ b/packages/playground/src/stores/message/root-message.store.ts
@@ -29,7 +29,6 @@ export class RootMessageStore extends AbstractMessageStore {
 		inputMessage: InputMessageStore,
 	): Promise<PlanMessageStore | ResponseMessageStore> => {
 		const room = this.room;
-		console.log("running message from root message store", inputMessage);
 
 		// connect to the parent
 		this.addChild(inputMessage);

--- a/packages/playground/src/stores/message/root-message.store.ts
+++ b/packages/playground/src/stores/message/root-message.store.ts
@@ -29,6 +29,7 @@ export class RootMessageStore extends AbstractMessageStore {
 		inputMessage: InputMessageStore,
 	): Promise<PlanMessageStore | ResponseMessageStore> => {
 		const room = this.room;
+		console.log("running message from root message store", inputMessage);
 
 		// connect to the parent
 		this.addChild(inputMessage);

--- a/packages/playground/src/stores/message/root-message.store.ts
+++ b/packages/playground/src/stores/message/root-message.store.ts
@@ -91,6 +91,11 @@ paramValues=[${JSON.stringify({
 		) as PlanMessageStore | ResponseMessageStore;
 		inputMessage.addChild(responseMessage);
 
+		// start running tools if there are any
+		if (responseMessage.type === "RESPONSE") {
+			// responseMessage.startToolExecution();
+		}
+
 		return responseMessage;
 	};
 }

--- a/packages/playground/src/types.d.ts
+++ b/packages/playground/src/types.d.ts
@@ -125,6 +125,7 @@ interface ResponseToolPixelMessage extends AbstractPixelMessage {
 			map: {
 				SMSS_PROJECT_NAME: string;
 				SMSS_PROJECT_ID: string;
+				SMSS_MCP_EXECUTION: "auto" | "ask" | "disabled";
 			};
 		};
 

--- a/packages/playground/src/types.d.ts
+++ b/packages/playground/src/types.d.ts
@@ -114,6 +114,8 @@ interface ResponseTextPixelMessage extends AbstractPixelMessage {
 	};
 }
 
+export type McpExecution = "auto" | "ask" | "disabled";
+
 interface ResponseToolPixelMessage extends AbstractPixelMessage {
 	type: "RESPONSE_TOOL";
 	tool_responses: {
@@ -125,7 +127,7 @@ interface ResponseToolPixelMessage extends AbstractPixelMessage {
 			map: {
 				SMSS_PROJECT_NAME: string;
 				SMSS_PROJECT_ID: string;
-				SMSS_MCP_EXECUTION: "auto" | "ask" | "disabled";
+				SMSS_MCP_EXECUTION: McpExecution;
 			};
 		};
 


### PR DESCRIPTION
## Description
Allow the FE to auto-execute tools

## Changes Made
- Create new constants and types for execution options
- Run child message's tools instead of current

## How to Test
1. Create a room with a tool that is auto-executable
2. Ask Playground a question that involves the tool