### PR TITLE
feat(client): something went wrong on click on block settings bug fix

### DIFF
--- a/packages/client/src/components/workspace/WorkspaceManager.tsx
+++ b/packages/client/src/components/workspace/WorkspaceManager.tsx
@@ -235,22 +235,9 @@ export const WorkspaceManager: React.FC<WorkspaceManagerProps> = observer(
 				?.getNodeById("main-tabset")
 				?.getAttr("weight");
 
-			model
-				.getBorderSet()
-				.getBorders()
-				.forEach((border) => {
-					// border.setSelected(isSettingsTab ? -1 : border.getSelected());
-					border.setSelected(
-						action.data.tabNode === "block-settings" &&
-							mainTabsetWeight === 0
-							? 1
-							: border.getSelected(),
-					);
-				});
-
 			if (isSettingsTab || mainTabsetWeight === 0) {
 				model.visitNodes((node) => {
-					if (node.getType() === "tabset") {
+					if (node && typeof node.getType === "function" && node.getType() === "tabset") {
 						const newWeight =
 							(isSettingsTab &&
 								node.getId() === "settings-tabset") ||


### PR DESCRIPTION
## Description
Something went wrong error on clicking the block settings by keeping the setting tab in the workspace open.

## Changes Made
Removed the unwanted border-set calculation which was causing this issue.

## How to Test
<!-- Explain how reviewers can test your changes -->

1. Create a new application.
2.Navigate to Settings of the newly created app.
3.Click on the App option.
4.Click on Block Settings.
5.Observe the error message “Something went wrong” will not occur anymore. It should as expected.
6.Navigate back to the App Library.
7.Try to open any app (existing or newly created) in Edit mode, no error should pop up.

## Notes
FIX demo : https://github.com/SEMOSS/semoss-ui/issues/2666#issuecomment-3912853643