### PR TITLE
fix: allow auto-execution of multiple tools in one message

### DIFF
--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -371,19 +371,20 @@ paramValues=[${JSON.stringify(paramValues)}]
 
 		const { output } = response.pixelReturn[0];
 
-		// don't create a new message if it is a string. More tools need to be executed
-		if (typeof output.responseMessage === "string") {
-			return;
+		// If the output is a string (as opposed to a tool response message), continue tool execution. Otherwise, create the response message
+		if (
+			typeof output === "string" ||
+			typeof output.responseMessage === "string"
+		) {
+			// Keep executing tools
+			await this.continueToolExecution(tool);
+		} else {
+			// create the response and link to the message
+			const responseMessage = createMessageStore(
+				room,
+				output.responseMessage,
+			);
+			this.addChild(responseMessage);
 		}
-
-		// create the response and link to the message
-		const responseMessage = createMessageStore(
-			room,
-			output.responseMessage,
-		);
-		this.addChild(responseMessage);
-
-		// keep going
-		await this.continueToolExecution(tool);
 	};
 }


### PR DESCRIPTION
## Description
Allow tools to be auto-executed even if there are multiple in a call

## Changes Made
1. response-message.store.ts was expecting `output: { responseMessage: string}` from AddPlaygroundToolExecution when the tool is mid-run, but instead it was getting back `output: string`
2. The logic check for "there are more tools to run, so don't create a response message, let's return" was happening before the additional tools were even getting called ...
3. The additional tools were getting called after the response message was created, which doesn't make sense because the response message only gets sent after all tools calls in a message are sent

## How to Test
1. Have an MCP with a tool set to auto-execute (for this example I'll use get_stock_price)
2. In a room with the MCP, ask for the price of Amazon and Meta
3. Verify both auto-execute and Playground returns something sensible
4. In a different room with the MCP, ask for the price of just one stock, just to make sure that is still working too
