### PR TITLE
fix: edit workspace

### DIFF
--- a/packages/playground/src/components/workspace/workspace-overlay.tsx
+++ b/packages/playground/src/components/workspace/workspace-overlay.tsx
@@ -23,7 +23,7 @@ import {
 } from "@semoss/ui/next";
 import { engineProjectToMCP } from "@/components";
 import { useChat } from "@/hooks";
-import type { App, Engine, MCP, Workspace } from "@/types";
+import type { App, Engine, MCP, MCPConfig, Workspace } from "@/types";
 
 export interface WorkspaceOverlayProps {
 	/** Track if the overlay is open */
@@ -54,9 +54,9 @@ export const WorkspaceOverlay: React.FC<WorkspaceOverlayProps> = ({
 	const [name, setName] = useState<string>("");
 	const [description, setDescription] = useState<string>("");
 	const [instructions, setInstructions] = useState<string>("");
-	const [selectedMCPMap, setSelectedMCPMap] = useState<Record<string, MCP>>(
-		{},
-	);
+	const [selectedMCPMap, setSelectedMCPMap] = useState<
+		Record<string, MCPConfig>
+	>({});
 
 	const [isLoadingSubmit, setIsLoadingSubmit] = useState<boolean>(false);
 	const [searchWord, setSearchWord] = useState<string>("");
@@ -83,11 +83,26 @@ export const WorkspaceOverlay: React.FC<WorkspaceOverlayProps> = ({
 			return;
 		}
 
-		setName("");
-		setDescription("");
-		setInstructions("");
-		setSelectedMCPMap({});
-	}, [open]);
+		if (workspaceId && getWorkspace.data) {
+			setName(getWorkspace.data.name);
+			setDescription(getWorkspace.data.description || "");
+			setInstructions(getWorkspace.data.system_prompt || "");
+			const initialMCPMap = getWorkspace.data.mcp.reduce(
+				(acc, val) => {
+					acc[val.id] = val;
+					return acc;
+				},
+				{} as Record<string, MCPConfig>,
+			);
+			setSelectedMCPMap(initialMCPMap);
+			return;
+		} else {
+			setName("");
+			setDescription("");
+			setInstructions("");
+			setSelectedMCPMap({});
+		}
+	}, [open, workspaceId, getWorkspace.data]);
 
 	/**
 	 * Constants
@@ -107,12 +122,12 @@ export const WorkspaceOverlay: React.FC<WorkspaceOverlayProps> = ({
 		isLoadingSubmit ||
 		(workspaceId && getWorkspace.status !== "SUCCESS");
 
-	const onMCPSelect = (mcp: MCP) => {
+	const onMCPSelect = (mcp: MCPConfig) => {
 		const updatedSelectedMCPMap = { ...selectedMCPMap };
 		if (updatedSelectedMCPMap[mcp.id]) {
 			delete updatedSelectedMCPMap[mcp.id];
 		} else {
-			updatedSelectedMCPMap[mcp.id] = mcp;
+			updatedSelectedMCPMap[mcp.id] = mcpMap[mcp.id];
 		}
 		setSelectedMCPMap(updatedSelectedMCPMap);
 	};

--- a/packages/playground/src/components/workspace/workspace-overlay.tsx
+++ b/packages/playground/src/components/workspace/workspace-overlay.tsx
@@ -127,7 +127,7 @@ export const WorkspaceOverlay: React.FC<WorkspaceOverlayProps> = ({
 		if (updatedSelectedMCPMap[mcp.id]) {
 			delete updatedSelectedMCPMap[mcp.id];
 		} else {
-			updatedSelectedMCPMap[mcp.id] = mcpMap[mcp.id];
+			updatedSelectedMCPMap[mcp.id] = mcp;
 		}
 		setSelectedMCPMap(updatedSelectedMCPMap);
 	};


### PR DESCRIPTION
## Description
Populate workspace data when editing

## Notes
The chips at the bottom should have names, but because GetWorkspace is not currently returning names, they do not. This is a BE bug that should be fixed soon