### PR TITLE
fix for edit workspace instructions

### DIFF
--- a/packages/playground/src/components/workspace/workspace-form.tsx
+++ b/packages/playground/src/components/workspace/workspace-form.tsx
@@ -141,7 +141,7 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 					<Textarea
 						id={instructionId}
 						placeholder="Enter Instructions"
-						value={instructions}
+						value={instructions.replace(/\\n/g, "\n")}
 						onChange={(e) => setInstructions(e.target.value)}
 						rows={4}
 						data-testid="workspaceForm-system_prompt-txt"


### PR DESCRIPTION
## Description
Modified instructions in edit workspaces to keep new lines in format

## Changes Made
One small change in workspace-form.tsx

## How to Test
1. Go to edit workspace form and put a text into the Instructions section that has new lines in it.
2. Click save and return to the edit workspace form and the new lines will be preserved.