### PR TITLE
Add folder zip download in room explorer

### DIFF
--- a/packages/playground/src/components/room/room-file-explorer.tsx
+++ b/packages/playground/src/components/room/room-file-explorer.tsx
@@ -86,32 +86,27 @@ export const RoomFileExplorer: React.FC<RoomFileExplorerProps> = observer(
 										}
 									},
 								},
-								item.type !== "directory"
-									? {
-											name: t("fileExplorer.download"),
-											action: async (item) => {
-												// save it
-												const { pixelReturn } =
-													await insight.actions.run<
-														[string]
-													>(
-														`DownloadInsightAsset(filePath=["${item.path}"]);`,
-													);
+								{
+									name: t("fileExplorer.download"),
+									action: async (item) => {
+										// save it
+										const { pixelReturn } =
+											await insight.actions.run<[string]>(
+												`DownloadInsightAsset(filePath=["${item.path}"]);`,
+											);
 
-												// get the file key
-												const fileKey =
-													pixelReturn[0].output;
+										// get the file key
+										const fileKey = pixelReturn[0].output;
 
-												// download the file
-												await download(
-													insight.insightId,
-													fileKey,
-												);
+										// download the file
+										await download(
+											insight.insightId,
+											fileKey,
+										);
 
-												refresh();
-											},
-										}
-									: null,
+										refresh();
+									},
+								},
 								{
 									name: t("fileExplorer.delete"),
 									action: async (item) => {


### PR DESCRIPTION
## Description
Adds ability to download a zip file of a directory in room explorer. This saves the user from needing to download files individually if there are many. This is most helpful if a process (e.g., an MCP creating documents) has created or placed a number of files into the room.

## Changes Made
Removes directory exclusion from `packages/playground/src/components/room/room-file-explorer.tsx` and exposes download options for directories

## How to Test
1. Upload files/directories into the room via the room explorer
2. Hover over three dots on right to see download option. 
3. Click download

<img width="1089" height="672" alt="image" src="https://github.com/user-attachments/assets/874f99d0-a771-4094-9a44-7fbe81bd544e" />

**Result**
<img width="362" height="114" alt="image" src="https://github.com/user-attachments/assets/06321d06-29d7-40a2-ad92-4a95ea69b915" />
