### PR TITLE
Resolve 572: 'Data grid Frame header not refreshing with new frame'

### DIFF
--- a/packages/client/src/components/blocks-workspace/blocks/settings/custom/grid-two/GridBlockColumnSettings.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/settings/custom/grid-two/GridBlockColumnSettings.tsx
@@ -8,6 +8,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { Sync } from "@mui/icons-material";
 import { observer } from "mobx-react-lite";
+import { useEffect } from "react";
 import {
 	type GridBlockColumn,
 	type GridBlockDef,
@@ -53,7 +54,8 @@ export const GridBlockColumnSettings = observer(
 				// get the columns by selector
 				const columnMap: Record<string, GridBlockColumn> =
 					data.columns.reduce((acc, val) => {
-						acc[val.name] = acc;
+						// Assign individual column to the key, instead of the object itself
+						acc[val.name] = val;
 
 						return acc;
 					}, {});
@@ -131,6 +133,18 @@ export const GridBlockColumnSettings = observer(
 		// columns to render
 		const columns = data.columns || [];
 
+		/**
+		 * Auto-sync when frame headers load after frame change
+		 */
+		useEffect(() => {
+			if (
+				!frameHeaders.isLoading &&
+				frameHeaders.data?.list?.length > 0
+			) {
+				syncFrameHeaders();
+			}
+		}, [frameHeaders.data?.list?.length]);
+
 		return (
 			<>
 				<BaseSettingSection label="Frame">
@@ -144,6 +158,8 @@ export const GridBlockColumnSettings = observer(
 							return option;
 						}}
 						onChange={(_, value) => {
+							// clear columns immediately
+							setData("columns", []);
 							// update the frame
 							setData("frame.name", value);
 						}}
@@ -185,7 +201,6 @@ export const GridBlockColumnSettings = observer(
 										>
 											<GridBlockColumnSettingsItem
 												id={id}
-												key={cIdx}
 												column={c}
 												index={cIdx}
 											/>


### PR DESCRIPTION
## Description
While editing the data grid block and you change the frame in the Data tab, it will now automatically clear the previous headers and reload the grid to the new frames headers.
Updated the grid block column settings to automatically sync frame headers when changing frames while editing the data grid block.

## Changes Made
Updated the grid block column settings:
- When creating the new column map, change to assign to the column for each key instead of the object itself. This was causing errors when trying to reload manually if previous headers were present. 
- Add useEffect() to call the syncHeaders() function when frame changes occur.
- Add state change to clear out columns when changing the frame. 
- Remove key from GridBlockSettingsItem to resolve error.


## How to Test
<!-- Explain how reviewers can test your changes -->
1. Create a Drag and Drop application and go into Edit mode.
2. Add notebook with two cells that contain different frame data.
3. Create a Grid Block and assign the first newly created frame. 
4. Headers should automatically sync on the block with a notification appearing on the top right. 
5. Change the frame to the 2nd.
6. Headers should clear, with new headers from the frame appearing and the same notification.