### PR TITLE
fix: render title of mcp tool instead of name of reactor

### DIFF
--- a/packages/playground/src/components/mcp/tools-default-view.tsx
+++ b/packages/playground/src/components/mcp/tools-default-view.tsx
@@ -123,7 +123,7 @@ export const ToolsDefaultView: React.FC<ToolsDefaultViewProps> = observer(
 	({ room, app, message, tool, mcp, toolResponse }) => {
 		const properties = mcp?.inputSchema?.properties || {};
 		const required = mcp?.inputSchema?.required || [];
-		const name = mcp?.name || "";
+		const name = mcp?.title || mcp?.name || "";
 		const description = mcp?.description || "";
 		const [data, setData] = useState<Record<string, unknown>>(() => {
 			return tool?.parameters;


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Originally, when clicking on the MCP tool of vector DB, it would render out the name of the tool, and the name of the reactor, instead of the title. This didn't allow for a custom headers. This will now allow you to render out the title, and therefore, allow you to change it to be in different terms, depending on use case

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->