### PR TITLE
Sidebar Footer Updates

### DIFF
--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -30,6 +30,7 @@ import {
 	InputGroupAddon,
 	InputGroupInput,
 	Muted,
+	Separator,
 	Sidebar,
 	SidebarContent,
 	SidebarFooter,
@@ -588,7 +589,8 @@ export const GlobalNav = observer(() => {
 				})}
 			</SidebarContent>
 			<SidebarFooter>
-				<SidebarMenu className="gap-2 px-2 pt-2">
+				<Separator className="group-data-[collapsible=icon]:hidden" />
+				<SidebarMenu className="gap-2 px-2 pt-2 group-data-[collapsible=icon]:hidden">
 					{root.theme.sidebar.footerItems.map((item) => (
 						<GlobalNavItem
 							key={item.path}


### PR DESCRIPTION
## Description
<!-- Updated Footer to be hidden during collapse, and added a seperator be…tween chat history and footer help buttons
 -->

## Changes Made
<!-- Updated global-nav component, added Separator and show/hide footer items logic -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Expanded Sidebar should show a bar separating Chat History and Help Menu Items (Bug Report, Feature Requests, Training Resources)
2. Collapse Sidebar results in those items hidden.

## Notes
<img width="231" height="553" alt="image" src="https://github.com/user-attachments/assets/35121d4c-598d-4e45-8920-2f11275736bb" />

<img width="181" height="630" alt="image" src="https://github.com/user-attachments/assets/82244f65-a979-48ac-ab18-aeff0d9febfa" />
