### PR TITLE
feat(client): delete community block bug fix

### DIFF
--- a/packages/client/src/components/blocks-workspace/panels/BlocksMenuPanel.tsx
+++ b/packages/client/src/components/blocks-workspace/panels/BlocksMenuPanel.tsx
@@ -177,10 +177,10 @@ export const BlocksMenuPanel = observer((props: AddBlocksMenuProps) => {
 		runPixel(`DeleteBlock(blockId = "${blockId}", hardDelete = true)`).then(
 			(res) => {
 				const { errors } = res;
-				if (errors.length) {
+				if (errors.length || !res.pixelReturn[0].output) {
 					notification.add({
 						color: "error",
-						message: errors.join(""),
+						message: errors.join("") ?? "Error deleting block",
 					});
 				} else {
 					notification.add({

--- a/packages/client/src/components/designer/AddBlocksMenuCard.tsx
+++ b/packages/client/src/components/designer/AddBlocksMenuCard.tsx
@@ -376,7 +376,10 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 								size="small"
 								onClick={(e) => {
 									e.stopPropagation();
-									handleOnTrashClick("", item.name);
+									handleOnTrashClick(
+										item['id'] ?? '',
+										item.name,
+									);
 								}}
 							>
 								<DeleteOutline sx={{ color: "#757575" }} />


### PR DESCRIPTION
## Description
While deleting community block success toaster message shows up, but block is not deleted.

## Changes Made

1. [BlocksMenuPanel.tsx](https://github.com/SEMOSS/semoss-ui/compare/2110-Delete-communityBlock-bugFix?expand=1#diff-d6ac02c1e23c4495aa4c58fd5950e4c6b02b2eae6785f190be8fd630c7c1cc37) - added null check for error condition
2. [AddBlocksMenuCard.tsx](https://github.com/SEMOSS/semoss-ui/compare/2110-Delete-communityBlock-bugFix?expand=1#diff-c9e07efa9ce21c379177826882e063eb99da762649da722c5aafb84cb24c9465) - passed the respective block Id on the **handleTrashClick** function to delete the respective delete click.

## How to Test
1. Go to an app and create a community block
3. Delete the community block from the blocks menu
4. Refresh the page
5. Check that the block is still shown in the blocks menu

**Expected Result**
Block is deleted once user confirms the delete in the delete modal

## Notes
Demo: https://github.com/SEMOSS/semoss-ui/issues/2110#issuecomment-3479297335