### PR TITLE
fix: infinite loop on error

### DIFF
--- a/libs/ui/src/components/Notification/Notification.tsx
+++ b/libs/ui/src/components/Notification/Notification.tsx
@@ -1,6 +1,12 @@
 import { Snackbar, type SxProps } from "@mui/material";
 import type React from "react";
-import { isValidElement, type ReactNode, useEffect, useState } from "react";
+import {
+	isValidElement,
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useState,
+} from "react";
 import type { NotificationMessage } from "./notification.types";
 
 // generate a uuid
@@ -90,7 +96,7 @@ export const Notification = (props: NotificationProps): JSX.Element => {
 	 * Add a new notification
 	 * @param state - state of the Notification Item
 	 */
-	const addNotification = (message: NotificationMessage) => {
+	const addNotification = useCallback((message: NotificationMessage) => {
 		// generate an id if there isn't one
 		if (!message.id) {
 			message.id = getUuid();
@@ -107,28 +113,28 @@ export const Notification = (props: NotificationProps): JSX.Element => {
 				},
 			];
 		});
-	};
+	}, []);
 
 	/**
 	 * Remove a notification
 	 * @param id - id of the notification to remove
 	 */
-	const removeNotification = (id: string) => {
+	const removeNotification = useCallback((id: string) => {
 		setNotifications((notifications) => {
 			return notifications.filter((n) => n.id !== id);
 		});
-	};
+	}, []);
 
 	/**
 	 * Close the notifications
 	 */
-	const closeNotification = () => {
+	const closeNotification = useCallback(() => {
 		// nullify it
 		setActive(null);
 
 		// close it
 		setIsOpen(false);
-	};
+	}, []);
 
 	const getMessage = (): ReactNode => {
 		if (

--- a/libs/ui/src/components/Notification/Notification.tsx
+++ b/libs/ui/src/components/Notification/Notification.tsx
@@ -143,7 +143,8 @@ export const Notification = (props: NotificationProps): JSX.Element => {
 		) {
 			return active.message;
 		} else if (
-			typeof active?.message === "object" &&
+			active?.message !== null &&
+			typeof active?.message === "object" && // typeof null = "object", so we need to check if it's not null
 			Object.keys(active.message).length
 		) {
 			return JSON.stringify(active.message);

--- a/packages/client/src/pages/app/AppDetailTabs/dependencies-tab.tsx
+++ b/packages/client/src/pages/app/AppDetailTabs/dependencies-tab.tsx
@@ -55,7 +55,7 @@ export const Dependencies = ({
 											: `${Env.MODULE}/api/e-${dep.id}/image/download`
 									}
 									alt={dep.name}
-									className="h-12 w-12 flex-shrink-0 rounded-lg object-cover"
+									className="h-12 w-12 shrink-0 rounded-lg object-cover"
 								/>
 								<div className="flex min-w-0 flex-col">
 									<Link
@@ -77,7 +77,7 @@ export const Dependencies = ({
 										</Muted>
 									</div>
 								</div>
-								<div className="ml-auto flex flex-shrink-0 items-center gap-2">
+								<div className="ml-auto flex shrink-0 items-center gap-2">
 									{dep.isPublic && (
 										<Badge variant="outline">Public</Badge>
 									)}

--- a/packages/client/src/pages/app/app-detail-page.tsx
+++ b/packages/client/src/pages/app/app-detail-page.tsx
@@ -143,7 +143,6 @@ export const AppDetailPage = (props: AppDetailsProps) => {
 
 	const fetchAppData = useCallback(
 		async (id: string) => {
-			console.log("fetching app data for id:", id);
 			await getPermission();
 			const currentPermission = getValues("permission");
 			const promises = [

--- a/packages/client/src/pages/app/app-detail-page.tsx
+++ b/packages/client/src/pages/app/app-detail-page.tsx
@@ -110,7 +110,7 @@ export const AppDetailPage = (props: AppDetailsProps) => {
 				message,
 			});
 		},
-		[notification],
+		[notification.add],
 	);
 	const navigate = useNavigate();
 	const getPermission = useCallback(async () => {
@@ -144,6 +144,7 @@ export const AppDetailPage = (props: AppDetailsProps) => {
 
 	const fetchAppData = useCallback(
 		async (id: string) => {
+			console.log("fetching app data for id:", id);
 			await getPermission();
 			const currentPermission = getValues("permission");
 			const promises = [
@@ -468,7 +469,7 @@ export const AppDetailPage = (props: AppDetailsProps) => {
 			>
 				<div
 					className={`flex h-full w-full flex-col gap-3 ${
-						showNav ? "m-auto max-w-[79rem]" : ""
+						showNav ? "m-auto max-w-316" : ""
 					}`}
 				>
 					{showNav && (
@@ -502,7 +503,7 @@ export const AppDetailPage = (props: AppDetailsProps) => {
 					)}
 
 					<div className="flex w-full flex-col gap-4 md:flex-row md:items-center">
-						<div className="h-16 w-16 flex-shrink-0 rounded-lg bg-muted">
+						<div className="h-16 w-16 shrink-0 rounded-lg bg-muted">
 							<img
 								src={`${Env.MODULE}/api/project-${appId}/projectImage/download`}
 								alt={appInfo?.project_name || "App"}
@@ -512,7 +513,7 @@ export const AppDetailPage = (props: AppDetailsProps) => {
 
 						<div className="flex min-w-0 flex-1 flex-col gap-1">
 							<h1
-								className="break-words font-semibold text-2xl text-foreground leading-normal md:overflow-hidden md:text-ellipsis md:whitespace-nowrap md:text-[30px]"
+								className="wrap-break-words font-semibold text-2xl text-foreground leading-normal md:overflow-hidden md:text-ellipsis md:whitespace-nowrap md:text-[30px]"
 								title={appInfo?.project_name}
 							>
 								{appInfo?.project_name}
@@ -549,7 +550,7 @@ export const AppDetailPage = (props: AppDetailsProps) => {
 								<Button
 									disabled={exportLoading}
 									variant="ghost"
-									className="gap-2 text-(--primary) hover:bg-transparent hover:text-(--primary)"
+									className="gap-2 text-primary hover:bg-transparent hover:text-primary"
 									onClick={() => exportApp()}
 									data-testid={"appDetail-export-btn"}
 								>
@@ -633,7 +634,7 @@ export const AppDetailPage = (props: AppDetailsProps) => {
 											<Badge
 												key={`tag-${tag}-${tag}`}
 												variant="outline"
-												className="border-(--primary) text-(--primary)"
+												className="border-primary text-primary"
 											>
 												{tag}
 											</Badge>
@@ -666,7 +667,7 @@ export const AppDetailPage = (props: AppDetailsProps) => {
 					</div>
 				</div>
 
-				<div className="flex flex-col rounded-lg bg-(--muted)">
+				<div className="flex flex-col rounded-lg bg-muted">
 					{visibleTabs.length > 0 && (
 						<Tabs
 							value={selectedTab}
@@ -715,7 +716,7 @@ export const AppDetailPage = (props: AppDetailsProps) => {
 							</div>
 						</Tabs>
 					)}
-					<div className="w-full bg-(--card) p-3 md:p-4">
+					<div className="w-full bg-card p-3 md:p-4">
 						{selectedTab === "Overview" && (
 							<Overview appInfo={appInfo} />
 						)}


### PR DESCRIPTION
## Description
Some pages show infinite loops when reactors error

## Changes Made
Calling notification.add was changing the value of notification.add, which can cause an infinite loop in a useEffect. Wrap notification.add in a callback

## How to Test
Many ways, but here's one:
1. Get on SemossWeb dev
2. In the GetProjectDependencies reactor, have it always throw an exception (for example, add `int tmp = 5 / 0;`)
3. Restart your server
4. On the App info page (where you would normally view dependencies), notice that GetProjectDependencies is called infinitely
5. Get on this branch
6. Rebuild libs/ui and packages/client
7.  On the App info page, verify that the error is shown but without bricking the page

## Notes
<!-- Any further notes regarding changes -->