### PR TITLE
fix(playground): dont pass workspace mcps to room options

### DIFF
--- a/packages/playground/src/stores/chat/chat.store.ts
+++ b/packages/playground/src/stores/chat/chat.store.ts
@@ -140,9 +140,15 @@ export class ChatStore {
 
 		let pixel = ``;
 
+		// Filter out workspace MCPs before saving (they shouldn't be persisted to the room)
+		const optionsToSave = {
+			...options,
+			mcp: options.mcp.filter((mcp) => !mcp?.fromWorkspace),
+		};
+
 		// set the options
 		pixel += `UpdateRoomOptions(roomId=${JSON.stringify(roomId)}, roomOptions=[${JSON.stringify(
-			options,
+			optionsToSave,
 		)}]);`;
 
 		// run the first message

--- a/packages/playground/src/stores/room/room.store.ts
+++ b/packages/playground/src/stores/room/room.store.ts
@@ -512,9 +512,15 @@ export class RoomStore {
 	 */
 	updateRoomOptions = async (options: RoomStore["options"]) => {
 		try {
+			// Filter out workspace MCPs before saving (they shouldn't be persisted to the room)
+			const optionsToSave = {
+				...options,
+				mcp: options.mcp.filter((mcp) => !mcp?.fromWorkspace),
+			};
+
 			await this.runRoomPixel(
 				`UpdateRoomOptions(roomId=${JSON.stringify(this._store.roomId)}, roomOptions=[${JSON.stringify(
-					options,
+					optionsToSave,
 				)}]);`,
 			);
 


### PR DESCRIPTION
## Description
Dont pass workspace mcps to room options

## Changes Made
Remove them

## How to Test
Try creating chats with workspaces and adding/removing other mcp's

