### PR TITLE
build(notebook): generateframefrompyvariable crashes fix

### DIFF
--- a/libs/ui/src/components/Terminal/Terminal.tsx
+++ b/libs/ui/src/components/Terminal/Terminal.tsx
@@ -242,6 +242,7 @@ const StyledTerminalWrapper = styled("div")<{ darkThemeStyle: string }>(
 			zIndex: 2,
 			position: "relative",
 		},
+		height: "100%",
 	}),
 );
 

--- a/packages/client/src/components/notebook/operations/FrameOperation.tsx
+++ b/packages/client/src/components/notebook/operations/FrameOperation.tsx
@@ -30,8 +30,10 @@ export const FrameOperation = observer((props: FrameOperationProps) => {
 	const { output } = props;
 	const { state } = useBlocks();
 	let cellDetail = null;
-	const queryDetail = state.getQuery(props.cellData.queryId.toString());
-	cellDetail = queryDetail.getCell(props.cellData.cellId.toString());
+	if (props?.cellData) {
+		const queryDetail = state.getQuery(props.cellData.queryId.toString());
+		cellDetail = queryDetail.getCell(props.cellData.cellId.toString());
+	}
 
 	const addLimit = cellDetail?.parameters?.dataLimit
 		? (Number(cellDetail.parameters.dataLimit) ?? -1)


### PR DESCRIPTION
## Description
While executing generateframefrompyvariable reactor, there is an error that makes page ineffective by showing error rendering component. 

## Changes Made
Found possible issues with executing the reactor generateframefrompyvariable  and added fix for the same.

## How to Test
<!-- Explain how reviewers can test your changes -->
1. In the app, open/create a app from **custom frame to visualization** template.
2. Go to create-pandas-frame notebook.
3. Press run-all or run all the cells in the notebook
4. Every cell should run and return response without errors.

## Notes
<!-- Any further notes regarding changes -->