### PR TITLE
fix to make extensions non-case sensitive

### DIFF
--- a/packages/playground/src/stores/room/room.store.ts
+++ b/packages/playground/src/stores/room/room.store.ts
@@ -846,22 +846,24 @@ export class RoomStore {
 			// set the new files
 			uploaded = response.data;
 
-			// filter the uploaded files to only include allowed file types based on the theme configuration (if configured)
+			const normalizeExt = (value: string) =>
+				value.trim().toLowerCase().replace(/^\./, "");
+
 			mediaInputs = uploaded.filter((f) => {
 				const allowed = this._theme.allowedFileTypes;
 
 				// If not configured (or empty), allow all
-				if (!allowed || allowed.length === 0) {
-					return true;
-				}
+				if (!allowed || allowed.length === 0) return true;
 
-				// get the extension
-				const ext = f.fileName.split(".").pop();
-				if (allowed.indexOf(ext) > -1) {
-					return true;
-				}
+				const allowedSet = new Set(allowed.map(normalizeExt));
 
-				return false;
+				const rawExt = f.fileName.split(".").pop() ?? "";
+				const ext = normalizeExt(rawExt);
+
+				// If there's no extension, it's not allowed (when allow-list is configured)
+				if (!ext) return false;
+
+				return allowedSet.has(ext);
 			});
 		}
 


### PR DESCRIPTION
## Description

## Changes Made

## How to Test
1. Try attaching an image that is PNG, JPG, JPEG, or SVG (case sensitive) to the new-room-page
2. Initiate a chat
3. Check room-page file explorer that the image was uploaded to the room
4. Check AskPlayground that it was sent to backend
5. Both 3 and 4 should have been successful

## Notes