### PR TITLE
Fix: tool status saved as "undefined"

### DIFF
--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -46,6 +46,6 @@ export interface MCPToolResponse {
 	name: string;
 	response: string;
 	roomId: string;
-	tool_status: "success" | "error" | "cancelled";
+	tool_status?: "success" | "error" | "cancelled";
 	executedParameters?: Record<string, unknown>;
 }

--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -389,8 +389,6 @@ export const GlobalNav = observer(() => {
 				)}
 				{BUCKETS.map((bucket) => {
 					const rooms = bucketedRooms[bucket];
-					console.log(rooms);
-
 					if (!open || rooms.length === 0) {
 						return null;
 					}

--- a/packages/playground/src/components/mcp/tools-default-view/tools-default-view.tsx
+++ b/packages/playground/src/components/mcp/tools-default-view/tools-default-view.tsx
@@ -146,7 +146,6 @@ export const ToolsDefaultView: React.FC<ToolsDefaultViewProps> = observer(
 				room.processTool(
 					m.id,
 					tool.id,
-					tool.name,
 					output,
 					success ? "success" : "error",
 					data,

--- a/packages/playground/src/components/room/room-content.tsx
+++ b/packages/playground/src/components/room/room-content.tsx
@@ -172,7 +172,6 @@ export const RoomContent: React.FC<RoomContentProps> = observer(({ room }) => {
 				room.processTool(
 					tool.message,
 					tool.id,
-					tool.name,
 					tool.response,
 					tool.tool_status,
 					tool.executedParameters,

--- a/packages/playground/src/stores/message/plan-message.store.ts
+++ b/packages/playground/src/stores/message/plan-message.store.ts
@@ -552,7 +552,7 @@ stepNumber=["${step.step_number}"]
 		message: ResponseMessageStore,
 		tool: ToolStore,
 		toolResponse: string,
-		toolStatus: "success" | "error" | "cancelled",
+		toolStatus: "success" | "error" | "cancelled" = "success",
 		executedParameters: Record<string, unknown>,
 	) => {
 		const step = this.step;

--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -362,13 +362,11 @@ paramValues=[${JSON.stringify({
 						tool.status === "LOADING" ||
 						tool.status === "INITIAL"
 					) {
-						console.log("unfinished", tool);
 						return true;
 					}
 				}
 			}
 		}
-
 		return false;
 	}
 
@@ -461,7 +459,7 @@ paramValues=[${JSON.stringify({
 	saveToolExecution = async (
 		tool: ToolStore,
 		toolResponse: string,
-		toolStatus: "success" | "error" | "cancelled",
+		toolStatus: "success" | "error" | "cancelled" = "success",
 		executedParameters: Record<string, unknown>,
 	): Promise<void> => {
 		const room = this.room;

--- a/packages/playground/src/stores/room/room.store.ts
+++ b/packages/playground/src/stores/room/room.store.ts
@@ -331,7 +331,6 @@ export class RoomStore {
 				}
 			}
 		}
-
 		return false;
 	}
 
@@ -923,7 +922,6 @@ export class RoomStore {
 	 * Process a tool call
 	 * @param messageId - id of the message
 	 * @param toolId - id of the tool
-	 * @param toolName - name of the tool
 	 * @param toolResponse - response from the tool
 	 * @param toolStatus - status of the tool execution
 	 * @param executedParameters - parameters used by the tool
@@ -931,9 +929,8 @@ export class RoomStore {
 	processTool = async (
 		messageId: string,
 		toolId: string,
-		toolName: string,
 		toolResponse: string,
-		toolStatus: "success" | "error" | "cancelled",
+		toolStatus: "success" | "error" | "cancelled" = "success",
 		executedParameters: Record<string, unknown>,
 	): Promise<void> => {
 		try {

--- a/packages/playground/src/stores/tool/tool.store.ts
+++ b/packages/playground/src/stores/tool/tool.store.ts
@@ -135,18 +135,12 @@ export class ToolStore {
 			this.parameters = part.toolResult.toolParameterValues || {};
 			this.response = part.toolResult.output;
 
-			// @ts-expect-error - TODO: Fix this. tool status should not be undefined
-			if (part.toolResult.toolStatus === "undefined") {
-				this.status = "SUCCESS";
-				console.error(
-					"TODO: Fix this. tool status should not be undefined",
-				);
-			} else if (part.toolResult.toolStatus === "success") {
-				this.status = "SUCCESS";
-			} else if (part.toolResult.toolStatus === "error") {
+			if (part.toolResult.toolStatus === "error") {
 				this.status = "ERROR";
 			} else if (part.toolResult.toolStatus === "cancelled") {
 				this.status = "CANCELLED";
+			} else {
+				this.status = "SUCCESS";
 			}
 
 			// update the tool result information


### PR DESCRIPTION
## Description
Calling tools in ask mode with custom UI was bricking the chat

## Changes Made
Need to pass "success" to the BE instead of "undefined"

## How to Test
Before pulling, on dev:
1. Call a tool with a custom UI in ask mode
2. Run the tool
3. Notice that you can no longer send messages

Pull this branch, then repeat the above. Verify that it's ok now
