### PR TITLE
Tool error / cancellation updates

### DIFF
--- a/packages/playground/src/components/mcp/tools-default-view.tsx
+++ b/packages/playground/src/components/mcp/tools-default-view.tsx
@@ -135,19 +135,33 @@ export const ToolsDefaultView: React.FC<ToolsDefaultViewProps> = observer(
 		// Tool Execution
 		const handleSubmit = async () => {
 			setIsSubmitting(true);
-			const response = await room.runRoomPixel<[string]>(
-				`RunMCPTool(project = [ "${app}" ], function=[ "${
-					mcp.name
-				}" ], paramValues=[ ${JSON.stringify(data)} ]);`,
-			);
-			const { output } = response.pixelReturn[0];
-
+			let success = false;
+			let output = "";
+			try {
+				const response = await room.runRoomPixel<[string]>(
+					`RunMCPTool(project = [ "${app}" ], function=[ "${
+						mcp.name
+					}" ], paramValues=[ ${JSON.stringify(data)} ]);`,
+					false,
+					false,
+				);
+				output = response.pixelReturn[0].output;
+				success = true;
+			} catch (error) {
+				output = error.toString();
+				success = false;
+			}
 			const m = room.getMessage(message);
 			if (!m || m instanceof ResponseMessageStore !== true) {
-				setIsSubmitting(false);
-				return;
+			} else {
+				room.processTool(
+					m.id,
+					tool.id,
+					tool.name,
+					output,
+					success ? "success" : "error",
+				);
 			}
-			room.processTool(m.id, tool.id, tool.name, output);
 			setIsSubmitting(false);
 		};
 

--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -6,7 +6,6 @@ import {
 } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { Button, Spinner } from "@semoss/ui/next";
-import { TOOL_CANCELLATION_PROMPT } from "@/constants";
 import { useLoadingMessage } from "@/hooks";
 import type { ResponseMessageStore } from "@/stores";
 
@@ -138,7 +137,7 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 									e.stopPropagation();
 									message.saveToolExecution(
 										tool,
-										TOOL_CANCELLATION_PROMPT,
+										"",
 										"cancelled",
 									);
 

--- a/packages/playground/src/constants.ts
+++ b/packages/playground/src/constants.ts
@@ -23,5 +23,16 @@ export const LOADING_MESSAGES = [
 	"Nearly ready...",
 ] as const;
 
-export const TOOL_CANCELLATION_PROMPT = `This tool execution was intentionally cancelled by the user. The AI assistant should inform the user of the tool's cancellation and ask the user for further instructions. The AI assistant may mention alternative tools or actions to take next, but should not take any further actions or select any further tools without user input.`;
-export const TOOL_ERROR_PROMPT = `This tool execution failed due to an unexpected error. The AI assistant should inform the user of the tool's failure and ask the user for further instructions. The AI assistant may mention alternative tools or actions to take next, but should not take any further actions or select any further tools without user input.`;
+export const TOOL_CANCELLATION_PROMPT = `The user chose not to execute this tool. This could be for various reasons (wrong parameters, unnecessary step, privacy concerns, timing, manual preference, etc.). You should:
+1. Acknowledge their decision without assuming why
+2. Ask if they need anything else or if the current state meets their needs  
+3. If they want to continue, ask how they'd prefer to proceed
+4. Avoid immediately re-suggesting the same tool unless they indicate the issue was just with parameters
+5. If this tool has been declined repeatedly, consider it may not fit their workflow preferences
+6. Wait for explicit user input before taking any further actions or executing tools`;
+
+export const TOOL_ERROR_PROMPT = `This tool execution failed due to an unexpected error. You should:
+1. Inform the user of the failure and briefly explain what went wrong
+2. If the error cause is clear and you know how to fix it (e.g., incorrect parameter, missing dependency), you may attempt one corrective action
+3. If the error is unclear or complex, ask the user for guidance and suggest alternative approaches
+4. Always explain your reasoning before taking any corrective actions`;

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -2,6 +2,7 @@ import { action, makeObservable, observable, runInAction } from "mobx";
 import {
 	MCP_EXECUTION_ASK,
 	MCP_EXECUTION_AUTO,
+	TOOL_CANCELLATION_PROMPT,
 	TOOL_ERROR_PROMPT,
 } from "@/constants";
 import { ToolStore } from "@/stores";
@@ -437,9 +438,9 @@ paramValues=[${JSON.stringify({
 
 			// save the response
 			await this.saveToolExecution(tool, output);
-		} catch {
+		} catch (e) {
 			// mark the failure
-			await this.saveToolExecution(tool, TOOL_ERROR_PROMPT, "error");
+			await this.saveToolExecution(tool, e.toString(), "error");
 		}
 	};
 
@@ -455,6 +456,13 @@ paramValues=[${JSON.stringify({
 		toolStatus: "success" | "error" | "cancelled" = "success",
 	): Promise<void> => {
 		const room = this.room;
+
+		// wrap the message
+		if (toolStatus === "error") {
+			toolResponse = `${TOOL_ERROR_PROMPT}${toolResponse ? `\n\nError Details: ${toolResponse}` : ""}`;
+		} else if (toolStatus === "cancelled") {
+			toolResponse = `${TOOL_CANCELLATION_PROMPT}${toolResponse ? `\n\nCancellation Details: ${toolResponse}` : ""}`;
+		}
 
 		// skip if the tool is already completed
 		if (tool.status === "SUCCESS" || tool.status === "CANCELLED") {

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -432,6 +432,7 @@ paramValues=[${JSON.stringify({
 			const response = await room.runRoomPixel<[string]>(
 				`RunMCPTool(project = [ "${tool.json._meta.SMSS_PROJECT_ID}" ], function=[ "${tool.json.name}" ], paramValues=[ ${JSON.stringify(tool.json.parameters)} ]);`,
 				false,
+				false,
 			);
 
 			const { output } = response.pixelReturn[0];

--- a/packages/playground/src/stores/room/room.store.ts
+++ b/packages/playground/src/stores/room/room.store.ts
@@ -889,6 +889,7 @@ export class RoomStore {
 	runRoomPixel = async <O extends [] | unknown[]>(
 		pixel: string,
 		showLoading: boolean = true,
+		setErrorOnFail: boolean = true,
 	): Promise<{
 		errors: string[];
 		insightId: string;
@@ -920,9 +921,11 @@ export class RoomStore {
 			});
 			return response;
 		} catch (e) {
-			runInAction(() => {
-				this._store.error = e;
-			});
+			if (setErrorOnFail) {
+				runInAction(() => {
+					this._store.error = e;
+				});
+			}
 			throw e;
 		} finally {
 			if (showLoading) {


### PR DESCRIPTION
## Description
Improve error handling of tools on playground

## Changes Made
- Errors are now passed to the LLM
- Errors encountered during auto-execute or on the default UI are no longer blocking

## How to Test
1. Have access to Tool A, an auto-executing tool that throws an error, and Tool B, a tool that does not auto-execute but also throws an error
2. Prompt the chat for Tool A
3. When it executes and errors, verify that the LLM acknowledges the error, and that you can still continue the chat
4. Repeat 2-3 for Tool B
