### PR TITLE
Allow users to cancel tools

### DIFF
--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -108,7 +108,11 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 								className="ml-1 flex size-9 flex-col items-center justify-center overflow-hidden rounded bg-destructive/10 p-2 text-destructive hover:bg-destructive/20"
 								onClick={(e) => {
 									e.stopPropagation();
-									console.log("cancelled");
+									message.saveToolExecution(
+										tool,
+										"This tool execution was cancelled by the user.",
+										true,
+									);
 								}}
 							>
 								<XIcon />

--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -46,7 +46,7 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 
 		return (
 			<div
-				className={`group flex w-full flex-row items-center gap-5 rounded-lg border border-border bg-primary-foreground p-4 text-left shadow-sm ${
+				className={`group/toolcard flex w-full flex-row items-center gap-5 rounded-lg border border-border bg-primary-foreground p-4 text-left shadow-sm ${
 					isDisabled
 						? "cursor-not-allowed opacity-50"
 						: `cursor-pointer hover:bg-accent ${isActive ? "border-primary" : ""}`
@@ -104,7 +104,7 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 									: tool._meta.map.SMSS_MCP_EXECUTION ===
 											"ask"
 										? "Click to open"
-										: ""}
+										: "This tool is set to auto-execute"}
 						</div>
 					</div>
 				</button>
@@ -113,7 +113,7 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 						type="button"
 						size="sm"
 						variant="outline"
-						className="border-primary/20 bg-primary/10 text-primary hover:bg-primary/20"
+						className="invisible hover:text-destructive group-hover/toolcard:visible"
 						onClick={(e) => {
 							e.stopPropagation();
 							message.saveToolExecution(

--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -1,6 +1,6 @@
-import { CheckIcon, HammerIcon, XCircleIcon, XIcon } from "lucide-react";
+import { CheckIcon, HammerIcon, XCircleIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@semoss/ui/next";
+import { Button } from "@semoss/ui/next";
 import type { ResponseMessageStore } from "@/stores";
 
 // Styled component replaced with Tailwind classes inline
@@ -101,25 +101,19 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 					</div>
 				</button>
 				{!tool.response && (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<button
-								type="button"
-								className="ml-1 flex size-9 flex-col items-center justify-center overflow-hidden rounded bg-destructive/10 p-2 text-destructive hover:bg-destructive/20"
-								onClick={(e) => {
-									e.stopPropagation();
-									message.saveToolExecution(
-										tool,
-										"This tool execution was intentionally cancelled by the user. The AI assistant should either proceed without using this tool if possible, choose another tool if necessary, or ask the user for further instructions.",
-										true,
-									);
-								}}
-							>
-								<XIcon />
-							</button>
-						</TooltipTrigger>
-						<TooltipContent>Cancel tool execution</TooltipContent>
-					</Tooltip>
+					<Button
+						type="button"
+						onClick={(e) => {
+							e.stopPropagation();
+							message.saveToolExecution(
+								tool,
+								"This tool execution was intentionally cancelled by the user. The AI assistant should either proceed without using this tool if possible, choose another tool if necessary, or ask the user for further instructions.",
+								true,
+							);
+						}}
+					>
+						Cancel
+					</Button>
 				)}
 			</div>
 		);

--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -110,7 +110,7 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 									e.stopPropagation();
 									message.saveToolExecution(
 										tool,
-										"This tool execution was cancelled by the user.",
+										"This tool execution was intentionally cancelled by the user. The AI assistant should either proceed without using this tool if possible, choose another tool if necessary, or ask the user for further instructions.",
 										true,
 									);
 								}}

--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -1,5 +1,6 @@
-import { CheckIcon, HammerIcon, XCircleIcon } from "lucide-react";
+import { CheckIcon, HammerIcon, XCircleIcon, XIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@semoss/ui/next";
 import type { ResponseMessageStore } from "@/stores";
 
 // Styled component replaced with Tailwind classes inline
@@ -44,58 +45,79 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 		}
 
 		return (
-			<button
-				type="button"
-				disabled={isDisabled}
+			<div
 				className={`group flex w-full flex-row items-center gap-5 rounded-lg border border-border bg-primary-foreground p-4 text-left shadow-sm ${
 					isDisabled
 						? "cursor-not-allowed opacity-50"
 						: `cursor-pointer hover:bg-accent ${isActive ? "border-primary" : ""}`
 				}`}
-				onClick={() => {
-					if (room.isSidebarNodeSelected(nodeId)) {
-						room.removeSidebarNode(nodeId);
-					} else {
-						// open the sidebar
-						room.addSidebarNode(nodeId, {
-							type: "tab",
-							name: tool.title,
-							component: "room-tool",
-							config: {
-								app: tool._meta.map.SMSS_PROJECT_ID,
-								tool: {
-									message: message.id,
-									id: tool.id,
-									name: tool.name,
-									parameters: tool.parameters,
-								},
-							},
-							enableClose: true,
-						});
-					}
-				}}
 			>
-				<div
-					className={`mr-1 flex size-9 flex-col items-center justify-center overflow-hidden rounded p-2 ${
-						tool.cancelled
-							? "bg-destructive/10 text-destructive"
-							: "bg-primary/10 text-primary"
-					}`}
+				<button
+					type="button"
+					disabled={isDisabled}
+					className="flex flex-1 flex-row items-center gap-5 text-left"
+					onClick={() => {
+						if (room.isSidebarNodeSelected(nodeId)) {
+							room.removeSidebarNode(nodeId);
+						} else {
+							// open the sidebar
+							room.addSidebarNode(nodeId, {
+								type: "tab",
+								name: tool.title,
+								component: "room-tool",
+								config: {
+									app: tool._meta.map.SMSS_PROJECT_ID,
+									tool: {
+										message: message.id,
+										id: tool.id,
+										name: tool.name,
+										parameters: tool.parameters,
+									},
+								},
+								enableClose: true,
+							});
+						}
+					}}
 				>
-					{icon}
-				</div>
-				<div className="flex-1">
-					<div className="truncate text-base" title={tool.title}>
-						{tool.title}
-					</div>
 					<div
-						className="truncate text-muted-foreground text-sm"
-						title={tool.title}
+						className={`mr-1 flex size-9 flex-col items-center justify-center overflow-hidden rounded p-2 ${
+							tool.cancelled
+								? "bg-destructive/10 text-destructive"
+								: "bg-primary/10 text-primary"
+						}`}
 					>
-						{tool.title}
+						{icon}
 					</div>
-				</div>
-			</button>
+					<div className="flex-1">
+						<div className="truncate text-base" title={tool.title}>
+							{tool.title}
+						</div>
+						<div
+							className="truncate text-muted-foreground text-sm"
+							title={tool.title}
+						>
+							{tool.title}
+						</div>
+					</div>
+				</button>
+				{!tool.response && (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<button
+								type="button"
+								className="ml-1 flex size-9 flex-col items-center justify-center overflow-hidden rounded bg-destructive/10 p-2 text-destructive hover:bg-destructive/20"
+								onClick={(e) => {
+									e.stopPropagation();
+									console.log("cancelled");
+								}}
+							>
+								<XIcon />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent>Cancel tool execution</TooltipContent>
+					</Tooltip>
+				)}
+			</div>
 		);
 	},
 );

--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -41,9 +41,9 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 		}
 
 		let icon = null;
-		if (tool.toolStatus === "error") {
+		if (tool.tool_status === "error") {
 			icon = <AlertTriangleIcon />;
-		} else if (tool.toolStatus === "cancelled") {
+		} else if (tool.tool_status === "cancelled") {
 			icon = <XCircleIcon />;
 		} else if (tool.response) {
 			icon = <CheckIcon />;
@@ -88,8 +88,8 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 				>
 					<div
 						className={`mr-1 flex size-9 flex-col items-center justify-center overflow-hidden rounded p-2 ${
-							tool.toolStatus === "error" ||
-							tool.toolStatus === "cancelled"
+							tool.tool_status === "error" ||
+							tool.tool_status === "cancelled"
 								? "bg-destructive/10 text-destructive"
 								: "bg-primary/10 text-primary"
 						}`}
@@ -105,9 +105,9 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 							title={tool.title}
 						>
 							{/* {tool.title} */}
-							{tool.toolStatus === "error"
+							{tool.tool_status === "error"
 								? "Failed to execute tool"
-								: tool.toolStatus === "cancelled"
+								: tool.tool_status === "cancelled"
 									? "Tool execution cancelled"
 									: tool.response
 										? "Completed"

--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -1,4 +1,9 @@
-import { CheckIcon, HammerIcon, XCircleIcon } from "lucide-react";
+import {
+	AlertTriangleIcon,
+	CheckIcon,
+	HammerIcon,
+	XCircleIcon,
+} from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { Button } from "@semoss/ui/next";
 import type { ResponseMessageStore } from "@/stores";
@@ -36,7 +41,9 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 		}
 
 		let icon = null;
-		if (tool.cancelled) {
+		if (tool.status === "error") {
+			icon = <AlertTriangleIcon />;
+		} else if (tool.status === "cancelled") {
 			icon = <XCircleIcon />;
 		} else if (tool.response) {
 			icon = <CheckIcon />;
@@ -81,7 +88,8 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 				>
 					<div
 						className={`mr-1 flex size-9 flex-col items-center justify-center overflow-hidden rounded p-2 ${
-							tool.cancelled
+							tool.status === "error" ||
+							tool.status === "cancelled"
 								? "bg-destructive/10 text-destructive"
 								: "bg-primary/10 text-primary"
 						}`}
@@ -97,14 +105,16 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 							title={tool.title}
 						>
 							{/* {tool.title} */}
-							{tool.cancelled
-								? "Cancelled"
-								: tool.response
-									? "Completed"
-									: tool._meta.map.SMSS_MCP_EXECUTION ===
-											"ask"
-										? "Click to open"
-										: "This tool is set to auto-execute"}
+							{tool.status === "error"
+								? "Failed to execute tool"
+								: tool.status === "cancelled"
+									? "Tool execution cancelled"
+									: tool.response
+										? "Completed"
+										: tool._meta.map.SMSS_MCP_EXECUTION ===
+												"ask"
+											? "Click to open"
+											: "This tool is set to auto-execute"}
 						</div>
 					</div>
 				</button>
@@ -119,7 +129,7 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 							message.saveToolExecution(
 								tool,
 								`This tool execution was intentionally cancelled by the user. The AI assistant should inform the user of the tool's cancellation and ask the user for further instructions. The AI assistant may mention alternative tools or actions to take next, but should not take any further actions or select any further tools without user input.`,
-								true,
+								"cancelled",
 							);
 						}}
 					>

--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -103,6 +103,9 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 				{!tool.response && (
 					<Button
 						type="button"
+						size="sm"
+						variant="outline"
+						className="border-primary/20 bg-primary/10 text-primary hover:bg-primary/20"
 						onClick={(e) => {
 							e.stopPropagation();
 							message.saveToolExecution(

--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -41,9 +41,9 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 		}
 
 		let icon = null;
-		if (tool.status === "error") {
+		if (tool.toolStatus === "error") {
 			icon = <AlertTriangleIcon />;
-		} else if (tool.status === "cancelled") {
+		} else if (tool.toolStatus === "cancelled") {
 			icon = <XCircleIcon />;
 		} else if (tool.response) {
 			icon = <CheckIcon />;
@@ -88,8 +88,8 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 				>
 					<div
 						className={`mr-1 flex size-9 flex-col items-center justify-center overflow-hidden rounded p-2 ${
-							tool.status === "error" ||
-							tool.status === "cancelled"
+							tool.toolStatus === "error" ||
+							tool.toolStatus === "cancelled"
 								? "bg-destructive/10 text-destructive"
 								: "bg-primary/10 text-primary"
 						}`}
@@ -105,9 +105,9 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 							title={tool.title}
 						>
 							{/* {tool.title} */}
-							{tool.status === "error"
+							{tool.toolStatus === "error"
 								? "Failed to execute tool"
-								: tool.status === "cancelled"
+								: tool.toolStatus === "cancelled"
 									? "Tool execution cancelled"
 									: tool.response
 										? "Completed"

--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, HammerIcon } from "lucide-react";
+import { CheckIcon, HammerIcon, XCircleIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import type { ResponseMessageStore } from "@/stores";
 
@@ -35,7 +35,9 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 		}
 
 		let icon = null;
-		if (tool.response) {
+		if (tool.cancelled) {
+			icon = <XCircleIcon />;
+		} else if (tool.response) {
 			icon = <CheckIcon />;
 		} else {
 			icon = <HammerIcon />;
@@ -74,7 +76,11 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 				}}
 			>
 				<div
-					className={`mr-1 flex size-9 flex-col items-center justify-center overflow-hidden rounded bg-primary/10 p-2 text-primary`}
+					className={`mr-1 flex size-9 flex-col items-center justify-center overflow-hidden rounded p-2 ${
+						tool.cancelled
+							? "bg-destructive/10 text-destructive"
+							: "bg-primary/10 text-primary"
+					}`}
 				>
 					{icon}
 				</div>

--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -96,7 +96,15 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 							className="truncate text-muted-foreground text-sm"
 							title={tool.title}
 						>
-							{tool.title}
+							{/* {tool.title} */}
+							{tool.cancelled
+								? "Cancelled"
+								: tool.response
+									? "Completed"
+									: tool._meta.map.SMSS_MCP_EXECUTION ===
+											"ask"
+										? "Click to open"
+										: ""}
 						</div>
 					</div>
 				</button>

--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -118,7 +118,7 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 							e.stopPropagation();
 							message.saveToolExecution(
 								tool,
-								"This tool execution was intentionally cancelled by the user. The AI assistant should either proceed without using this tool if possible, choose another tool if necessary, or ask the user for further instructions.",
+								`This tool execution was intentionally cancelled by the user. The AI assistant should inform the user of the tool's cancellation and ask the user for further instructions. The AI assistant may mention alternative tools or actions to take next, but should not take any further actions or select any further tools without user input.`,
 								true,
 							);
 						}}

--- a/packages/playground/src/components/message/response-message.tsx
+++ b/packages/playground/src/components/message/response-message.tsx
@@ -1,6 +1,7 @@
 import {
 	ArrowLeftIcon,
 	ArrowRightIcon,
+	CircleAlert,
 	CopyIcon,
 	MessageCircleIcon,
 	RefreshCwIcon,
@@ -80,8 +81,12 @@ export const ResponseMessage: React.FC<ResponseMessageProps> = observer(
 			}
 		};
 
+		const areToolsActive =
+			message.type === "RESPONSE" &&
+			message.tools.some((tool) => !tool.response);
+
 		return (
-			<div className="group mb-0 flex w-full flex-col gap-2 overflow-hidden">
+			<div className="group mb-0 flex w-full flex-col gap-2">
 				<div className="group flex flex-row items-center gap-2">
 					<MessageCircleIcon className="size-4" />
 					<span className="mr-0.5 font-medium text-base">
@@ -100,8 +105,14 @@ export const ResponseMessage: React.FC<ResponseMessageProps> = observer(
 						tool={t}
 					/>
 				))}
+				{areToolsActive && (
+					<p className="mt-2 flex items-center gap-2 text-muted-foreground text-sm">
+						<CircleAlert className="size-4" />
+						Please complete the tool(s) to proceed.
+					</p>
+				)}
 
-				<div className="flex flex-1 flex-row items-center justify-start gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+				<div className="-ml-2.5 flex flex-1 flex-row items-center justify-start gap-1 opacity-0 transition-opacity group-hover:opacity-100">
 					{inputMessage?.siblings.length > 1 && (
 						<>
 							<Tooltip>

--- a/packages/playground/src/components/room/room.tsx
+++ b/packages/playground/src/components/room/room.tsx
@@ -137,11 +137,18 @@ export const Room: React.FC<RoomProps> = observer(({ room }) => {
 		};
 	}, [room]);
 
+	/**
+	 * Constants
+	 */
 	const isDisabled =
 		Boolean(room.error) ||
 		room.mode === "executing" ||
 		(room.tail.type === "RESPONSE" &&
-			room.tail.tools.some((tool) => !tool.response));
+			room.history.some(
+				(message) =>
+					message.type === "RESPONSE" &&
+					message.tools.some((tool) => !tool.response),
+			));
 
 	return (
 		<div className="flex h-full w-full flex-col bg-secondary-background transition-all duration-200 ease-in-out">

--- a/packages/playground/src/components/room/room.tsx
+++ b/packages/playground/src/components/room/room.tsx
@@ -137,7 +137,11 @@ export const Room: React.FC<RoomProps> = observer(({ room }) => {
 		};
 	}, [room]);
 
-	const isDisabled = Boolean(room.error) || room.mode === "executing";
+	const isDisabled =
+		Boolean(room.error) ||
+		room.mode === "executing" ||
+		(room.tail.type === "RESPONSE" &&
+			room.tail.tools.some((tool) => !tool.response));
 
 	return (
 		<div className="flex h-full w-full flex-col bg-secondary-background transition-all duration-200 ease-in-out">

--- a/packages/playground/src/stores/message/abstract-message.store.ts
+++ b/packages/playground/src/stores/message/abstract-message.store.ts
@@ -1,6 +1,6 @@
 import { action, computed, makeObservable, observable } from "mobx";
-import type { RoomStore } from "@/stores";
-import type { AbstractPixelMessage } from "@/types";
+import type { ResponseMessageStore, RoomStore } from "@/stores";
+import type { AbstractPixelMessage, PixelMessage } from "@/types";
 
 /**
  * Abstract Message Store
@@ -25,6 +25,11 @@ export abstract class AbstractMessageStore {
 	 * Track if it is an root, input, or response message
 	 */
 	abstract type: "ROOT" | "PLAN" | "INPUT" | "RESPONSE";
+
+	/**
+	 * Track its pixelMessageType
+	 */
+	abstract pixelMessageType: PixelMessage["type"];
 
 	/**
 	 * Parent of the message
@@ -140,6 +145,20 @@ export abstract class AbstractMessageStore {
 	addChild = (message: AbstractMessageStore) => {
 		// store it
 		this.children.push(message);
+
+		// if the child is an INPUT_TOOL_EXEC, find the related tool message and mark its response
+		if (message.pixelMessageType === "INPUT_TOOL_EXEC") {
+			let currentMessage: AbstractMessageStore | null = this;
+			while (currentMessage !== null) {
+				if (currentMessage.pixelMessageType === "RESPONSE_TOOL") break;
+				currentMessage = currentMessage.parent;
+			}
+			if (currentMessage !== null) {
+				(currentMessage as ResponseMessageStore).markToolAsUsed(
+					(message as ResponseMessageStore).inputToolExecData,
+				);
+			}
+		}
 
 		// last idx is the position
 		const position = this.children.length - 1;

--- a/packages/playground/src/stores/message/input-message.store.ts
+++ b/packages/playground/src/stores/message/input-message.store.ts
@@ -7,6 +7,9 @@ import { AbstractMessageStore } from "./abstract-message.store";
  */
 export class InputMessageStore extends AbstractMessageStore {
 	readonly type = "INPUT";
+	readonly pixelMessageType:
+		| InputTextPixelMessage["type"]
+		| InputMediaPixelMessage["type"];
 
 	/**
 	 * Text associated with the message
@@ -29,6 +32,7 @@ export class InputMessageStore extends AbstractMessageStore {
 		message: InputTextPixelMessage | InputMediaPixelMessage,
 	) {
 		super(room, message);
+		this.pixelMessageType = message.type;
 
 		this.text = message.inputUIPrompt;
 		this.mediaInputs = message.mediaInputs;

--- a/packages/playground/src/stores/message/plan-message.store.ts
+++ b/packages/playground/src/stores/message/plan-message.store.ts
@@ -17,6 +17,8 @@ import { createMessageStore } from "./utility";
  */
 export class PlanMessageStore extends AbstractMessageStore {
 	readonly type = "PLAN";
+	readonly pixelMessageType: ResponseTextPixelMessage["type"] =
+		"RESPONSE_TEXT";
 
 	/**
 	 * Text associated with the message

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -17,6 +17,10 @@ import { createMessageStore } from "./utility";
  */
 export class ResponseMessageStore extends AbstractMessageStore {
 	readonly type = "RESPONSE";
+	readonly pixelMessageType:
+		| ResponseTextPixelMessage["type"]
+		| ResponseToolPixelMessage["type"]
+		| InputToolExecPixelMessage["type"];
 
 	/**
 	 * Text associated with the message
@@ -51,6 +55,14 @@ export class ResponseMessageStore extends AbstractMessageStore {
 		/** Response for the tool */
 		response: string;
 	}[] = [];
+
+	/**
+	 * If this is input tool exec, the tool call id it is executing
+	 */
+	inputToolExecData: {
+		toolCallId: string;
+		inputPrompt: string;
+	} | null = null;
 
 	/**
 	 * Current execution index of the tool
@@ -90,6 +102,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 			| InputToolExecPixelMessage,
 	) {
 		super(room, message);
+		this.pixelMessageType = message.type;
 
 		if (message.type === "RESPONSE_TEXT") {
 			this.text = message.content;
@@ -109,6 +122,13 @@ export class ResponseMessageStore extends AbstractMessageStore {
 				parameters: t.arguments,
 				response: "",
 			}));
+		}
+
+		if (message.type === "INPUT_TOOL_EXEC") {
+			this.inputToolExecData = {
+				toolCallId: message.tool_call_id,
+				inputPrompt: message.inputPrompt,
+			};
 		}
 
 		// set the model
@@ -326,7 +346,7 @@ paramValues=[${JSON.stringify({
 	};
 
 	/**
-	 * Save a tool execution responsex
+	 * Save a tool execution response
 	 * @param tool - tool to save
 	 * @param toolResponse - response of the tool
 	 */
@@ -380,5 +400,30 @@ paramValues=[${JSON.stringify({})}]
 			// start running tools if there are any
 			(responseMessage as ResponseMessageStore).startToolExecution();
 		}
+	};
+
+	/**
+	 * Mark a tool as used. Should be called when reconstructing from an INPUT_TOOL_EXEC message
+	 * @param tool - tool to save
+	 * @param toolResponse - response of the tool
+	 */
+	markToolAsUsed = (inputToolExecData: {
+		toolCallId: string;
+		inputPrompt: string;
+	}): void => {
+		// find the correct tool
+		const tool = this.tools.find(
+			(t) => t.id === inputToolExecData.toolCallId,
+		);
+		if (!tool) {
+			return;
+		}
+
+		const toolResponse = inputToolExecData.inputPrompt;
+
+		// save the response
+		runInAction(() => {
+			tool.response = toolResponse;
+		});
 	};
 }

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -56,7 +56,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 		response: string;
 
 		/** If the tool execution was cancelled or errored */
-		toolStatus?: "success" | "error" | "cancelled";
+		tool_status?: "success" | "error" | "cancelled";
 	}[] = [];
 
 	/**
@@ -133,7 +133,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 			this.inputToolExecData = {
 				toolCallId: message.tool_call_id,
 				inputPrompt: message.inputPrompt,
-				toolStatus: "success", // default to success, implement in the future
+				toolStatus: message.tool_status ?? "success", // default to success
 			};
 		}
 
@@ -375,8 +375,7 @@ paramValues=[${JSON.stringify({
 		// save the response
 		runInAction(() => {
 			tool.response = toolResponse;
-			// in the future, would like to pass status to AddPlaygroundToolExecution too
-			tool.toolStatus = status;
+			tool.tool_status = status;
 		});
 
 		// wait for the pixel to run
@@ -394,7 +393,8 @@ ${this.id ? `parentMessageId=["${this.id}"],` : ""}
 toolId = ["${tool.id}"],
 toolName=["${tool.name}"],
 toolExecutionResponse=["<encode>${toolResponse}</encode>"],
-paramValues=[${JSON.stringify({})}]
+paramValues=[${JSON.stringify({})}],
+mcpToolStatus=${JSON.stringify(status)}
 );`,
 		);
 
@@ -423,13 +423,11 @@ paramValues=[${JSON.stringify({})}]
 	/**
 	 * Mark a tool as used. Should be called when reconstructing from an INPUT_TOOL_EXEC message
 	 * @param tool - tool to save
-	 * @param toolResponse - response of the tool
+	 * @param inputToolExecData - data from the input tool exec message
 	 */
-	markToolAsUsed = (inputToolExecData: {
-		toolCallId: string;
-		inputPrompt: string;
-		status?: "success" | "error" | "cancelled";
-	}): void => {
+	markToolAsUsed = (
+		inputToolExecData: ResponseMessageStore["inputToolExecData"],
+	): void => {
 		// find the correct tool
 		const tool = this.tools.find(
 			(t) => t.id === inputToolExecData.toolCallId,
@@ -441,7 +439,7 @@ paramValues=[${JSON.stringify({})}]
 		// save the response
 		runInAction(() => {
 			tool.response = inputToolExecData.inputPrompt;
-			tool.toolStatus = inputToolExecData.status || "success";
+			tool.tool_status = inputToolExecData.toolStatus ?? "success";
 		});
 	};
 }

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -56,7 +56,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 		response: string;
 
 		/** If the tool execution was cancelled or errored */
-		status?: "success" | "error" | "cancelled";
+		toolStatus?: "success" | "error" | "cancelled";
 	}[] = [];
 
 	/**
@@ -65,7 +65,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 	inputToolExecData: {
 		toolCallId: string;
 		inputPrompt: string;
-		status?: "success" | "error" | "cancelled";
+		toolStatus?: "success" | "error" | "cancelled";
 	} | null = null;
 
 	/**
@@ -133,7 +133,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 			this.inputToolExecData = {
 				toolCallId: message.tool_call_id,
 				inputPrompt: message.inputPrompt,
-				status: "success", // default to success, implement in the future
+				toolStatus: "success", // default to success, implement in the future
 			};
 		}
 
@@ -376,7 +376,7 @@ paramValues=[${JSON.stringify({
 		runInAction(() => {
 			tool.response = toolResponse;
 			// in the future, would like to pass status to AddPlaygroundToolExecution too
-			tool.status = status;
+			tool.toolStatus = status;
 		});
 
 		// wait for the pixel to run
@@ -441,7 +441,7 @@ paramValues=[${JSON.stringify({})}]
 		// save the response
 		runInAction(() => {
 			tool.response = inputToolExecData.inputPrompt;
-			tool.status = inputToolExecData.status || "success";
+			tool.toolStatus = inputToolExecData.status || "success";
 		});
 	};
 }

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -54,6 +54,9 @@ export class ResponseMessageStore extends AbstractMessageStore {
 
 		/** Response for the tool */
 		response: string;
+
+		/** If the tool execution was cancelled */
+		cancelled?: boolean;
 	}[] = [];
 
 	/**
@@ -62,6 +65,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 	inputToolExecData: {
 		toolCallId: string;
 		inputPrompt: string;
+		cancelled?: boolean;
 	} | null = null;
 
 	/**
@@ -121,6 +125,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 				name: t.name,
 				parameters: t.arguments,
 				response: "",
+				cancelled: false,
 			}));
 		}
 
@@ -128,6 +133,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 			this.inputToolExecData = {
 				toolCallId: message.tool_call_id,
 				inputPrompt: message.inputPrompt,
+				cancelled: false, // default to false, implement in the future
 			};
 		}
 
@@ -353,12 +359,15 @@ paramValues=[${JSON.stringify({
 	saveToolExecution = async (
 		tool: ResponseMessageStore["tools"][number],
 		toolResponse: string,
+		cancelled: boolean = false,
 	): Promise<void> => {
 		const room = this.room;
 
 		// save the response
 		runInAction(() => {
 			tool.response = toolResponse;
+			// in the future, would like to pass cancelled to AddPlaygroundToolExecution too
+			tool.cancelled = cancelled;
 		});
 
 		// wait for the pixel to run
@@ -410,6 +419,7 @@ paramValues=[${JSON.stringify({})}]
 	markToolAsUsed = (inputToolExecData: {
 		toolCallId: string;
 		inputPrompt: string;
+		cancelled?: boolean;
 	}): void => {
 		// find the correct tool
 		const tool = this.tools.find(
@@ -419,11 +429,10 @@ paramValues=[${JSON.stringify({})}]
 			return;
 		}
 
-		const toolResponse = inputToolExecData.inputPrompt;
-
 		// save the response
 		runInAction(() => {
-			tool.response = toolResponse;
+			tool.response = inputToolExecData.inputPrompt;
+			tool.cancelled = inputToolExecData.cancelled || false;
 		});
 	};
 }

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -55,8 +55,8 @@ export class ResponseMessageStore extends AbstractMessageStore {
 		/** Response for the tool */
 		response: string;
 
-		/** If the tool execution was cancelled */
-		cancelled?: boolean;
+		/** If the tool execution was cancelled or errored */
+		status?: "success" | "error" | "cancelled";
 	}[] = [];
 
 	/**
@@ -65,7 +65,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 	inputToolExecData: {
 		toolCallId: string;
 		inputPrompt: string;
-		cancelled?: boolean;
+		status?: "success" | "error" | "cancelled";
 	} | null = null;
 
 	/**
@@ -133,7 +133,7 @@ export class ResponseMessageStore extends AbstractMessageStore {
 			this.inputToolExecData = {
 				toolCallId: message.tool_call_id,
 				inputPrompt: message.inputPrompt,
-				cancelled: false, // default to false, implement in the future
+				status: "success", // default to success, implement in the future
 			};
 		}
 
@@ -355,7 +355,7 @@ paramValues=[${JSON.stringify({
 			await this.saveToolExecution(
 				tool,
 				`This tool execution failed due to an unexpected error. The AI assistant should inform the user of the tool's failure and ask the user for further instructions. The AI assistant may mention alternative tools or actions to take next, but should not take any further actions or select any further tools without user input.`,
-				true,
+				"error",
 			);
 		}
 	};
@@ -368,15 +368,15 @@ paramValues=[${JSON.stringify({
 	saveToolExecution = async (
 		tool: ResponseMessageStore["tools"][number],
 		toolResponse: string,
-		cancelled: boolean = false,
+		status: "success" | "error" | "cancelled" = "success",
 	): Promise<void> => {
 		const room = this.room;
 
 		// save the response
 		runInAction(() => {
 			tool.response = toolResponse;
-			// in the future, would like to pass cancelled to AddPlaygroundToolExecution too
-			tool.cancelled = cancelled;
+			// in the future, would like to pass status to AddPlaygroundToolExecution too
+			tool.status = status;
 		});
 
 		// wait for the pixel to run
@@ -428,7 +428,7 @@ paramValues=[${JSON.stringify({})}]
 	markToolAsUsed = (inputToolExecData: {
 		toolCallId: string;
 		inputPrompt: string;
-		cancelled?: boolean;
+		status?: "success" | "error" | "cancelled";
 	}): void => {
 		// find the correct tool
 		const tool = this.tools.find(
@@ -441,7 +441,7 @@ paramValues=[${JSON.stringify({})}]
 		// save the response
 		runInAction(() => {
 			tool.response = inputToolExecData.inputPrompt;
-			tool.cancelled = inputToolExecData.cancelled || false;
+			tool.status = inputToolExecData.status || "success";
 		});
 	};
 }

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -340,15 +340,24 @@ paramValues=[${JSON.stringify({
 			return;
 		}
 
-		// wait for the pixel to run
-		const response = await room.runRoomPixel<[string]>(
-			`RunMCPTool(project = [ "${tool._meta.map.SMSS_PROJECT_ID}" ], function=[ "${tool.name}" ], paramValues=[ ${JSON.stringify(tool.parameters)} ]);`,
-		);
+		try {
+			// wait for the pixel to run
+			const response = await room.runRoomPixel<[string]>(
+				`RunMCPTool(project = [ "${tool._meta.map.SMSS_PROJECT_ID}" ], function=[ "${tool.name}" ], paramValues=[ ${JSON.stringify(tool.parameters)} ]);`,
+			);
 
-		const { output } = response.pixelReturn[0];
+			const { output } = response.pixelReturn[0];
 
-		// save the response
-		await this.saveToolExecution(tool, output);
+			// save the response
+			await this.saveToolExecution(tool, output);
+		} catch {
+			// mark the failure
+			await this.saveToolExecution(
+				tool,
+				`This tool execution failed due to an unexpected error. The AI assistant should inform the user of the tool's failure and ask the user for further instructions. The AI assistant may mention alternative tools or actions to take next, but should not take any further actions or select any further tools without user input.`,
+				true,
+			);
+		}
 	};
 
 	/**

--- a/packages/playground/src/stores/message/root-message.store.ts
+++ b/packages/playground/src/stores/message/root-message.store.ts
@@ -10,6 +10,7 @@ import { createMessageStore } from "./utility";
  */
 export class RootMessageStore extends AbstractMessageStore {
 	readonly type = "ROOT";
+	readonly pixelMessageType = null;
 
 	constructor(room: AbstractMessageStore["room"]) {
 		super(room, {

--- a/packages/playground/src/stores/room/room.store.ts
+++ b/packages/playground/src/stores/room/room.store.ts
@@ -708,7 +708,7 @@ export class RoomStore {
 			}
 
 			const tool = message.getTool(toolId, toolName);
-			if (!tool) {
+			if (!tool || tool.response) {
 				return;
 			}
 

--- a/packages/playground/src/stores/room/room.store.ts
+++ b/packages/playground/src/stores/room/room.store.ts
@@ -447,13 +447,16 @@ export class RoomStore {
 
 			// If the last message is a response and it has tool executions, start them (happens for new rooms and page reloads)
 			if (this.tail.type === "RESPONSE") {
-				this.tail.startToolExecution();
+				this.tail
+					.startToolExecution()
+					.finally(() => this.setIsLoading(false));
+			} else {
+				this.setIsLoading(false);
 			}
 		} catch (e) {
 			console.error(e);
-			throw new Error(e.message || "Error initializing room");
-		} finally {
 			this.setIsLoading(false);
+			throw new Error(e.message || "Error initializing room");
 		}
 	};
 

--- a/packages/playground/src/types.d.ts
+++ b/packages/playground/src/types.d.ts
@@ -126,6 +126,7 @@ export interface InputToolExecPixelMessage extends AbstractPixelMessage {
 	visible: false;
 	tool_call_id: string;
 	tool_name: string;
+	tool_status: "error" | "cancelled" | "success";
 	modelId: string;
 	inputPrompt: string;
 	ornaments: {

--- a/packages/playground/src/types.d.ts
+++ b/packages/playground/src/types.d.ts
@@ -127,6 +127,7 @@ export interface InputToolExecPixelMessage extends AbstractPixelMessage {
 	tool_call_id: string;
 	tool_name: string;
 	modelId: string;
+	inputPrompt: string;
 	ornaments: {
 		modelName?: string;
 	};


### PR DESCRIPTION
## Description
Various styling fixes and improvements surrounding tool calls
Goes with https://github.com/SEMOSS/Semoss/pull/1898

## Changes Made
- When building message history, mark tools with responses as complete
- Allow users to cancel tool requests
- Catch auto-executing errors and pass to model
- Prevent users from chatting until tools are complete
- Don't resubmit tools
- When the first message is an auto-execute response, have the spinner running

## Test steps
- Prerequisite: need an MCP (or several) with one tool set to auto-execute that works (TOOL A), one tool set to auto-execute that throws an error (TOOL B), and one tool set to ask that works (TOOL C)
- For all of the below test steps, you should be in chats with access to the aforementioned tools. Many of the below steps may be run from the same chat, but some will specify new chats
- Control: make sure TOOL A works
- Control: make sure TOOL C works
- Prompt for TOOL C. Verify that you may not type in the chat until the tool is completed
- Prompt for TOOL C, then click "cancel". Verify Playground acknowledges the cancellation and continues the chat
- Prompt for TOOL B. Verify Playground acknowledges the error and continues the chat
- In a new chat, prompt for TOOL A. Verify that the loading spinner appears while it is auto-executing
- In a chat, prompt for TOOL C, submit it, then prompt for TOOL A. Open up the UI for TOOL C and attempt to re-submit. Verify that Playground does not acknowledge tool responses from "old" tools that have already have responses
- Try prompting for various combinations of A, B, C, with various cancellations/successes, and verify all works as expected