### PR TITLE
Fixed similar font size among h1 to h6 headings

### DIFF
--- a/libs/ui/src/styles/globals.css
+++ b/libs/ui/src/styles/globals.css
@@ -193,6 +193,27 @@
   .section-title-gap-sm {
     gap: 1rem;
   }
+  h1, h2, h3, h4, h5, h6 {
+    color: #000000;
+  }
+  h1 {
+    font-size: 32px;
+  }
+  h2 {
+     font-size: 24px;
+  }
+  h3 {
+    font-size: 18.72px;
+  }
+  h4 {
+    font-size: 16px;
+  }
+  h5 {
+    font-size: 13.28px;
+  }
+  h6 {
+    font-size: 10.72px;
+  }
 }
 
 /*  ---break  ---*/


### PR DESCRIPTION
## Description
In this PR, I have tried to fix the issue related to similar font size among the headings (h1....h6). Earlier the default size of headings was same which may be caused by Tailwind CSS rules. 

## Changes Made
- I have added explicit h1..h6 CSS into (globals.css) file inside the layer base { ... } block so it overrides Tailwind and persists the default size of each heading.

@johbaxter , please take a look into the changes. please check if this works or should i go with any other approach?

<img width="727" height="848" alt="image" src="https://github.com/user-attachments/assets/58760546-7e2e-4812-97b9-d17ed7d0ed4b" />

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->