### PR TITLE
534 Export Data Tool for Data Frames 

### DIFF
--- a/libs/renderer/src/store/state/migration/MigrationManager.ts
+++ b/libs/renderer/src/store/state/migration/MigrationManager.ts
@@ -15,6 +15,7 @@ import migrate__1_0_0_alpha_13__to_1_0_0_alpha_14 from "./migrate__1_0_0_alpha_1
 import migrate__1_0_0_alpha_14__to_1_0_0_alpha_15 from "./migrate__1_0_0_alpha_14__to___1_0_0_alpha_15";
 import migrate__1_0_0_alpha_15__to_1_0_0_alpha_16 from "./migrate__1_0_0_alpha_15__to___1_0_0_alpha_16";
 import migrate__1_0_0_alpha_16__to_1_0_0_alpha_17 from "./migrate__1_0_0_alpha_16__to___1_0_0_alpha_17";
+import migrate__1_0_0_alpha_17__to___1_0_0_alpha_18 from "./migrate__1_0_0_alpha_17__to___1_0_0_alpha_18";
 import type { Migration, MigrationState } from "./migration.types";
 
 // TODO: ANYTIME VERSION CHANGES
@@ -67,6 +68,8 @@ export class MigrationManager {
 			migrate__1_0_0_alpha_15__to_1_0_0_alpha_16,
 		[migrate__1_0_0_alpha_16__to_1_0_0_alpha_17.versionFrom]:
 			migrate__1_0_0_alpha_16__to_1_0_0_alpha_17,
+		[migrate__1_0_0_alpha_17__to___1_0_0_alpha_18.versionFrom]:
+			migrate__1_0_0_alpha_17__to___1_0_0_alpha_18,
 	};
 
 	/**

--- a/libs/renderer/src/store/state/migration/migrate__1_0_0_alpha_17__to___1_0_0_alpha_18.ts
+++ b/libs/renderer/src/store/state/migration/migrate__1_0_0_alpha_17__to___1_0_0_alpha_18.ts
@@ -1,0 +1,15 @@
+import type { Migration, MigrationState } from "./migration.types";
+
+const migrate__1_0_0_alpha_17__to_1_0_0_alpha_18: Migration = {
+	versionFrom: "1.0.0-alpha.17",
+	versionTo: "1.0.0-alpha.18",
+	// This function performs a migration on the state by adding the export button to the layout
+	async run(state: MigrationState): Promise<MigrationState> {
+		const newState: MigrationState = { ...state };
+		// We do not need to modify state queries, variables, etc.
+		// We update the state, so the export button panel can be rendered in the Blocks Workspace layout
+		return newState;
+	},
+};
+
+export default migrate__1_0_0_alpha_17__to_1_0_0_alpha_18;

--- a/packages/client/src/components/blocks-workspace/BlocksWorkspace.tsx
+++ b/packages/client/src/components/blocks-workspace/BlocksWorkspace.tsx
@@ -32,6 +32,7 @@ import { DEFAULT_MENU } from "./menus/default-menu";
 import {
 	BlocksMenuPanel,
 	DesignerPanel,
+	ExportButtonPanel,
 	LayersPanel,
 	NotebookExplorerPanel,
 	NotebookViewerPanel,
@@ -111,6 +112,7 @@ const DEFAULT_OPTIONS: WorkspaceOptions = {
 				location: "right",
 				size: BLOCK_SETTINGS_MIN_WIDTH,
 				minSize: BLOCK_SETTINGS_MIN_WIDTH,
+				selected: 0,
 				children: [
 					{
 						type: "tab",
@@ -121,6 +123,15 @@ const DEFAULT_OPTIONS: WorkspaceOptions = {
 							className: "selected_block",
 						},
 						helpText: "Block Settings",
+					},
+					{
+						type: "tab",
+						id: "export-button",
+						name: "Export",
+						component: "export-button",
+						config: {},
+						helpText: "Export Tool",
+						enableDrag: false,
 					},
 				],
 			},
@@ -318,6 +329,8 @@ export const BlocksWorkspace = observer((props: BlocksWorkspaceProps) => {
 			return <SettingsPanel value={config.value} />;
 		} else if (component === "settings") {
 			return <SettingsNavPanel />; // This is a placeholder for the settings tab, which is handled in the border layout
+		} else if (component === "export-button") {
+			return <ExportButtonPanel />;
 		}
 		return <>{component}</>;
 	};

--- a/packages/client/src/components/blocks-workspace/panels/ExportButtonPanel.tsx
+++ b/packages/client/src/components/blocks-workspace/panels/ExportButtonPanel.tsx
@@ -1,0 +1,615 @@
+import { Sync } from "@mui/icons-material";
+import { observer } from "mobx-react-lite";
+import { useEffect, useId, useMemo, useState } from "react";
+import type { BlockJSON, ListenerActions } from "@semoss/renderer";
+import {
+	ActionMessages,
+	useBlocks,
+	useBlocksPixel,
+	useFrameHeaders,
+} from "@semoss/renderer";
+import {
+	Autocomplete,
+	Box,
+	Button,
+	Chip,
+	IconButton,
+	Stack,
+	Switch,
+	styled,
+	TextField,
+	Typography,
+	useNotification,
+} from "@semoss/ui";
+import { Panel } from "@/components/workspace";
+import { useDesigner } from "@/hooks";
+
+export interface GridBlockColumn {
+	name: string;
+	width?: string;
+	selector: string;
+}
+
+const StyledContainer = styled("div")(({ theme }) => ({
+	display: "flex",
+	flexDirection: "column",
+	gap: theme.spacing(2),
+	padding: theme.spacing(2),
+	height: "100%",
+	overflowY: "auto",
+}));
+
+const StyledFieldWrapper = styled("div")(() => ({
+	display: "flex",
+	flexDirection: "column",
+	justifyContent: "center",
+	paddingTop: "5px",
+	paddingBottom: "5px",
+	gap: "8px",
+}));
+
+const StyledChipsContainer = styled(Box)(({ theme }) => ({
+	display: "flex",
+	flexWrap: "wrap",
+	gap: theme.spacing(1),
+	maxHeight: "20vh",
+	overflowY: "auto",
+	paddingRight: theme.spacing(1),
+	"&::-webkit-scrollbar": {
+		width: "8px",
+	},
+	"&::-webkit-scrollbar-track": {
+		background: "transparent",
+	},
+	"&::-webkit-scrollbar-thumb": {
+		background: theme.palette.mode === "dark" ? "#555" : "#ccc",
+		borderRadius: "4px",
+	},
+	"&::-webkit-scrollbar-thumb:hover": {
+		background: theme.palette.mode === "dark" ? "#777" : "#aaa",
+	},
+}));
+
+const StyledSectionTitle = styled(Typography)(({ theme }) => ({
+	fontSize: "12px",
+	fontWeight: 600,
+	color: theme.palette.text.secondary,
+	textTransform: "uppercase",
+	letterSpacing: "0.5px",
+	marginTop: theme.spacing(1),
+}));
+
+export const ExportButtonPanel = observer(() => {
+	const frameSelectId = useId();
+	const notification = useNotification();
+	const { designer } = useDesigner();
+	const { state } = useBlocks();
+
+	const [selectedFrame, setSelectedFrame] = useState<string>("");
+	const [selectedColumns, setSelectedColumns] = useState<GridBlockColumn[]>(
+		[],
+	);
+	const [downloadType, setDownloadType] = useState<
+		"csv" | "tsv" | "text" | "excel"
+	>("csv");
+	const [delimiter, setDelimiter] = useState<string>("");
+	const [buttonLabel, setButtonLabel] = useState<string>("Export Data");
+	const [isLoading, setIsLoading] = useState(false);
+	const [exportMode, setExportMode] = useState<"button" | "direct">("button");
+	const [previousFrame, setPreviousFrame] = useState<string>("");
+	const [hasInitializedFrame, setHasInitializedFrame] = useState(false);
+
+	// Fetch available frames using useBlocksPixel
+	const getFrames = useBlocksPixel<string[]>("GetFrames();", {
+		data: [],
+	});
+	const availableFrameNames =
+		getFrames.status === "SUCCESS" ? getFrames.data : [];
+
+	// Get frame headers for the selected frame
+	const frameHeaders = useFrameHeaders(selectedFrame);
+
+	// Compute columns from frame headers
+	const frameColumns = useMemo(() => {
+		return frameHeaders.data.list.map((item) => {
+			return {
+				name: item.alias,
+				selector: item.header,
+				width: undefined,
+			};
+		});
+	}, [frameHeaders]);
+
+	// When user selects a NEW frame, mark that we need to initialize columns
+	useEffect(() => {
+		if (selectedFrame !== previousFrame) {
+			setPreviousFrame(selectedFrame);
+			setHasInitializedFrame(false); // Mark that we need to initialize
+		}
+	}, [selectedFrame, previousFrame]);
+
+	// Once frameColumns are loaded for a new frame, populate selectedColumns once per frame
+	useEffect(() => {
+		if (selectedFrame && frameColumns.length > 0 && !hasInitializedFrame) {
+			// Only set once when columns first load for this frame
+			setSelectedColumns([...frameColumns]);
+			setHasInitializedFrame(true);
+		}
+		if (!selectedFrame) {
+			setSelectedColumns([]);
+		}
+	}, [frameColumns, selectedFrame, hasInitializedFrame]);
+
+	/**
+	 * Refresh the available frames list
+	 */
+	const handleRefreshFrames = () => {
+		getFrames.refresh();
+		notification.add({
+			color: "success",
+			message: "Frames refreshed",
+		});
+	};
+
+	/**
+	 * Remove a column from the selected columns list
+	 */
+	const handleRemoveColumn = (columnNameToRemove: string) => {
+		const updatedColumns = selectedColumns.filter(
+			(col) => col.name !== columnNameToRemove,
+		);
+		setSelectedColumns(updatedColumns);
+	};
+
+	/**
+	 * Reset selection to include all available columns
+	 */
+	const handleReset = () => {
+		if (frameColumns.length > 0) {
+			setSelectedColumns([...frameColumns]);
+		}
+	};
+
+	/**
+	 * Find an existing notebook with matching pixel statement
+	 */
+	const findMatchingNotebook = (
+		targetPixelStatement: string,
+	): string | null => {
+		const allQueries = state.queries; // Get all queries/notebooks
+
+		for (const queryId in allQueries) {
+			const queryData = allQueries[queryId];
+			// Check if the notebook has cells
+			if (queryData.cells) {
+				// Get all cell IDs from the cells object
+				const cellIds = Object.keys(queryData.cells);
+				if (cellIds.length > 0) {
+					// Get the first cell
+					const firstCellId = cellIds[0];
+					const firstCell = queryData.cells[firstCellId];
+					if (
+						firstCell &&
+						firstCell.parameters?.type === "pixel" &&
+						firstCell.parameters?.code === targetPixelStatement
+					) {
+						return queryId;
+					}
+				}
+			}
+		}
+
+		return null;
+	};
+
+	/**
+	 * Create an export button and place it in the layer
+	 */
+	const handleCreateExportButton = async () => {
+		try {
+			setIsLoading(true);
+
+			// Validate delimiter for text format
+			if (downloadType === "text" && !delimiter.trim()) {
+				notification.add({
+					color: "warning",
+					message:
+						"Delimiter is not defined. Please enter a delimiter for the file.",
+				});
+				return;
+			}
+
+			// Validate that we have the required data
+			if (!selectedFrame || selectedColumns.length === 0) {
+				notification.add({
+					color: "error",
+					message: "Please select a frame and at least one column",
+				});
+				return;
+			}
+
+			// Build the pixel statement
+			const columnNames = selectedColumns
+				.map((col) => col.name)
+				.join(",");
+
+			let conversionFunction = "ToCsv()";
+			if (downloadType === "csv") {
+				conversionFunction = "ToCsv()";
+			} else if (downloadType === "tsv") {
+				conversionFunction = "ToTsv()";
+			} else if (downloadType === "text") {
+				conversionFunction = `ToTxt(delimiter=["${delimiter}"])`;
+			} else if (downloadType === "excel") {
+				conversionFunction = "ToExcel()";
+			}
+
+			const pixelStatement = `Frame(frame=[${selectedFrame}])|Select(${columnNames})|${conversionFunction}`;
+
+			// Check if a notebook with this exact pixel statement already exists
+			let finalNotebookName = findMatchingNotebook(pixelStatement);
+			let isNewNotebook = true;
+
+			// If no matching notebook exists, create a new one
+			if (!finalNotebookName) {
+				const notebookName = `export_${selectedFrame}_${downloadType}`;
+
+				// Find a unique name for the new notebook
+				finalNotebookName = notebookName;
+				let count = 1;
+				while (state.getQuery(finalNotebookName)) {
+					finalNotebookName = `${notebookName} (${count})`;
+					count++;
+				}
+
+				// Create a new code cell with the pixel statement
+				await state.dispatch({
+					message: ActionMessages.NEW_QUERY,
+					payload: {
+						queryId: finalNotebookName,
+						config: {
+							cells: [
+								{
+									id: "1",
+									widget: "code",
+									parameters: {
+										type: "pixel",
+										code: pixelStatement,
+									},
+								},
+							],
+						},
+					},
+				});
+			} else {
+				isNewNotebook = false;
+			}
+
+			// Determine the parent for placement
+			// If a block is selected, use its parent; otherwise use the root page
+			let parentId = "page-1"; // default to main page
+			let parentSlot = "content";
+
+			if (designer.selected) {
+				const selectedBlock = state.getBlock(designer.selected);
+				if (selectedBlock?.parent) {
+					parentId = selectedBlock.parent.id;
+					parentSlot = selectedBlock.parent.slot || "content";
+				}
+			}
+
+			// Create a listener action that runs the export query when the button is clicked
+			const runQueryAction: ListenerActions = {
+				message: ActionMessages.RUN_QUERY,
+				payload: {
+					queryId: finalNotebookName,
+				},
+			};
+
+			if (exportMode === "direct") {
+				// Direct export mode: just run the query immediately
+				await state.dispatch({
+					message: ActionMessages.RUN_QUERY,
+					payload: {
+						queryId: finalNotebookName,
+					},
+				});
+
+				notification.add({
+					color: "success",
+					message: isNewNotebook
+						? `Exporting data from ${selectedFrame}...`
+						: `Exporting data from existing query...`,
+				});
+			} else {
+				// Button mode: create a button block that triggers the export
+				// Create the button block JSON structure
+				const buttonBlockJSON: BlockJSON = {
+					widget: "button",
+					data: {
+						style: {},
+						label: buttonLabel,
+						variant: "contained",
+						color: "primary",
+						show: "true",
+						type: "button",
+					},
+					listeners: {
+						onClick: {
+							type: "sync",
+							order: [runQueryAction],
+						},
+						preProcess: {
+							type: "sync",
+							order: [],
+						},
+					},
+					slots: {},
+				};
+
+				// Add the button block to the selected layer
+				await state.dispatch({
+					message: ActionMessages.ADD_BLOCK,
+					payload: {
+						json: buttonBlockJSON,
+						position: {
+							parent: parentId,
+							slot: parentSlot,
+						},
+					},
+				});
+
+				notification.add({
+					color: "success",
+					message: isNewNotebook
+						? `Export button "${buttonLabel}" created and added to layer`
+						: `Export button "${buttonLabel}" created (using existing query)`,
+				});
+			}
+		} catch (error) {
+			console.error("Error creating export button:", error);
+			notification.add({
+				color: "error",
+				message: "Failed to create export button",
+			});
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	return (
+		<Panel>
+			<StyledContainer>
+				<div>
+					<Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+						Export Data
+					</Typography>
+					{/* Frame Selection */}
+					<StyledSectionTitle variant="body2">
+						Frame
+					</StyledSectionTitle>
+					<StyledFieldWrapper>
+						<Stack direction="row" spacing={1}>
+							<Autocomplete
+								fullWidth
+								id={`export-frame-select-${frameSelectId}`}
+								multiple={false}
+								disabled={getFrames.status !== "SUCCESS"}
+								value={selectedFrame}
+								options={availableFrameNames}
+								getOptionLabel={(option) => option}
+								onChange={(_, value) => {
+									setSelectedFrame(value || "");
+								}}
+								freeSolo={false}
+								renderInput={(params) => (
+									<TextField
+										{...params}
+										placeholder="Select frame"
+										size="small"
+										variant="outlined"
+									/>
+								)}
+							/>
+							<IconButton
+								size="small"
+								onClick={handleRefreshFrames}
+								title="Refresh frames"
+								sx={{ mt: 0.5 }}
+							>
+								<Sync fontSize="medium" />
+							</IconButton>
+						</Stack>
+					</StyledFieldWrapper>
+					{/* Column Selection */}
+					{selectedFrame && (
+						<>
+							<StyledSectionTitle variant="body2">
+								Columns ({selectedColumns?.length || 0})
+							</StyledSectionTitle>
+							<StyledFieldWrapper>
+								<StyledChipsContainer>
+									{selectedColumns?.map((col) => (
+										<Chip
+											key={col.name}
+											label={col.name}
+											size="small"
+											variant="outlined"
+											onDelete={() =>
+												handleRemoveColumn(col.name)
+											}
+										/>
+									))}
+									{!selectedColumns?.length && (
+										<Typography
+											variant="body2"
+											color="secondary"
+										>
+											No columns selected
+										</Typography>
+									)}
+								</StyledChipsContainer>
+								<Stack
+									display="flex"
+									flexDirection="row"
+									gap={1}
+									justifyContent="flex-end"
+								>
+									<Button
+										size="small"
+										color="primary"
+										variant="outlined"
+										onClick={handleReset}
+										disabled={
+											selectedColumns.length ===
+											frameColumns.length
+										}
+									>
+										Reset
+									</Button>
+								</Stack>
+							</StyledFieldWrapper>
+						</>
+					)}
+					{/* Download Type Selection */}
+					{selectedFrame && (
+						<StyledFieldWrapper>
+							<Autocomplete
+								fullWidth
+								multiple={false}
+								value={downloadType}
+								options={["", "csv", "tsv", "text", "excel"]}
+								onChange={(_, value) =>
+									setDownloadType(
+										(value || "csv") as
+											| "csv"
+											| "tsv"
+											| "text"
+											| "excel",
+									)
+								}
+								getOptionLabel={(option) =>
+									option === "csv"
+										? "CSV"
+										: option === "tsv"
+											? "TSV"
+											: option === "text"
+												? "Text"
+												: option === "excel"
+													? "Excel"
+													: ""
+								}
+								renderInput={(params) => (
+									<TextField
+										{...params}
+										label="Download Type"
+										size="small"
+									/>
+								)}
+							/>
+
+							{downloadType === "text" && (
+								<TextField
+									size="small"
+									label="Delimiter"
+									value={delimiter}
+									onChange={(e) =>
+										setDelimiter(e.target.value)
+									}
+									placeholder=","
+									fullWidth
+									helperText='Enter the delimiter (e.g., "," or "|")'
+								/>
+							)}
+						</StyledFieldWrapper>
+					)}
+					{/* Export Mode Toggle */}
+					{selectedFrame && (
+						<StyledFieldWrapper>
+							<Stack
+								direction="row"
+								alignItems="center"
+								spacing={1}
+							>
+								<StyledSectionTitle variant="body2">
+									Direct Export
+								</StyledSectionTitle>
+								<Stack
+									direction="row"
+									alignItems="center"
+									spacing={0.5}
+								>
+									<Switch
+										size="small"
+										checked={exportMode === "direct"}
+										onChange={(
+											e: React.ChangeEvent<HTMLInputElement>,
+										) =>
+											setExportMode(
+												e.target.checked
+													? "direct"
+													: "button",
+											)
+										}
+									/>
+								</Stack>
+							</Stack>
+						</StyledFieldWrapper>
+					)}
+					{/* Button Label - Only show for button mode */}
+					{selectedFrame && exportMode === "button" && (
+						<StyledFieldWrapper>
+							<TextField
+								size="small"
+								label="Button Label"
+								value={buttonLabel}
+								onChange={(e) => setButtonLabel(e.target.value)}
+								placeholder="Export Data"
+								fullWidth
+							/>
+						</StyledFieldWrapper>
+					)}
+					{/* Create Button or Export Button - conditionally rendered */}
+					{selectedFrame && (
+						<StyledFieldWrapper sx={{ mt: 2 }}>
+							<Button
+								size="medium"
+								color="primary"
+								variant="contained"
+								onClick={handleCreateExportButton}
+								disabled={
+									selectedColumns.length === 0 ||
+									isLoading ||
+									(exportMode === "button" &&
+										!buttonLabel.trim())
+								}
+								fullWidth
+							>
+								{isLoading
+									? "Processing..."
+									: exportMode === "button"
+										? "Create Export Button"
+										: "Export Data"}
+							</Button>
+						</StyledFieldWrapper>
+					)}{" "}
+					{availableFrameNames.length === 0 && (
+						<Box
+							sx={{
+								mt: 2,
+								p: 2,
+								bgcolor: "warning.lighter",
+								borderRadius: 1,
+							}}
+						>
+							<Typography variant="body2" color="warning">
+								No frames found. Create a frame or refresh
+								frames to get started.
+							</Typography>
+						</Box>
+					)}
+				</div>
+			</StyledContainer>
+		</Panel>
+	);
+});

--- a/packages/client/src/components/blocks-workspace/panels/index.ts
+++ b/packages/client/src/components/blocks-workspace/panels/index.ts
@@ -1,5 +1,6 @@
 export * from "./BlocksMenuPanel";
 export * from "./DesignerPanel";
+export * from "./ExportButtonPanel";
 export * from "./LayersPanel";
 export * from "./NotebookExplorerPanel";
 export * from "./NotebookViewerPanel";

--- a/packages/client/src/components/flex-layout/flexlayout.css
+++ b/packages/client/src/components/flex-layout/flexlayout.css
@@ -54,6 +54,17 @@
     line-height: 18px; /* 138.462% */
 }
 
+.flexlayout__border_button_right.flexlayout__border_button--unselected {
+    background-color: var(--Secondary-Selected, #ebebeb);
+    color: var(--text-secondary, #666);
+}
+
+
+.flexlayout__border_button_right.flexlayout__border_button:hover {
+    background: var(--Primary-Selected, #ebf4fe);
+    color: var(--text-secondary, #666);
+}
+
 .flexlayout__border_left .flexlayout__border_button--selected {
     background-color: rgb(255, 255, 255);
     color: rgb(4, 113, 240);


### PR DESCRIPTION
## Description
We add in a new standalone Export Data panel that allows users to create export buttons or directly export data from data frames. We also add a new Export button for the flex layout on the right panel.

## Changes Made
- Toggle between creating an export button or directly exporting data
- Dropdown to select from available frames with manual refresh capability
- Select/deselect specific columns with a reset button to restore all columns
- Dropdown for multiple export formats (CSV, TSV, Excel, and Text) 

- Automatic notebooks creation with format [export_[frame]_[type]. As well, detection to reuses existing notebooks with identical export configurations to prevent duplicates.
- New Migration file that reloads the state of the layout to add Export button to older applications and to new applications.

## How to Test
1. Create a Drag & Drop Application.
2. Open the 'Export Data' panel by clicking the 'Export' button. Check that there is a warning of no valid data frames.
3. Create a notebook and create a Frame with valid data.
4. Click on the refresh button to update the dropdown and select the frame you created.
5. Select / Deselect columns from the frame. (Check if the reset button works)
6. Select Export Type
7. Create export button, and check if notebook and button was created.
8. Switch the toggle, and run the export and see if you get a valid export.
9. Go back to creating a button OR exporting live, and change up the different inputs and see if you get the desired outcomes.
