### PR TITLE
Resolves: 533 Data Import Large Frame crash Bug 

### DIFF
--- a/packages/client/src/components/notebook/operations/FrameOperation.tsx
+++ b/packages/client/src/components/notebook/operations/FrameOperation.tsx
@@ -35,14 +35,25 @@ export const FrameOperation = observer((props: FrameOperationProps) => {
 		cellDetail = queryDetail.getCell(props.cellData.cellId.toString());
 	}
 
-	const addLimit = cellDetail?.parameters?.dataLimit
+	const getCount = useBlocksPixel<number>(
+		`Frame(frame=[${output.name}] )|QueryAll()|QueryRowCount();`,
+	);
+
+	// Determine the limit to use
+	const rowCount = getCount.status === "SUCCESS" ? getCount.data : 0;
+	const hasDataLimit = cellDetail?.parameters?.dataLimit;
+	const addLimit = hasDataLimit
 		? (Number(cellDetail.parameters.dataLimit) ?? -1)
-		: -1;
+		: rowCount > 500
+			? 20
+			: -1;
+
 	const queryToRun = useMemo(
 		() =>
 			`Frame(frame=[${output.name}] )|QueryAll()|Limit(${addLimit})|CollectAll();`,
-		[output],
+		[output, addLimit],
 	);
+
 	// get the data from the frame
 	const getData = useBlocksPixel<{
 		data: {
@@ -50,11 +61,6 @@ export const FrameOperation = observer((props: FrameOperationProps) => {
 			headers: string[];
 		};
 	}>(queryToRun);
-
-	// get the count of data in the frame
-	const getCount = useBlocksPixel<number>(
-		`Frame(frame=[${output.name}] )|QueryAll()|QueryRowCount();`,
-	);
 
 	// get the statuses
 	const isLoading =


### PR DESCRIPTION
## Description
I updated the 'addLimit' functionality in the FrameOperations file where for both Custom SQL / normal Data Import cells will default to 20 rows as preview for the Frame if the whole data set, even with added limits, exceeds 500 rows. This will actually render a preview, rather than dumping all rows into the preview table for the frame. 

## Changes Made
1. Move getCount function above 'addLimit' declatation
2. Add new variables for row count of the cell and data limit.
3. Add new variables to the 'addLimit' logic.

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Login to the client site and create new Drag n Drop application.
2. Use a large (over 500 row) db and create a Data Import with the Custom SQL option and select all rows.
3. The Frame will resolve, showing a 20 row preview of the desired data.
4. Create another Data Import with the 'From Data Catalog' and put your desired limit. 
5. If more than 500 rows, you will see the 20 row preview of the data.
6. If less than 500 rows, you will see the data itself.

## Notes
<img width="495" height="247" alt="image" src="https://github.com/user-attachments/assets/ac0b29d4-c04a-432c-ac31-9a5505d38746" />
<img width="495" height="493" alt="image" src="https://github.com/user-attachments/assets/61a73bdf-bc34-4139-a042-a5f014e93ed9" />
<img width="503" height="445" alt="image" src="https://github.com/user-attachments/assets/961652ec-57de-415a-8b5a-248002dfc141" />


