### PR TITLE
Refactor condition check for group in flushBuffer

### DIFF
--- a/libs/renderer/src/components/cell-defaults/filter-data-cell/FilterDataCell.tsx
+++ b/libs/renderer/src/components/cell-defaults/filter-data-cell/FilterDataCell.tsx
@@ -327,8 +327,7 @@ export const FilterDataCell: CellComponent<FilterDataCellDef> = observer(
 				const flushBuffer = () => {
 					const trimmed = buffer.trim();
 					if (!trimmed) return;
-					const isGroup =
-						trimmed.includes("AND") || trimmed.includes("OR");
+					const isGroup = /(?:^|\s)(?:AND|OR)(?:\s|$)/.test(trimmed);
 					parts.push(
 						isGroup ? buildGroup(trimmed) : parseRule(trimmed),
 					);


### PR DESCRIPTION
Column names containing "AND" or "OR" as substrings were incorrectly detected as group condition operators, causing infinite recursion in parseQuery.

Frame query was: CREATOR == []

## Changes Made
Changed substring check .includes("AND") || .includes("OR") to regex /(?:^|\s)(?:AND|OR)(?:\s|$)/

## How to Test
Create a filter-data cell on a frame with a column named a word that contains OR or AND (ex: creator)
Save and reload the app
Expected: Cell renders without crash

What happens now without the fix:
```
RangeError: Maximum call stack size exceeded
    at String.match (<anonymous>)
    at buildGroup (index-DPUoRyug.js:424578:28)
    at flushBuffer (index-DPUoRyug.js:424575:30)
```
Stack overflow and the notebook fails to render.