### PR TITLE
potential fix- needs testing with Windows cpu

### DIFF
--- a/packages/playground/src/components/room/room-input.tsx
+++ b/packages/playground/src/components/room/room-input.tsx
@@ -355,19 +355,51 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 											setIsDragging(false);
 										}}
 										onPaste={(e) => {
-											// set the new files
-											const updated = Array.from(
-												e.clipboardData.files,
+											const cd = e.clipboardData;
+
+											const imageFiles = Array.from(cd.files || []).filter((f) =>
+												f.type?.startsWith("image/")
 											);
 
-											if (updated.length > 0) {
+											const textPlainRaw = cd.getData("text/plain") || "";
+											const textPlain = textPlainRaw.trim();
+
+											const html = cd.getData("text/html") || "";
+
+											const { htmlHasImg, htmlHasMeaningfulText } = (() => {
+												if (!html) return { htmlHasImg: false, htmlHasMeaningfulText: false };
+
+												const doc = new DOMParser().parseFromString(html, "text/html");
+												const htmlHasImg = !!doc.querySelector("img");
+
+												doc.querySelectorAll("img,style,script,meta,link").forEach((n) => n.remove());
+
+												const txt = (doc.body?.textContent || "")
+												.replace(/\u00A0/g, " ")
+												.trim();
+
+												return { htmlHasImg, htmlHasMeaningfulText: txt.length > 0 };
+											})();
+
+											const hasMeaningfulText = textPlain.length > 0 || htmlHasMeaningfulText;
+											const hasAnyImage = imageFiles.length > 0 || htmlHasImg;
+
+											if (hasMeaningfulText && hasAnyImage) {
 												e.preventDefault();
-												setFiles((prev) => [
-													...prev,
-													...updated,
-												]);
+												document.execCommand("insertText", false, textPlainRaw);
+												return;
 											}
-										}}
+
+											if (hasMeaningfulText) return;
+
+											if (imageFiles.length > 0) {
+												e.preventDefault();
+												setFiles((prev) => [...prev, ...imageFiles]);
+												return;
+											}
+
+											if (htmlHasImg) return;
+											}}
 									/>
 								</div>
 							}


### PR DESCRIPTION
## Description
Most significant change is that If both plain text and image exist in non-html or html clipboard data, only text will be pasted.

## Changes Made
Instead of only looking at the uploaded files, the clipboard data is examined for plain image and text as well as html image and text. Certain times, such as with Excel text, html images were included in the clipboard data.

## How to Test (need Windows computer)
1. Try to copy/paste any image into the textarea. The image box should appear underneath.
2. Try to copy/paste any text from Excel, OneNote, etc. Only the text should appear in the textarea without any image box underneath.

## Notes
Should look something like this:
<img width="944" height="435" alt="image (1)" src="https://github.com/user-attachments/assets/aafb3d5b-3f70-4f70-b390-4b427a4d1292" />
 - Excel test pasted successfully without any associated image
 - Real Madrid image pasted successfully