### PR TITLE
fix: adding unzip as secondary option on zip files

### DIFF
--- a/packages/client/src/components/app-workspace/app-file-explorer.tsx
+++ b/packages/client/src/components/app-workspace/app-file-explorer.tsx
@@ -293,18 +293,26 @@ export const AppFileExplorer: React.FC<AppFileExplorerProps> = observer(
 											},
 										}
 									: null,
-								// item.path.endsWith(".zip")
-								// 	? {
-								// 			name: "Unzip",
-								// 			action: async () => {
-								// 				const pixel = "";
+								item.path.endsWith(".zip")
+									? {
+											name: "Unzip",
+											action: async (item) => {
+												try {
+													await insight.actions.run(
+														`UnzipFile(filePath=["version/assets${item.path}"], space=["${app}"]);`,
+													);
 
-								// 				await insight.actions.run(
-								// 					pixel,
-								// 				);
-								// 			},
-								// 		}
-								// 	: null,
+													toast.success(
+														"File unzipped successfully",
+													);
+
+													refresh();
+												} catch (e) {
+													toast.error(`Error: ${e}`);
+												}
+											},
+										}
+									: null,
 								{
 									name: "Delete",
 									action: async (item) => {


### PR DESCRIPTION
## Description
Adding in secondary option for zip files to allow for unzip

## Changes Made
adding in new secondary option in the app-file-expoloer
## How to Test
<!-- Explain how reviewers can test your changes -->
1. create new app 
2. unpload zip 
3. hit secondary menu to unzip 
<img width="1587" height="889" alt="image" src="https://github.com/user-attachments/assets/5c9664b2-85c3-4678-b4a8-7baf0a3a53ad" />
<img width="458" height="284" alt="image" src="https://github.com/user-attachments/assets/938c2f9d-4f49-4695-ad84-9212f83842db" />
<img width="411" height="308" alt="image" src="https://github.com/user-attachments/assets/48fe0944-4ee1-4ba3-94c7-fb9cf1071903" />


## Notes
<!-- Any further notes regarding changes -->