### PR TITLE
fix: properly save tool responses

### DIFF
--- a/packages/playground/src/stores/room/room.store.ts
+++ b/packages/playground/src/stores/room/room.store.ts
@@ -513,18 +513,33 @@ export class RoomStore {
 				// if its tool execution, update the corresponding tool
 				const toolExecMessage = m.message;
 				if (toolExecMessage instanceof ToolExecutionMessageStore) {
-					const parentToolExecMessage =
-						messages[m.parentMessageId].message;
-					if (parentToolExecMessage instanceof ResponseMessageStore) {
-						parentToolExecMessage.tools.forEach((tool) => {
-							if (tool.id === toolExecMessage.callId) {
-								// save the response
-								runInAction(() => {
-									tool.response = toolExecMessage.response;
-									tool.status = toolExecMessage.status;
-								});
-							}
-						});
+					// Run up the chain to find the message containing the tool
+					// (because it can go reponse_tool -> input_tool_exec -> input_tool_exec)
+					let toolExecMessageParent: AbstractMessageStore =
+						toolExecMessage.parent;
+					while (toolExecMessageParent) {
+						if (
+							toolExecMessageParent instanceof
+							ResponseMessageStore
+						) {
+							// We've found the parent response message, now find the tool
+							toolExecMessageParent.tools.forEach((tool) => {
+								if (tool.id === toolExecMessage.callId) {
+									// save the response
+									runInAction(() => {
+										tool.response =
+											toolExecMessage.response;
+										tool.status = toolExecMessage.status;
+									});
+								}
+							});
+							// Break because we've found the right parent
+							break;
+						} else {
+							// keep going up the chain
+							toolExecMessageParent =
+								toolExecMessageParent.parent;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Description
Fixes the issue where a message with many completed tools would only show the first as completed

## Changes Made
- Fix the logic for appending responses

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->