### PR TITLE
WIP: Playground agent page layout

### DIFF
--- a/libs/i18n/src/resources/locales/en/playground/workspace.json
+++ b/libs/i18n/src/resources/locales/en/playground/workspace.json
@@ -112,6 +112,6 @@
 	},
 	"new": {
 		"title": "New Agent",
-		"subtitle": "Create a new agent to get started"
+		"subtitle": "Create an agent with custom instructions and access to tools and resources"
 	}
 }

--- a/packages/playground/src/components/mcp/mcp-selector.tsx
+++ b/packages/playground/src/components/mcp/mcp-selector.tsx
@@ -6,7 +6,7 @@ import {
 	WrenchIcon,
 	XIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "@semoss/i18n";
 import { useInsight, useIteratorPixel } from "@semoss/sdk/react";
 import {
@@ -49,229 +49,219 @@ interface MCPSelectorProps {
 /**
  * Renders the MCPSelector component for selecting mcps within an agent
  */
-export const MCPSelector: React.FC<MCPSelectorProps> = ({
-	type,
-	values,
-	disabled,
-	onChange,
-}) => {
-	const { t } = useTranslation("mcp");
-	const { actions } = useInsight();
-	const [search, setSearch] = useState<string>("");
-	const [isKnowledgeOverlayOpen, setIsKnowledgeOverlayOpen] = useState(false);
-	const [modalMCP, setModalMCP] = useState<MCP | null>(null);
-	const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
+export const MCPSelector = memo<MCPSelectorProps>(
+	({ type, values, disabled, onChange }) => {
+		const { t } = useTranslation("mcp");
+		const { actions } = useInsight();
+		const [search, setSearch] = useState<string>("");
+		const [isKnowledgeOverlayOpen, setIsKnowledgeOverlayOpen] =
+			useState(false);
+		const [modalMCP, setModalMCP] = useState<MCP | null>(null);
+		const [expandedTools, setExpandedTools] = useState<Set<string>>(
+			new Set(),
+		);
 
-	// Tool fetch state (TOOLBOX only — auto-fetched as items load)
-	const [toolsCache, setToolsCache] = useState<Record<string, MCPTool[]>>({});
-	const [toolsLoading, setToolsLoading] = useState<Set<string>>(new Set());
+		// Tool fetch state (TOOLBOX only — auto-fetched as items load)
+		const [toolsCache, setToolsCache] = useState<Record<string, MCPTool[]>>(
+			{},
+		);
+		const [toolsLoading, setToolsLoading] = useState<Set<string>>(
+			new Set(),
+		);
 
-	// Stable refs so fetchTools useCallback has no deps
-	const actionsRef = useRef(actions);
-	actionsRef.current = actions;
-	const fetchedRef = useRef(new Set<string>());
+		// Stable refs so fetchTools useCallback has no deps
+		const actionsRef = useRef(actions);
+		actionsRef.current = actions;
+		const fetchedRef = useRef(new Set<string>());
 
-	const debouncedSearch = useDebouncedValue(search);
+		const debouncedSearch = useDebouncedValue(search);
 
-	// track the selected ones
-	const selected = values.reduce(
-		(acc, curr) => {
-			acc[curr.id] = curr;
-			return acc;
-		},
-		{} as Record<string, MCPConfig>,
-	);
+		// track the selected ones
+		const selected = values.reduce(
+			(acc, curr) => {
+				acc[curr.id] = curr;
+				return acc;
+			},
+			{} as Record<string, MCPConfig>,
+		);
 
-	/**
-	 * Get all of the mcps with lazy loading
-	 */
-	const getMCP = useIteratorPixel<(Engine | App)[], MCP>(
-		(limit, offset) =>
-			`MyEngineProject (metaKeys = ["tag", "description"], metaFilters=[{"tag":["MCP"]}], type=${type === "TOOLBOX" ? `["PROJECT", "STORAGE", "DATABASE", "FUNCTION"]` : `["VECTOR"]`}, ${debouncedSearch ? `filterWord=${JSON.stringify(debouncedSearch)}, ` : ""}limit=[${limit}], offset=[${offset}])`,
-		(response) => {
-			// if its less than the limit, we know its the end
-			if (response.length < 25) {
-				return -1;
-			}
+		/**
+		 * Get all of the mcps with lazy loading
+		 */
+		const getMCP = useIteratorPixel<(Engine | App)[], MCP>(
+			(limit, offset) =>
+				`MyEngineProject (metaKeys = ["tag", "description"], metaFilters=[{"tag":["MCP"]}], type=${type === "TOOLBOX" ? `["PROJECT", "STORAGE", "DATABASE", "FUNCTION"]` : `["VECTOR"]`}, ${debouncedSearch ? `filterWord=${JSON.stringify(debouncedSearch)}, ` : ""}limit=[${limit}], offset=[${offset}])`,
+			(response) => {
+				// if its less than the limit, we know its the end
+				if (response.length < 25) {
+					return -1;
+				}
 
-			return Infinity;
-		},
-		(response) => {
-			return response.map(engineProjectToMCP);
-		},
-		{
-			limit: 25,
-		},
-		[debouncedSearch],
-	);
+				return Infinity;
+			},
+			(response) => {
+				return response.map(engineProjectToMCP);
+			},
+			{
+				limit: 25,
+			},
+			[debouncedSearch],
+		);
 
-	/**
-	 * Setup infinite scroll for the list
-	 */
-	const { setScroll } = useInfiniteScroll({
-		disabled: getMCP.isLoading || !getMCP.hasMore || !open,
-		onNext: () => {
-			getMCP.next();
-		},
-	});
-
-	/**
-	 * Fetch tools for a single MCP — stable, uses ref for actions
-	 */
-	const fetchTools = useCallback(async (id: string) => {
-		if (fetchedRef.current.has(id)) return;
-		fetchedRef.current.add(id);
-
-		setToolsLoading((prev) => {
-			const s = new Set(prev);
-			s.add(id);
-			return s;
+		/**
+		 * Setup infinite scroll for the list
+		 */
+		const { setScroll } = useInfiniteScroll({
+			disabled: getMCP.isLoading || !getMCP.hasMore || !open,
+			onNext: () => {
+				getMCP.next();
+			},
 		});
-		try {
-			const result = await actionsRef.current.run(
-				`GetMCPTools(project=["${id}"]);`,
-			);
-			const tools: MCPTool[] =
-				result?.pixelReturn?.[0]?.output?.tools ?? [];
-			setToolsCache((prev) => ({ ...prev, [id]: tools }));
-		} catch {
-			setToolsCache((prev) => ({ ...prev, [id]: [] }));
-		} finally {
+
+		/**
+		 * Fetch tools for a single MCP — stable, uses ref for actions
+		 */
+		const fetchTools = useCallback(async (id: string) => {
+			if (fetchedRef.current.has(id)) return;
+			fetchedRef.current.add(id);
+
 			setToolsLoading((prev) => {
 				const s = new Set(prev);
-				s.delete(id);
+				s.add(id);
 				return s;
 			});
-		}
-	}, []);
+			try {
+				const result = await actionsRef.current.run(
+					`GetMCPTools(project=["${id}"]);`,
+				);
+				const tools: MCPTool[] =
+					result?.pixelReturn?.[0]?.output?.tools ?? [];
+				setToolsCache((prev) => ({ ...prev, [id]: tools }));
+			} catch {
+				setToolsCache((prev) => ({ ...prev, [id]: [] }));
+			} finally {
+				setToolsLoading((prev) => {
+					const s = new Set(prev);
+					s.delete(id);
+					return s;
+				});
+			}
+		}, []);
 
-	/**
-	 * As new items appear (infinite scroll), fetch their tools
-	 */
-	useEffect(() => {
-		if (type !== "TOOLBOX") return;
-		for (const mcp of getMCP.data) {
-			void fetchTools(mcp.id);
-		}
-	}, [getMCP.data, fetchTools, type]);
+		/**
+		 * As new items appear (infinite scroll), fetch their tools
+		 */
+		useEffect(() => {
+			if (type !== "TOOLBOX") return;
+			for (const mcp of getMCP.data) {
+				void fetchTools(mcp.id);
+			}
+		}, [getMCP.data, fetchTools, type]);
 
-	/**
-	 * Reset expanded tools when the modal MCP changes
-	 */
-	// biome-ignore lint/correctness/useExhaustiveDependencies: modalMCP?.id is an intentional trigger, not a value used in the effect body
-	useEffect(() => {
-		setExpandedTools(new Set());
-	}, [modalMCP?.id]);
+		/**
+		 * Reset expanded tools when the modal MCP changes
+		 */
+		// biome-ignore lint/correctness/useExhaustiveDependencies: modalMCP?.id is an intentional trigger, not a value used in the effect body
+		useEffect(() => {
+			setExpandedTools(new Set());
+		}, [modalMCP?.id]);
 
-	/**
-	 * Select a mcp
-	 */
-	const onSelect = (mcp: MCPConfig) => {
-		// copy for react
-		const updated = {
-			...selected,
+		/**
+		 * Select a mcp
+		 */
+		const onSelect = (mcp: MCPConfig) => {
+			// copy for react
+			const updated = {
+				...selected,
+			};
+
+			if (Object.hasOwn(updated, mcp.id)) {
+				// remove it
+				delete updated[mcp.id];
+			} else {
+				// add it
+				updated[mcp.id] = mcp;
+			}
+
+			onChange(Object.values(updated));
 		};
 
-		if (Object.hasOwn(updated, mcp.id)) {
-			// remove it
-			delete updated[mcp.id];
-		} else {
-			// add it
-			updated[mcp.id] = mcp;
-		}
-
-		onChange(Object.values(updated));
-	};
-
-	return (
-		<div className="w-full overflow-hidden rounded-xl border-border bg-card shadow-sm">
-			{/* Search bar */}
-			<div className="flex w-full flex-row gap-2 border-border bg-primary-foreground p-4">
-				<InputGroup className="bg-background">
-					<InputGroupInput
-						placeholder={t("selector.search")}
-						value={search}
-						disabled={disabled || getMCP.isLoading}
-						onChange={(e) => setSearch(e.target.value)}
-					/>
-					<InputGroupAddon>
-						<SearchIcon />
-					</InputGroupAddon>
-				</InputGroup>
-				{type === "KNOWLEDGE" && (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onClick={(event) => {
-									event.preventDefault();
-									event.stopPropagation();
-									setIsKnowledgeOverlayOpen(true);
-								}}
-								disabled={disabled}
-							>
-								<PlusIcon />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>
-							{t("selector.createKnowledgeSource")}
-						</TooltipContent>
-					</Tooltip>
-				)}
-			</div>
-
-			{/* Scrollable list */}
-			<div ref={(e) => setScroll(e)} className="h-96 overflow-y-auto">
-				{getMCP.isLoading && (
-					<div className="flex h-96 w-full items-center justify-center">
-						<Spinner />
-					</div>
-				)}
-				{!getMCP.isLoading && getMCP.data.length === 0 && (
-					<div className="flex h-96 w-full items-center justify-center">
-						<Muted>
-							{type === "TOOLBOX"
-								? t("selector.noToolboxesFound")
-								: t("selector.noKnowledgeFound")}
-						</Muted>
-					</div>
-				)}
-				{!getMCP.isLoading && getMCP.data.length > 0 && (
-					<div className="divide-y divide-border">
-						{getMCP.data.map((mcp) => {
-							const isSelected = Object.hasOwn(selected, mcp.id);
-							const isFromWorkspace = values.some(
-								(v) => v.id === mcp.id && v.fromWorkspace,
-							);
-							const isLoadingTools = toolsLoading.has(mcp.id);
-							const tools = toolsCache[mcp.id];
-
-							return (
-								<button
-									key={mcp.id}
+		return (
+			<div className="w-full overflow-hidden rounded-xl border-border bg-card shadow-sm">
+				{/* Search bar */}
+				<div className="flex w-full flex-row gap-2 border-border bg-primary-foreground p-4">
+					<InputGroup className="bg-background">
+						<InputGroupInput
+							placeholder={t("selector.search")}
+							value={search}
+							disabled={disabled || getMCP.isLoading}
+							onChange={(e) => setSearch(e.target.value)}
+						/>
+						<InputGroupAddon>
+							<SearchIcon />
+						</InputGroupAddon>
+					</InputGroup>
+					{type === "KNOWLEDGE" && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
 									type="button"
-									onClick={() => {
-										if (type === "TOOLBOX") {
-											setModalMCP(mcp);
-										} else {
-											onSelect({
-												id: mcp.id,
-												name: mcp.name,
-												type: mcp.type,
-											});
-										}
+									variant="outline"
+									size="sm"
+									onClick={(event) => {
+										event.preventDefault();
+										event.stopPropagation();
+										setIsKnowledgeOverlayOpen(true);
 									}}
-									className={`flex w-full items-start gap-3 px-4 py-3 text-left transition hover:bg-muted/40 ${disabled || isFromWorkspace ? "pointer-events-none opacity-60" : ""}`}
-									disabled={disabled || isFromWorkspace}
+									disabled={disabled}
 								>
-									{/* Plain div checkbox — avoids Radix usePresence ref loop */}
-									<div
-										aria-hidden="true"
-										onClick={(e) => {
-											e.stopPropagation();
-											if (!disabled && !isFromWorkspace) {
+									<PlusIcon />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>
+								{t("selector.createKnowledgeSource")}
+							</TooltipContent>
+						</Tooltip>
+					)}
+				</div>
+
+				{/* Scrollable list */}
+				<div ref={(e) => setScroll(e)} className="h-96 overflow-y-auto">
+					{getMCP.isLoading && (
+						<div className="flex h-96 w-full items-center justify-center">
+							<Spinner />
+						</div>
+					)}
+					{!getMCP.isLoading && getMCP.data.length === 0 && (
+						<div className="flex h-96 w-full items-center justify-center">
+							<Muted>
+								{type === "TOOLBOX"
+									? t("selector.noToolboxesFound")
+									: t("selector.noKnowledgeFound")}
+							</Muted>
+						</div>
+					)}
+					{!getMCP.isLoading && getMCP.data.length > 0 && (
+						<div className="divide-y divide-border">
+							{getMCP.data.map((mcp) => {
+								const isSelected = Object.hasOwn(
+									selected,
+									mcp.id,
+								);
+								const isFromWorkspace = values.some(
+									(v) => v.id === mcp.id && v.fromWorkspace,
+								);
+								const isLoadingTools = toolsLoading.has(mcp.id);
+								const tools = toolsCache[mcp.id];
+
+								return (
+									<button
+										key={mcp.id}
+										type="button"
+										onClick={() => {
+											if (type === "TOOLBOX") {
+												setModalMCP(mcp);
+											} else {
 												onSelect({
 													id: mcp.id,
 													name: mcp.name,
@@ -279,261 +269,290 @@ export const MCPSelector: React.FC<MCPSelectorProps> = ({
 												});
 											}
 										}}
-										className={`mt-0.5 flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-[4px] border shadow-xs ${isSelected ? "border-primary bg-primary text-primary-foreground" : "border-input bg-transparent dark:bg-input/30"}`}
+										className={`flex w-full items-start gap-3 px-4 py-3 text-left transition hover:bg-muted/40 ${disabled || isFromWorkspace ? "pointer-events-none opacity-60" : ""}`}
+										disabled={disabled || isFromWorkspace}
 									>
-										{isSelected && (
-											<CheckIcon className="h-3 w-3" />
-										)}
-									</div>
-
-									{/* Name, description, tool pills */}
-									<div className="min-w-0 flex-1">
-										<div className="flex items-center gap-2">
-											<span className="truncate font-medium text-sm">
-												{mcp.name}
-											</span>
+										{/* Plain div checkbox — avoids Radix usePresence ref loop */}
+										<div
+											aria-hidden="true"
+											onClick={(e) => {
+												e.stopPropagation();
+												if (
+													!disabled &&
+													!isFromWorkspace
+												) {
+													onSelect({
+														id: mcp.id,
+														name: mcp.name,
+														type: mcp.type,
+													});
+												}
+											}}
+											className={`mt-0.5 flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-[4px] border shadow-xs ${isSelected ? "border-primary bg-primary text-primary-foreground" : "border-input bg-transparent dark:bg-input/30"}`}
+										>
+											{isSelected && (
+												<CheckIcon className="h-3 w-3" />
+											)}
 										</div>
-										{mcp.description && (
-											<p className="truncate text-muted-foreground text-xs">
-												{mcp.description}
-											</p>
-										)}
 
-										{/* Tool list — dot-separated */}
-										{type === "TOOLBOX" && (
-											<div className="mt-1">
-												{isLoadingTools && (
-													<div className="flex items-center gap-1.5">
-														<Spinner className="size-3" />
-														<span className="text-muted-foreground text-xs">
-															Loading tools…
-														</span>
-													</div>
-												)}
-												{!isLoadingTools &&
-													tools !== undefined &&
-													tools.length > 0 && (
-														<div className="mt-0.5 flex items-center gap-2 overflow-hidden">
-															<span className="inline-flex shrink-0 items-center rounded-full border border-border bg-muted px-2 py-0.5 font-medium text-muted-foreground text-xs">
-																{tools.length}{" "}
-																{tools.length ===
-																1
-																	? "tool"
-																	: "tools"}
+										{/* Name, description, tool pills */}
+										<div className="min-w-0 flex-1">
+											<div className="flex items-center gap-2">
+												<span className="truncate font-medium text-sm">
+													{mcp.name}
+												</span>
+											</div>
+											{mcp.description && (
+												<p className="truncate text-muted-foreground text-xs">
+													{mcp.description}
+												</p>
+											)}
+
+											{/* Tool list — dot-separated */}
+											{type === "TOOLBOX" && (
+												<div className="mt-1">
+													{isLoadingTools && (
+														<div className="flex items-center gap-1.5">
+															<Spinner className="size-3" />
+															<span className="text-muted-foreground text-xs">
+																Loading tools…
 															</span>
-															<p className="min-w-0 truncate text-muted-foreground text-xs">
-																{tools
-																	.map(
-																		(
-																			tool,
-																		) =>
-																			tool.title ||
-																			tool.name,
-																	)
-																	.join(
-																		" · ",
-																	)}
-															</p>
 														</div>
 													)}
-											</div>
-										)}
-									</div>
-								</button>
-							);
-						})}
-					</div>
-				)}
-			</div>
-
-			{/* Selected badges strip */}
-			{values.length > 0 && (
-				<ScrollArea className="w-full whitespace-nowrap">
-					<ScrollBar orientation="horizontal" />
-					<div className="flex space-x-2 p-4">
-						{values.map((t) => (
-							<Badge
-								key={t.id}
-								variant="secondary"
-								className="text-sm"
-								title={t.name}
-							>
-								<div className="w-32 truncate">{t.name}</div>
-								<Button
-									className="ml-1"
-									type="button"
-									variant="ghost"
-									size="icon-sm"
-									disabled={disabled || t.fromWorkspace}
-									onClick={() => {
-										onSelect(t);
-									}}
-								>
-									<XIcon />
-								</Button>
-							</Badge>
-						))}
-					</div>
-				</ScrollArea>
-			)}
-
-			<NewKnowledgeOverlay
-				key={`${getMCP?.data?.length}`}
-				open={isKnowledgeOverlayOpen}
-				onClose={(knowledge) => {
-					// update it
-					if (knowledge) {
-						onChange([...values, knowledge]);
-						// refresh the list to show the newly created knowledge store selected
-						getMCP.reset();
-					}
-
-					// close the overlay
-					setIsKnowledgeOverlayOpen(false);
-				}}
-			/>
-
-			{/* Tool details modal - TOOLBOX only */}
-			<Dialog
-				open={modalMCP !== null}
-				onOpenChange={(open) => {
-					if (!open) setModalMCP(null);
-				}}
-			>
-				<DialogContent className="max-w-lg">
-					<DialogHeader>
-						<DialogTitle>{modalMCP?.name}</DialogTitle>
-					</DialogHeader>
-
-					{modalMCP?.description && (
-						<p className="text-muted-foreground text-sm">
-							{modalMCP.description}
-						</p>
-					)}
-
-					{/* Loading */}
-					{modalMCP && toolsLoading.has(modalMCP.id) && (
-						<div className="flex items-center gap-2 py-4">
-							<Spinner className="size-4" />
-							<span className="text-muted-foreground text-sm">
-								Loading tools…
-							</span>
+													{!isLoadingTools &&
+														tools !== undefined &&
+														tools.length > 0 && (
+															<div className="mt-0.5 flex items-center gap-2 overflow-hidden">
+																<span className="inline-flex shrink-0 items-center rounded-full border border-border bg-muted px-2 py-0.5 font-medium text-muted-foreground text-xs">
+																	{
+																		tools.length
+																	}{" "}
+																	{tools.length ===
+																	1
+																		? "tool"
+																		: "tools"}
+																</span>
+																<p className="min-w-0 truncate text-muted-foreground text-xs">
+																	{tools
+																		.map(
+																			(
+																				tool,
+																			) =>
+																				tool.title ||
+																				tool.name,
+																		)
+																		.join(
+																			" · ",
+																		)}
+																</p>
+															</div>
+														)}
+												</div>
+											)}
+										</div>
+									</button>
+								);
+							})}
 						</div>
 					)}
+				</div>
 
-					{/* Tool list */}
-					{modalMCP &&
-						!toolsLoading.has(modalMCP.id) &&
-						toolsCache[modalMCP.id] && (
-							<div className="max-h-72 overflow-y-auto">
-								{toolsCache[modalMCP.id].length === 0 ? (
-									<p className="py-4 text-center text-muted-foreground text-sm">
-										No tools available
-									</p>
-								) : (
-									<div className="divide-y divide-border">
-										{toolsCache[modalMCP.id].map((tool) => {
-											const isExpanded =
-												expandedTools.has(tool.name);
-											const hasDesc = Boolean(
-												tool.description,
-											);
-											return (
-												<button
-													key={tool.name}
-													type="button"
-													onClick={() => {
-														if (!hasDesc) return;
-														setExpandedTools(
-															(prev) => {
-																const next =
-																	new Set(
-																		prev,
-																	);
-																if (
-																	next.has(
-																		tool.name,
-																	)
-																)
-																	next.delete(
-																		tool.name,
-																	);
-																else
-																	next.add(
-																		tool.name,
-																	);
-																return next;
-															},
-														);
-													}}
-													className="flex w-full items-start gap-3 py-3 text-left"
-												>
-													<WrenchIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-													<div className="min-w-0 flex-1">
-														<div className="flex items-center justify-between gap-2">
-															<p className="font-semibold text-sm">
-																{tool.title ||
-																	tool.name}
-															</p>
-															{hasDesc && (
-																<ChevronDownIcon
-																	className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${isExpanded ? "rotate-180" : ""}`}
-																/>
-															)}
-														</div>
-														{isExpanded &&
-															hasDesc && (
-																<p className="mt-1 text-muted-foreground text-xs leading-relaxed">
-																	{
-																		tool.description
-																	}
-																</p>
-															)}
-													</div>
-												</button>
-											);
-										})}
+				{/* Selected badges strip */}
+				{values.length > 0 && (
+					<ScrollArea className="w-full whitespace-nowrap">
+						<ScrollBar orientation="horizontal" />
+						<div className="flex space-x-2 p-4">
+							{values.map((t) => (
+								<Badge
+									key={t.id}
+									variant="secondary"
+									className="text-sm"
+									title={t.name}
+								>
+									<div className="w-32 truncate">
+										{t.name}
 									</div>
-								)}
+									<Button
+										className="ml-1"
+										type="button"
+										variant="ghost"
+										size="icon-sm"
+										disabled={disabled || t.fromWorkspace}
+										onClick={() => {
+											onSelect(t);
+										}}
+									>
+										<XIcon />
+									</Button>
+								</Badge>
+							))}
+						</div>
+					</ScrollArea>
+				)}
+
+				<NewKnowledgeOverlay
+					key={`${getMCP?.data?.length}`}
+					open={isKnowledgeOverlayOpen}
+					onClose={(knowledge) => {
+						// update it
+						if (knowledge) {
+							onChange([...values, knowledge]);
+							// refresh the list to show the newly created knowledge store selected
+							getMCP.reset();
+						}
+
+						// close the overlay
+						setIsKnowledgeOverlayOpen(false);
+					}}
+				/>
+
+				{/* Tool details modal - TOOLBOX only */}
+				<Dialog
+					open={modalMCP !== null}
+					onOpenChange={(open) => {
+						if (!open) setModalMCP(null);
+					}}
+				>
+					<DialogContent className="max-w-lg">
+						<DialogHeader>
+							<DialogTitle>{modalMCP?.name}</DialogTitle>
+						</DialogHeader>
+
+						{modalMCP?.description && (
+							<p className="text-muted-foreground text-sm">
+								{modalMCP.description}
+							</p>
+						)}
+
+						{/* Loading */}
+						{modalMCP && toolsLoading.has(modalMCP.id) && (
+							<div className="flex items-center gap-2 py-4">
+								<Spinner className="size-4" />
+								<span className="text-muted-foreground text-sm">
+									Loading tools…
+								</span>
 							</div>
 						)}
 
-					<div className="flex justify-end gap-2 pt-2">
-						<Button
-							type="button"
-							variant="outline"
-							onClick={() => setModalMCP(null)}
-						>
-							Close
-						</Button>
-						{modalMCP && (
+						{/* Tool list */}
+						{modalMCP &&
+							!toolsLoading.has(modalMCP.id) &&
+							toolsCache[modalMCP.id] && (
+								<div className="max-h-72 overflow-y-auto">
+									{toolsCache[modalMCP.id].length === 0 ? (
+										<p className="py-4 text-center text-muted-foreground text-sm">
+											No tools available
+										</p>
+									) : (
+										<div className="divide-y divide-border">
+											{toolsCache[modalMCP.id].map(
+												(tool) => {
+													const isExpanded =
+														expandedTools.has(
+															tool.name,
+														);
+													const hasDesc = Boolean(
+														tool.description,
+													);
+													return (
+														<button
+															key={tool.name}
+															type="button"
+															onClick={() => {
+																if (!hasDesc)
+																	return;
+																setExpandedTools(
+																	(prev) => {
+																		const next =
+																			new Set(
+																				prev,
+																			);
+																		if (
+																			next.has(
+																				tool.name,
+																			)
+																		)
+																			next.delete(
+																				tool.name,
+																			);
+																		else
+																			next.add(
+																				tool.name,
+																			);
+																		return next;
+																	},
+																);
+															}}
+															className="flex w-full items-start gap-3 py-3 text-left"
+														>
+															<WrenchIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+															<div className="min-w-0 flex-1">
+																<div className="flex items-center justify-between gap-2">
+																	<p className="font-semibold text-sm">
+																		{tool.title ||
+																			tool.name}
+																	</p>
+																	{hasDesc && (
+																		<ChevronDownIcon
+																			className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${isExpanded ? "rotate-180" : ""}`}
+																		/>
+																	)}
+																</div>
+																{isExpanded &&
+																	hasDesc && (
+																		<p className="mt-1 text-muted-foreground text-xs leading-relaxed">
+																			{
+																				tool.description
+																			}
+																		</p>
+																	)}
+															</div>
+														</button>
+													);
+												},
+											)}
+										</div>
+									)}
+								</div>
+							)}
+
+						<div className="flex justify-end gap-2 pt-2">
 							<Button
 								type="button"
-								disabled={
-									disabled ||
-									values.some(
-										(v) =>
-											v.id === modalMCP.id &&
-											v.fromWorkspace,
-									)
-								}
-								onClick={() => {
-									onSelect({
-										id: modalMCP.id,
-										name: modalMCP.name,
-										type: modalMCP.type,
-									});
-									setModalMCP(null);
-								}}
+								variant="outline"
+								onClick={() => setModalMCP(null)}
 							>
-								{Object.hasOwn(selected, modalMCP.id)
-									? "Deselect"
-									: "Select"}
+								Close
 							</Button>
-						)}
-					</div>
-				</DialogContent>
-			</Dialog>
-		</div>
-	);
-};
+							{modalMCP && (
+								<Button
+									type="button"
+									disabled={
+										disabled ||
+										values.some(
+											(v) =>
+												v.id === modalMCP.id &&
+												v.fromWorkspace,
+										)
+									}
+									onClick={() => {
+										onSelect({
+											id: modalMCP.id,
+											name: modalMCP.name,
+											type: modalMCP.type,
+										});
+										setModalMCP(null);
+									}}
+								>
+									{Object.hasOwn(selected, modalMCP.id)
+										? "Deselect"
+										: "Select"}
+								</Button>
+							)}
+						</div>
+					</DialogContent>
+				</Dialog>
+			</div>
+		);
+	},
+);

--- a/packages/playground/src/components/mcp/mcp-selector.tsx
+++ b/packages/playground/src/components/mcp/mcp-selector.tsx
@@ -1,21 +1,21 @@
 import {
+	CheckIcon,
+	ChevronDownIcon,
 	PlusIcon,
 	SearchIcon,
-	SquareArrowOutUpRightIcon,
+	WrenchIcon,
 	XIcon,
 } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "@semoss/i18n";
-import { useIteratorPixel } from "@semoss/sdk/react";
+import { useInsight, useIteratorPixel } from "@semoss/sdk/react";
 import {
 	Badge,
 	Button,
-	Checkbox,
-	Field,
-	FieldContent,
-	FieldDescription,
-	FieldLabel,
-	FieldTitle,
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
 	InputGroup,
 	InputGroupAddon,
 	InputGroupInput,
@@ -29,12 +29,8 @@ import {
 	useDebouncedValue,
 	useInfiniteScroll,
 } from "@semoss/ui/next";
-import {
-	engineProjectToMCP,
-	mcpToPlatformUrl,
-	NewKnowledgeOverlay,
-} from "@/components";
-import type { App, Engine, MCP, MCPConfig } from "@/types";
+import { engineProjectToMCP, NewKnowledgeOverlay } from "@/components";
+import type { App, Engine, MCP, MCPConfig, MCPTool } from "@/types";
 
 interface MCPSelectorProps {
 	/** Type of mcp */
@@ -60,12 +56,24 @@ export const MCPSelector: React.FC<MCPSelectorProps> = ({
 	onChange,
 }) => {
 	const { t } = useTranslation("mcp");
+	const { actions } = useInsight();
 	const [search, setSearch] = useState<string>("");
 	const [isKnowledgeOverlayOpen, setIsKnowledgeOverlayOpen] = useState(false);
+	const [modalMCP, setModalMCP] = useState<MCP | null>(null);
+	const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
+
+	// Tool fetch state (TOOLBOX only — auto-fetched as items load)
+	const [toolsCache, setToolsCache] = useState<Record<string, MCPTool[]>>({});
+	const [toolsLoading, setToolsLoading] = useState<Set<string>>(new Set());
+
+	// Stable refs so fetchTools useCallback has no deps
+	const actionsRef = useRef(actions);
+	actionsRef.current = actions;
+	const fetchedRef = useRef(new Set<string>());
 
 	const debouncedSearch = useDebouncedValue(search);
 
-	// track the selected one
+	// track the selected ones
 	const selected = values.reduce(
 		(acc, curr) => {
 			acc[curr.id] = curr;
@@ -98,7 +106,7 @@ export const MCPSelector: React.FC<MCPSelectorProps> = ({
 	);
 
 	/**
-	 * Setup infinite scroll for the command list
+	 * Setup infinite scroll for the list
 	 */
 	const { setScroll } = useInfiniteScroll({
 		disabled: getMCP.isLoading || !getMCP.hasMore || !open,
@@ -106,6 +114,54 @@ export const MCPSelector: React.FC<MCPSelectorProps> = ({
 			getMCP.next();
 		},
 	});
+
+	/**
+	 * Fetch tools for a single MCP — stable, uses ref for actions
+	 */
+	const fetchTools = useCallback(async (id: string) => {
+		if (fetchedRef.current.has(id)) return;
+		fetchedRef.current.add(id);
+
+		setToolsLoading((prev) => {
+			const s = new Set(prev);
+			s.add(id);
+			return s;
+		});
+		try {
+			const result = await actionsRef.current.run(
+				`GetMCPTools(project=["${id}"]);`,
+			);
+			const tools: MCPTool[] =
+				result?.pixelReturn?.[0]?.output?.tools ?? [];
+			setToolsCache((prev) => ({ ...prev, [id]: tools }));
+		} catch {
+			setToolsCache((prev) => ({ ...prev, [id]: [] }));
+		} finally {
+			setToolsLoading((prev) => {
+				const s = new Set(prev);
+				s.delete(id);
+				return s;
+			});
+		}
+	}, []);
+
+	/**
+	 * As new items appear (infinite scroll), fetch their tools
+	 */
+	useEffect(() => {
+		if (type !== "TOOLBOX") return;
+		for (const mcp of getMCP.data) {
+			void fetchTools(mcp.id);
+		}
+	}, [getMCP.data, fetchTools, type]);
+
+	/**
+	 * Reset expanded tools when the modal MCP changes
+	 */
+	// biome-ignore lint/correctness/useExhaustiveDependencies: modalMCP?.id is an intentional trigger, not a value used in the effect body
+	useEffect(() => {
+		setExpandedTools(new Set());
+	}, [modalMCP?.id]);
 
 	/**
 	 * Select a mcp
@@ -129,6 +185,7 @@ export const MCPSelector: React.FC<MCPSelectorProps> = ({
 
 	return (
 		<div className="w-full overflow-hidden rounded-xl border-border bg-card shadow-sm">
+			{/* Search bar */}
 			<div className="flex w-full flex-row gap-2 border-border bg-primary-foreground p-4">
 				<InputGroup className="bg-background">
 					<InputGroupInput
@@ -145,6 +202,7 @@ export const MCPSelector: React.FC<MCPSelectorProps> = ({
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<Button
+								type="button"
 								variant="outline"
 								size="sm"
 								onClick={(event) => {
@@ -164,10 +222,8 @@ export const MCPSelector: React.FC<MCPSelectorProps> = ({
 				)}
 			</div>
 
-			<ScrollArea
-				className="h-96 w-full flex-1"
-				viewportRef={(e) => setScroll(e)}
-			>
+			{/* Scrollable list */}
+			<div ref={(e) => setScroll(e)} className="h-96 overflow-y-auto">
 				{getMCP.isLoading && (
 					<div className="flex h-96 w-full items-center justify-center">
 						<Spinner />
@@ -182,73 +238,118 @@ export const MCPSelector: React.FC<MCPSelectorProps> = ({
 						</Muted>
 					</div>
 				)}
-				{!getMCP.isLoading && getMCP.data.length !== 0 && (
-					<div className="grid grid-cols-1 gap-4 p-4 md:grid-cols-2">
-						{getMCP.data.map((mcp) => (
-							<FieldLabel key={mcp.id} className="col-span-1">
-								<Field
-									orientation="horizontal"
-									className="pb-2!"
-								>
-									<FieldContent>
-										<FieldTitle
-											className="line-clamp-1"
-											title={mcp.name}
-										>
-											{mcp.name}
-										</FieldTitle>
-										{mcp.description && (
-											<FieldDescription
-												className="line-clamp-2"
-												title={mcp.description}
-											>
-												{mcp.description}
-											</FieldDescription>
-										)}
-									</FieldContent>
+				{!getMCP.isLoading && getMCP.data.length > 0 && (
+					<div className="divide-y divide-border">
+						{getMCP.data.map((mcp) => {
+							const isSelected = Object.hasOwn(selected, mcp.id);
+							const isFromWorkspace = values.some(
+								(v) => v.id === mcp.id && v.fromWorkspace,
+							);
+							const isLoadingTools = toolsLoading.has(mcp.id);
+							const tools = toolsCache[mcp.id];
 
-									<Checkbox
-										className="data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-white"
-										disabled={
-											disabled ||
-											values.some(
-												(a) =>
-													a.id === mcp.id &&
-													a.fromWorkspace,
-											)
+							return (
+								<button
+									key={mcp.id}
+									type="button"
+									onClick={() => {
+										if (type === "TOOLBOX") {
+											setModalMCP(mcp);
+										} else {
+											onSelect({
+												id: mcp.id,
+												name: mcp.name,
+												type: mcp.type,
+											});
 										}
-										checked={Object.hasOwn(
-											selected,
-											mcp.id,
-										)}
-										onCheckedChange={() => {
-											onSelect(mcp);
+									}}
+									className={`flex w-full items-start gap-3 px-4 py-3 text-left transition hover:bg-muted/40 ${disabled || isFromWorkspace ? "pointer-events-none opacity-60" : ""}`}
+									disabled={disabled || isFromWorkspace}
+								>
+									{/* Plain div checkbox — avoids Radix usePresence ref loop */}
+									<div
+										aria-hidden="true"
+										onClick={(e) => {
+											e.stopPropagation();
+											if (!disabled && !isFromWorkspace) {
+												onSelect({
+													id: mcp.id,
+													name: mcp.name,
+													type: mcp.type,
+												});
+											}
 										}}
-									/>
-								</Field>
-								<div className="flex w-full flex-row justify-end px-4 pb-4">
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<a
-												target="_blank"
-												href={mcpToPlatformUrl(mcp)}
-											>
-												<SquareArrowOutUpRightIcon className="size-4" />
-											</a>
-										</TooltipTrigger>
-										<TooltipContent>
-											{t("selector.viewDetails")}
-										</TooltipContent>
-									</Tooltip>
-								</div>
-							</FieldLabel>
-						))}
+										className={`mt-0.5 flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded-[4px] border shadow-xs ${isSelected ? "border-primary bg-primary text-primary-foreground" : "border-input bg-transparent dark:bg-input/30"}`}
+									>
+										{isSelected && (
+											<CheckIcon className="h-3 w-3" />
+										)}
+									</div>
+
+									{/* Name, description, tool pills */}
+									<div className="min-w-0 flex-1">
+										<div className="flex items-center gap-2">
+											<span className="truncate font-medium text-sm">
+												{mcp.name}
+											</span>
+										</div>
+										{mcp.description && (
+											<p className="truncate text-muted-foreground text-xs">
+												{mcp.description}
+											</p>
+										)}
+
+										{/* Tool list — dot-separated */}
+										{type === "TOOLBOX" && (
+											<div className="mt-1">
+												{isLoadingTools && (
+													<div className="flex items-center gap-1.5">
+														<Spinner className="size-3" />
+														<span className="text-muted-foreground text-xs">
+															Loading tools…
+														</span>
+													</div>
+												)}
+												{!isLoadingTools &&
+													tools !== undefined &&
+													tools.length > 0 && (
+														<div className="mt-0.5 flex items-center gap-2 overflow-hidden">
+															<span className="inline-flex shrink-0 items-center rounded-full border border-border bg-muted px-2 py-0.5 font-medium text-muted-foreground text-xs">
+																{tools.length}{" "}
+																{tools.length ===
+																1
+																	? "tool"
+																	: "tools"}
+															</span>
+															<p className="min-w-0 truncate text-muted-foreground text-xs">
+																{tools
+																	.map(
+																		(
+																			tool,
+																		) =>
+																			tool.title ||
+																			tool.name,
+																	)
+																	.join(
+																		" · ",
+																	)}
+															</p>
+														</div>
+													)}
+											</div>
+										)}
+									</div>
+								</button>
+							);
+						})}
 					</div>
 				)}
-			</ScrollArea>
+			</div>
+
+			{/* Selected badges strip */}
 			{values.length > 0 && (
 				<ScrollArea className="w-full whitespace-nowrap">
-					<ScrollBar orientation="horizontal"></ScrollBar>
+					<ScrollBar orientation="horizontal" />
 					<div className="flex space-x-2 p-4">
 						{values.map((t) => (
 							<Badge
@@ -275,6 +376,7 @@ export const MCPSelector: React.FC<MCPSelectorProps> = ({
 					</div>
 				</ScrollArea>
 			)}
+
 			<NewKnowledgeOverlay
 				key={`${getMCP?.data?.length}`}
 				open={isKnowledgeOverlayOpen}
@@ -290,6 +392,148 @@ export const MCPSelector: React.FC<MCPSelectorProps> = ({
 					setIsKnowledgeOverlayOpen(false);
 				}}
 			/>
+
+			{/* Tool details modal - TOOLBOX only */}
+			<Dialog
+				open={modalMCP !== null}
+				onOpenChange={(open) => {
+					if (!open) setModalMCP(null);
+				}}
+			>
+				<DialogContent className="max-w-lg">
+					<DialogHeader>
+						<DialogTitle>{modalMCP?.name}</DialogTitle>
+					</DialogHeader>
+
+					{modalMCP?.description && (
+						<p className="text-muted-foreground text-sm">
+							{modalMCP.description}
+						</p>
+					)}
+
+					{/* Loading */}
+					{modalMCP && toolsLoading.has(modalMCP.id) && (
+						<div className="flex items-center gap-2 py-4">
+							<Spinner className="size-4" />
+							<span className="text-muted-foreground text-sm">
+								Loading tools…
+							</span>
+						</div>
+					)}
+
+					{/* Tool list */}
+					{modalMCP &&
+						!toolsLoading.has(modalMCP.id) &&
+						toolsCache[modalMCP.id] && (
+							<div className="max-h-72 overflow-y-auto">
+								{toolsCache[modalMCP.id].length === 0 ? (
+									<p className="py-4 text-center text-muted-foreground text-sm">
+										No tools available
+									</p>
+								) : (
+									<div className="divide-y divide-border">
+										{toolsCache[modalMCP.id].map((tool) => {
+											const isExpanded =
+												expandedTools.has(tool.name);
+											const hasDesc = Boolean(
+												tool.description,
+											);
+											return (
+												<button
+													key={tool.name}
+													type="button"
+													onClick={() => {
+														if (!hasDesc) return;
+														setExpandedTools(
+															(prev) => {
+																const next =
+																	new Set(
+																		prev,
+																	);
+																if (
+																	next.has(
+																		tool.name,
+																	)
+																)
+																	next.delete(
+																		tool.name,
+																	);
+																else
+																	next.add(
+																		tool.name,
+																	);
+																return next;
+															},
+														);
+													}}
+													className="flex w-full items-start gap-3 py-3 text-left"
+												>
+													<WrenchIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+													<div className="min-w-0 flex-1">
+														<div className="flex items-center justify-between gap-2">
+															<p className="font-semibold text-sm">
+																{tool.title ||
+																	tool.name}
+															</p>
+															{hasDesc && (
+																<ChevronDownIcon
+																	className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${isExpanded ? "rotate-180" : ""}`}
+																/>
+															)}
+														</div>
+														{isExpanded &&
+															hasDesc && (
+																<p className="mt-1 text-muted-foreground text-xs leading-relaxed">
+																	{
+																		tool.description
+																	}
+																</p>
+															)}
+													</div>
+												</button>
+											);
+										})}
+									</div>
+								)}
+							</div>
+						)}
+
+					<div className="flex justify-end gap-2 pt-2">
+						<Button
+							type="button"
+							variant="outline"
+							onClick={() => setModalMCP(null)}
+						>
+							Close
+						</Button>
+						{modalMCP && (
+							<Button
+								type="button"
+								disabled={
+									disabled ||
+									values.some(
+										(v) =>
+											v.id === modalMCP.id &&
+											v.fromWorkspace,
+									)
+								}
+								onClick={() => {
+									onSelect({
+										id: modalMCP.id,
+										name: modalMCP.name,
+										type: modalMCP.type,
+									});
+									setModalMCP(null);
+								}}
+							>
+								{Object.hasOwn(selected, modalMCP.id)
+									? "Deselect"
+									: "Select"}
+							</Button>
+						)}
+					</div>
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 };

--- a/packages/playground/src/components/mcp/mcp-selector.tsx
+++ b/packages/playground/src/components/mcp/mcp-selector.tsx
@@ -165,16 +165,16 @@ export const MCPSelector: React.FC<MCPSelectorProps> = ({
 			</div>
 
 			<ScrollArea
-				className="h-64 w-full flex-1"
+				className="h-96 w-full flex-1"
 				viewportRef={(e) => setScroll(e)}
 			>
 				{getMCP.isLoading && (
-					<div className="flex h-64 w-full items-center justify-center">
+					<div className="flex h-96 w-full items-center justify-center">
 						<Spinner />
 					</div>
 				)}
 				{!getMCP.isLoading && getMCP.data.length === 0 && (
-					<div className="flex h-64 w-full items-center justify-center">
+					<div className="flex h-96 w-full items-center justify-center">
 						<Muted>
 							{type === "TOOLBOX"
 								? t("selector.noToolboxesFound")

--- a/packages/playground/src/components/workspace/index.ts
+++ b/packages/playground/src/components/workspace/index.ts
@@ -1,3 +1,4 @@
+export * from "./knowledge-selector";
 export * from "./members";
 export * from "./workspace-card";
 export * from "./workspace-chat-list";

--- a/packages/playground/src/components/workspace/knowledge-selector.tsx
+++ b/packages/playground/src/components/workspace/knowledge-selector.tsx
@@ -1,0 +1,648 @@
+import {
+	BookmarkIcon,
+	CheckIcon,
+	ChevronDownIcon,
+	FileIcon,
+	FileImageIcon,
+	FileSpreadsheetIcon,
+	FileTextIcon,
+	InfoIcon,
+	PlusIcon,
+	SearchIcon,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Env, post, useInsight, usePixel } from "@semoss/sdk/react";
+import {
+	Badge,
+	Button,
+	Checkbox,
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+	Spinner,
+	toast,
+} from "@semoss/ui/next";
+import { NewKnowledgeOverlay } from "@/components/knowledge/new-knowledge-mcp-overlay";
+import type { MCPConfig } from "@/types";
+import { formatDateTime } from "@/utility";
+
+type KnowledgeItem = {
+	id: string;
+	name: string;
+	description: string;
+	tags: string[];
+	dateCreated: string;
+	favorite: boolean;
+};
+
+type EngineAsset = {
+	fileName?: string;
+	name?: string;
+	path?: string;
+	type?: string;
+	lastModified?: string;
+	fileSize?: string | number;
+};
+
+const getFileIcon = (fileName: string) => {
+	const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
+	if (ext === "pdf")
+		return <FileTextIcon className="h-4 w-4 shrink-0 text-red-500" />;
+	if (ext === "doc" || ext === "docx")
+		return <FileTextIcon className="h-4 w-4 shrink-0 text-blue-500" />;
+	if (ext === "xls" || ext === "xlsx" || ext === "csv")
+		return (
+			<FileSpreadsheetIcon className="h-4 w-4 shrink-0 text-green-600" />
+		);
+	if (["png", "jpg", "jpeg", "gif", "webp", "svg"].includes(ext))
+		return <FileImageIcon className="h-4 w-4 shrink-0 text-purple-500" />;
+	return <FileIcon className="h-4 w-4 shrink-0 text-muted-foreground" />;
+};
+
+const formatFileSize = (fileSize: string | number): string => {
+	const s = String(fileSize ?? "");
+	const match = s.match(/^([\d.]+)\s*(KB|MB|GB|B)?$/i);
+	if (!match) return s;
+	const num = parseFloat(match[1]);
+	const unit = (match[2] ?? "B").toUpperCase();
+	let bytes = num;
+	if (unit === "GB") bytes = num * 1024 * 1024 * 1024;
+	else if (unit === "MB") bytes = num * 1024 * 1024;
+	else if (unit === "KB") bytes = num * 1024;
+	if (bytes === 0) return s;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+interface KnowledgeSelectorProps {
+	values: MCPConfig[];
+	onChange: (values: MCPConfig[]) => void;
+	disabled?: boolean;
+}
+
+export const KnowledgeSelector = ({
+	values,
+	onChange,
+	disabled = false,
+}: KnowledgeSelectorProps) => {
+	const { actions } = useInsight();
+
+	// Filter / sort state
+	const [search, setSearch] = useState("");
+	const [tagFilter, setTagFilter] = useState<string[]>([]);
+	const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
+	const [sortBy, setSortBy] = useState<"name" | "date">("name");
+
+	// Local favorite overrides (optimistic updates)
+	const [favorites, setFavorites] = useState<Record<string, boolean>>({});
+
+	// Create new knowledge
+	const [newKnowledgeOpen, setNewKnowledgeOpen] = useState(false);
+
+	// Info / document modal
+	const [infoItem, setInfoItem] = useState<KnowledgeItem | null>(null);
+	const [docAssets, setDocAssets] = useState<EngineAsset[]>([]);
+	const [docLoading, setDocLoading] = useState(false);
+	const [docError, setDocError] = useState<string | null>(null);
+
+	// Fetch all vector engines (same pixel as the main knowledge page)
+	const getKnowledge = usePixel<
+		{
+			app_id?: string;
+			app_name?: string;
+			app_favorite?: number;
+			database_date_created?: string;
+			database_favorite?: number;
+			description?: string;
+			tag?: string | string[];
+		}[]
+	>(`MyEngines(engineTypes=['VECTOR'], metaKeys=["description","tag"]);`, {
+		data: [],
+	});
+
+	// Normalize raw pixel response into typed items
+	const items: KnowledgeItem[] = useMemo(() => {
+		if (!getKnowledge.data) return [];
+		return getKnowledge.data.map((item) => {
+			const rawTag = item.tag;
+			const tags = Array.isArray(rawTag)
+				? rawTag
+				: rawTag
+					? [rawTag]
+					: [];
+			return {
+				id: item.app_id || "",
+				name: item.app_name || "Untitled",
+				description: item.description || "",
+				tags,
+				dateCreated: item.database_date_created || "",
+				favorite:
+					item.app_favorite === 1 || item.database_favorite === 1,
+			};
+		});
+	}, [getKnowledge.data]);
+
+	// All unique tags across all items (for the filter popover)
+	const allTags = useMemo(() => {
+		const set = new Set<string>();
+		items.forEach((item) => {
+			item.tags.forEach((t) => {
+				if (t) set.add(t);
+			});
+		});
+		return Array.from(set).sort();
+	}, [items]);
+
+	// IDs of currently attached knowledge sources (local state to avoid re-render loops)
+	const [selectedIds, setSelectedIds] = useState<Set<string>>(
+		() => new Set(values.map((v) => v.id)),
+	);
+
+	// Sync selectedIds when the values prop changes from the parent
+	useEffect(() => {
+		setSelectedIds(new Set(values.map((v) => v.id)));
+	}, [values]);
+
+	// Apply search + tag filter + favorites filter + sort
+	const filtered = useMemo(() => {
+		let list = items;
+
+		if (search.trim()) {
+			const q = search.toLowerCase();
+			list = list.filter(
+				(item) =>
+					item.name.toLowerCase().includes(q) ||
+					item.description.toLowerCase().includes(q) ||
+					item.tags.some((t) => t.toLowerCase().includes(q)),
+			);
+		}
+
+		if (tagFilter.length > 0) {
+			list = list.filter((item) =>
+				tagFilter.some((f) =>
+					item.tags.some((t) => t.toLowerCase() === f.toLowerCase()),
+				),
+			);
+		}
+
+		if (showFavoritesOnly) {
+			list = list.filter((item) => favorites[item.id] ?? item.favorite);
+		}
+
+		list = [...list].sort((a, b) => {
+			if (sortBy === "name") return a.name.localeCompare(b.name);
+			return b.dateCreated.localeCompare(a.dateCreated);
+		});
+
+		return list;
+	}, [items, search, tagFilter, showFavoritesOnly, favorites, sortBy]);
+
+	const toggleSelected = (item: KnowledgeItem) => {
+		if (disabled) return;
+		const next = new Set(selectedIds);
+		if (next.has(item.id)) {
+			next.delete(item.id);
+			onChange(values.filter((v) => v.id !== item.id));
+		} else {
+			next.add(item.id);
+			onChange([
+				...values,
+				{
+					id: item.id,
+					name: item.name,
+					description: item.description,
+					type: "VECTOR",
+				},
+			]);
+		}
+		setSelectedIds(next);
+	};
+
+	const toggleFavorite = async (e: React.MouseEvent, item: KnowledgeItem) => {
+		e.stopPropagation();
+		const current = favorites[item.id] ?? item.favorite;
+		const next = !current;
+		setFavorites((prev) => ({ ...prev, [item.id]: next }));
+		try {
+			await post<{ success: boolean }>(
+				`${Env.MODULE}/api/auth/engine/setEngineFavorite`,
+				{ engineId: item.id, isFavorite: next },
+				{},
+			);
+		} catch {
+			setFavorites((prev) => ({ ...prev, [item.id]: current }));
+			toast.error("Failed to update favorite.");
+		}
+	};
+
+	const openInfo = async (e: React.MouseEvent, item: KnowledgeItem) => {
+		e.stopPropagation();
+		setInfoItem(item);
+		setDocAssets([]);
+		setDocError(null);
+		setDocLoading(true);
+		try {
+			const result = await actions.run(
+				`ListDocumentsInVectorDatabase(engine=["${item.id}"]);`,
+			);
+			const output = result?.pixelReturn?.[0]?.output;
+			const assets: EngineAsset[] = Array.isArray(output) ? output : [];
+			setDocAssets(assets.filter((a) => a?.type !== "folder"));
+		} catch (err) {
+			setDocError(
+				err instanceof Error
+					? err.message
+					: "Failed to load documents.",
+			);
+		} finally {
+			setDocLoading(false);
+		}
+	};
+
+	if (getKnowledge.status === "LOADING") {
+		return (
+			<div className="flex h-32 items-center justify-center">
+				<Spinner />
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-3">
+			{/* Row 1: search + filter controls */}
+			<div className="flex flex-wrap items-center gap-2">
+				<InputGroup className="min-w-[180px] flex-1 bg-background">
+					<InputGroupInput
+						placeholder="Search knowledge sources..."
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") e.preventDefault();
+						}}
+					/>
+					<InputGroupAddon>
+						<SearchIcon className="size-4" />
+					</InputGroupAddon>
+				</InputGroup>
+
+				{/* Tag filter */}
+				{allTags.length > 0 && (
+					<Popover>
+						<PopoverTrigger asChild>
+							<Button type="button" variant="outline" size="sm">
+								{tagFilter.length === 0
+									? "Tags"
+									: `Tags (${tagFilter.length})`}
+								<ChevronDownIcon className="ml-1 h-4 w-4" />
+							</Button>
+						</PopoverTrigger>
+						<PopoverContent className="w-52 p-0" align="start">
+							<Command>
+								<CommandInput placeholder="Search tags…" />
+								<CommandList className="max-h-48">
+									<CommandEmpty>No tags found.</CommandEmpty>
+									<CommandGroup>
+										{allTags.map((tag) => (
+											<CommandItem
+												key={tag}
+												onSelect={() =>
+													setTagFilter((prev) =>
+														prev.includes(tag)
+															? prev.filter(
+																	(t) =>
+																		t !==
+																		tag,
+																)
+															: [...prev, tag],
+													)
+												}
+											>
+												<Checkbox
+													checked={tagFilter.includes(
+														tag,
+													)}
+													className="mr-2"
+												/>
+												{tag}
+											</CommandItem>
+										))}
+									</CommandGroup>
+								</CommandList>
+							</Command>
+						</PopoverContent>
+					</Popover>
+				)}
+
+				{/* Favorites toggle */}
+				<Button
+					type="button"
+					variant={showFavoritesOnly ? "secondary" : "outline"}
+					size="sm"
+					onClick={() => setShowFavoritesOnly((v) => !v)}
+				>
+					<BookmarkIcon
+						className={`h-4 w-4 ${showFavoritesOnly ? "fill-current" : ""}`}
+					/>
+					Favorites
+				</Button>
+
+				{/* Sort */}
+				<Popover>
+					<PopoverTrigger asChild>
+						<Button type="button" variant="outline" size="sm">
+							{sortBy === "name" ? "Sort: Name" : "Sort: Date"}
+							<ChevronDownIcon className="ml-1 h-4 w-4" />
+						</Button>
+					</PopoverTrigger>
+					<PopoverContent className="w-40 p-1" align="start">
+						<Button
+							type="button"
+							variant={sortBy === "name" ? "secondary" : "ghost"}
+							size="sm"
+							className="w-full justify-start"
+							onClick={() => setSortBy("name")}
+						>
+							Name (A–Z)
+						</Button>
+						<Button
+							type="button"
+							variant={sortBy === "date" ? "secondary" : "ghost"}
+							size="sm"
+							className="w-full justify-start"
+							onClick={() => setSortBy("date")}
+						>
+							Date (newest)
+						</Button>
+					</PopoverContent>
+				</Popover>
+
+				{/* New knowledge source */}
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					onClick={() => setNewKnowledgeOpen(true)}
+					disabled={disabled}
+				>
+					<PlusIcon className="size-4" />
+					New
+				</Button>
+			</div>
+
+			{/* Scrollable list */}
+			<div className="h-80 overflow-y-auto rounded-lg border border-border">
+				{filtered.length === 0 ? (
+					<div className="flex h-32 items-center justify-center text-muted-foreground text-sm">
+						{search || tagFilter.length > 0 || showFavoritesOnly
+							? "No results match your filters."
+							: "No knowledge sources available."}
+					</div>
+				) : (
+					<div className="divide-y divide-border">
+						{filtered.map((item) => {
+							const isSelected = selectedIds.has(item.id);
+							const isFav = favorites[item.id] ?? item.favorite;
+							return (
+								<button
+									key={item.id}
+									type="button"
+									onClick={() => toggleSelected(item)}
+									className={`flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition hover:bg-muted/40 ${disabled ? "pointer-events-none opacity-60" : ""}`}
+								>
+									{/* Plain div checkbox - avoids Radix usePresence ref loop */}
+									<div
+										aria-hidden="true"
+										className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] border shadow-xs ${isSelected ? "border-primary bg-primary text-primary-foreground" : "border-input bg-transparent dark:bg-input/30"}`}
+									>
+										{isSelected && (
+											<CheckIcon className="h-3 w-3" />
+										)}
+									</div>
+									{/* Name + description + tags */}
+									<div className="min-w-0 flex-1 space-y-1">
+										<div className="flex items-center">
+											<p className="truncate font-medium text-sm leading-none">
+												{item.name}
+											</p>
+											<Button
+												type="button"
+												variant="ghost"
+												size="icon-sm"
+												className="ml-2 shrink-0 text-muted-foreground hover:text-primary"
+												onClick={(e) =>
+													openInfo(e, item)
+												}
+											>
+												<InfoIcon className="h-3.5 w-3.5" />
+											</Button>
+										</div>
+										{item.description && (
+											<p className="line-clamp-1 text-muted-foreground text-xs">
+												{item.description}
+											</p>
+										)}
+										{item.tags.length > 0 && (
+											<div className="flex flex-wrap gap-1 pt-0.5">
+												{item.tags.map((tag) => (
+													<Badge
+														key={tag}
+														variant="secondary"
+														className="text-xs"
+													>
+														{tag}
+													</Badge>
+												))}
+											</div>
+										)}
+									</div>
+									{item.dateCreated && (
+										<span className="shrink-0 whitespace-nowrap text-muted-foreground text-xs tabular-nums">
+											{formatDateTime(item.dateCreated)}
+										</span>
+									)}
+									<Button
+										type="button"
+										variant="ghost"
+										size="icon-sm"
+										onClick={(e) => toggleFavorite(e, item)}
+										className="shrink-0"
+										disabled={disabled}
+									>
+										<BookmarkIcon
+											className={`h-4 w-4 ${isFav ? "fill-current text-primary" : "text-muted-foreground"}`}
+										/>
+									</Button>
+								</button>
+							);
+						})}
+					</div>
+				)}
+			</div>
+
+			{/* Selection summary */}
+			{selectedIds.size > 0 && (
+				<p className="text-muted-foreground text-xs">
+					{selectedIds.size} knowledge source
+					{selectedIds.size !== 1 ? "s" : ""} selected
+				</p>
+			)}
+
+			{/* Create new knowledge overlay */}
+			<NewKnowledgeOverlay
+				open={newKnowledgeOpen}
+				onClose={(newKnowledge) => {
+					if (newKnowledge) {
+						onChange([...values, newKnowledge]);
+						getKnowledge.refresh();
+					}
+					setNewKnowledgeOpen(false);
+				}}
+			/>
+
+			{/* Document list modal */}
+			<Dialog
+				open={!!infoItem}
+				onOpenChange={(open) => {
+					if (!open) {
+						setInfoItem(null);
+						setDocAssets([]);
+						setDocError(null);
+					}
+				}}
+			>
+				<DialogContent className="max-w-2xl">
+					<DialogHeader>
+						<DialogTitle>{infoItem?.name}</DialogTitle>
+					</DialogHeader>
+					<div className="space-y-4">
+						{/* Description + tags */}
+						{infoItem?.description && (
+							<p className="text-muted-foreground text-sm">
+								{infoItem.description}
+							</p>
+						)}
+						{infoItem?.tags && infoItem.tags.length > 0 && (
+							<div className="flex flex-wrap gap-1">
+								{infoItem.tags.map((tag) => (
+									<Badge
+										key={tag}
+										variant="secondary"
+										className="text-xs"
+									>
+										{tag}
+									</Badge>
+								))}
+							</div>
+						)}
+						{infoItem?.dateCreated && (
+							<p className="text-muted-foreground text-xs">
+								Created {formatDateTime(infoItem.dateCreated)}
+							</p>
+						)}
+
+						{/* Document list */}
+						<div>
+							<p className="mb-2 font-medium text-sm">
+								Documents
+								{!docLoading && docAssets.length > 0 && (
+									<span className="ml-1.5 font-normal text-muted-foreground">
+										({docAssets.length})
+									</span>
+								)}
+							</p>
+							{docLoading ? (
+								<div className="flex items-center gap-2 text-muted-foreground text-sm">
+									<Spinner className="size-3" />
+									Loading…
+								</div>
+							) : docError ? (
+								<p className="text-destructive text-sm">
+									{docError}
+								</p>
+							) : docAssets.length === 0 ? (
+								<p className="text-muted-foreground text-sm">
+									No documents found.
+								</p>
+							) : (
+								<ScrollArea className="h-52 rounded-md border">
+									<table className="w-full table-fixed text-sm">
+										<thead>
+											<tr className="border-b text-muted-foreground text-xs">
+												<th className="px-4 pt-2 pb-2 text-left font-medium">
+													Name
+												</th>
+												<th className="w-36 px-3 pt-2 pb-2 text-left font-medium">
+													Date Uploaded
+												</th>
+												<th className="w-20 px-4 pt-2 pb-2 text-right font-medium">
+													Size
+												</th>
+											</tr>
+										</thead>
+										<tbody>
+											{docAssets.map((f, idx) => {
+												const name =
+													f.fileName ||
+													f.name ||
+													(f.path
+														? f.path
+																.split(/[/\\]/)
+																.pop()
+														: "") ||
+													"Untitled";
+												return (
+													<tr
+														key={`${f.path || name}-${idx}`}
+														className="border-b transition last:border-0 hover:bg-muted/40"
+													>
+														<td className="px-4 py-2">
+															<div className="flex min-w-0 items-center gap-2">
+																{getFileIcon(
+																	name,
+																)}
+																<span className="break-all font-medium text-xs">
+																	{name}
+																</span>
+															</div>
+														</td>
+														<td className="w-36 px-3 py-2 text-muted-foreground text-xs tabular-nums">
+															{f.lastModified
+																? formatDateTime(
+																		f.lastModified,
+																	)
+																: "—"}
+														</td>
+														<td className="w-20 px-4 py-2 text-right text-muted-foreground text-xs tabular-nums">
+															{f.fileSize != null
+																? formatFileSize(
+																		f.fileSize,
+																	)
+																: "—"}
+														</td>
+													</tr>
+												);
+											})}
+										</tbody>
+									</table>
+								</ScrollArea>
+							)}
+						</div>
+					</div>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+};

--- a/packages/playground/src/components/workspace/knowledge-selector.tsx
+++ b/packages/playground/src/components/workspace/knowledge-selector.tsx
@@ -2,15 +2,11 @@ import {
 	BookmarkIcon,
 	CheckIcon,
 	ChevronDownIcon,
-	FileIcon,
-	FileImageIcon,
-	FileSpreadsheetIcon,
-	FileTextIcon,
 	InfoIcon,
 	PlusIcon,
 	SearchIcon,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { Env, post, useInsight, usePixel } from "@semoss/sdk/react";
 import {
 	Badge,
@@ -32,12 +28,13 @@ import {
 	Popover,
 	PopoverContent,
 	PopoverTrigger,
+	ScrollArea,
 	Spinner,
 	toast,
 } from "@semoss/ui/next";
 import { NewKnowledgeOverlay } from "@/components/knowledge/new-knowledge-mcp-overlay";
 import type { MCPConfig } from "@/types";
-import { formatDateTime } from "@/utility";
+import { formatDateTime, formatFileSize, getFileIcon } from "@/utility";
 
 type KnowledgeItem = {
 	id: string;
@@ -57,592 +54,599 @@ type EngineAsset = {
 	fileSize?: string | number;
 };
 
-const getFileIcon = (fileName: string) => {
-	const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
-	if (ext === "pdf")
-		return <FileTextIcon className="h-4 w-4 shrink-0 text-red-500" />;
-	if (ext === "doc" || ext === "docx")
-		return <FileTextIcon className="h-4 w-4 shrink-0 text-blue-500" />;
-	if (ext === "xls" || ext === "xlsx" || ext === "csv")
-		return (
-			<FileSpreadsheetIcon className="h-4 w-4 shrink-0 text-green-600" />
-		);
-	if (["png", "jpg", "jpeg", "gif", "webp", "svg"].includes(ext))
-		return <FileImageIcon className="h-4 w-4 shrink-0 text-purple-500" />;
-	return <FileIcon className="h-4 w-4 shrink-0 text-muted-foreground" />;
-};
-
-const formatFileSize = (fileSize: string | number): string => {
-	const s = String(fileSize ?? "");
-	const match = s.match(/^([\d.]+)\s*(KB|MB|GB|B)?$/i);
-	if (!match) return s;
-	const num = parseFloat(match[1]);
-	const unit = (match[2] ?? "B").toUpperCase();
-	let bytes = num;
-	if (unit === "GB") bytes = num * 1024 * 1024 * 1024;
-	else if (unit === "MB") bytes = num * 1024 * 1024;
-	else if (unit === "KB") bytes = num * 1024;
-	if (bytes === 0) return s;
-	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
-	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-};
-
 interface KnowledgeSelectorProps {
 	values: MCPConfig[];
 	onChange: (values: MCPConfig[]) => void;
 	disabled?: boolean;
 }
 
-export const KnowledgeSelector = ({
-	values,
-	onChange,
-	disabled = false,
-}: KnowledgeSelectorProps) => {
-	const { actions } = useInsight();
+export const KnowledgeSelector = memo(
+	({ values, onChange, disabled = false }: KnowledgeSelectorProps) => {
+		const { actions } = useInsight();
 
-	// Filter / sort state
-	const [search, setSearch] = useState("");
-	const [tagFilter, setTagFilter] = useState<string[]>([]);
-	const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
-	const [sortBy, setSortBy] = useState<"name" | "date">("name");
+		// Filter / sort state
+		const [search, setSearch] = useState("");
+		const [tagFilter, setTagFilter] = useState<string[]>([]);
+		const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
+		const [sortBy, setSortBy] = useState<"name" | "date">("name");
 
-	// Local favorite overrides (optimistic updates)
-	const [favorites, setFavorites] = useState<Record<string, boolean>>({});
+		// Local favorite overrides (optimistic updates)
+		const [favorites, setFavorites] = useState<Record<string, boolean>>({});
 
-	// Create new knowledge
-	const [newKnowledgeOpen, setNewKnowledgeOpen] = useState(false);
+		// Create new knowledge
+		const [newKnowledgeOpen, setNewKnowledgeOpen] = useState(false);
 
-	// Info / document modal
-	const [infoItem, setInfoItem] = useState<KnowledgeItem | null>(null);
-	const [docAssets, setDocAssets] = useState<EngineAsset[]>([]);
-	const [docLoading, setDocLoading] = useState(false);
-	const [docError, setDocError] = useState<string | null>(null);
+		// Info / document modal
+		const [infoItem, setInfoItem] = useState<KnowledgeItem | null>(null);
+		const [docAssets, setDocAssets] = useState<EngineAsset[]>([]);
+		const [docLoading, setDocLoading] = useState(false);
+		const [docError, setDocError] = useState<string | null>(null);
 
-	// Fetch all vector engines (same pixel as the main knowledge page)
-	const getKnowledge = usePixel<
-		{
-			app_id?: string;
-			app_name?: string;
-			app_favorite?: number;
-			database_date_created?: string;
-			database_favorite?: number;
-			description?: string;
-			tag?: string | string[];
-		}[]
-	>(`MyEngines(engineTypes=['VECTOR'], metaKeys=["description","tag"]);`, {
-		data: [],
-	});
-
-	// Normalize raw pixel response into typed items
-	const items: KnowledgeItem[] = useMemo(() => {
-		if (!getKnowledge.data) return [];
-		return getKnowledge.data.map((item) => {
-			const rawTag = item.tag;
-			const tags = Array.isArray(rawTag)
-				? rawTag
-				: rawTag
-					? [rawTag]
-					: [];
-			return {
-				id: item.app_id || "",
-				name: item.app_name || "Untitled",
-				description: item.description || "",
-				tags,
-				dateCreated: item.database_date_created || "",
-				favorite:
-					item.app_favorite === 1 || item.database_favorite === 1,
-			};
-		});
-	}, [getKnowledge.data]);
-
-	// All unique tags across all items (for the filter popover)
-	const allTags = useMemo(() => {
-		const set = new Set<string>();
-		items.forEach((item) => {
-			item.tags.forEach((t) => {
-				if (t) set.add(t);
-			});
-		});
-		return Array.from(set).sort();
-	}, [items]);
-
-	// IDs of currently attached knowledge sources (local state to avoid re-render loops)
-	const [selectedIds, setSelectedIds] = useState<Set<string>>(
-		() => new Set(values.map((v) => v.id)),
-	);
-
-	// Sync selectedIds when the values prop changes from the parent
-	useEffect(() => {
-		setSelectedIds(new Set(values.map((v) => v.id)));
-	}, [values]);
-
-	// Apply search + tag filter + favorites filter + sort
-	const filtered = useMemo(() => {
-		let list = items;
-
-		if (search.trim()) {
-			const q = search.toLowerCase();
-			list = list.filter(
-				(item) =>
-					item.name.toLowerCase().includes(q) ||
-					item.description.toLowerCase().includes(q) ||
-					item.tags.some((t) => t.toLowerCase().includes(q)),
-			);
-		}
-
-		if (tagFilter.length > 0) {
-			list = list.filter((item) =>
-				tagFilter.some((f) =>
-					item.tags.some((t) => t.toLowerCase() === f.toLowerCase()),
-				),
-			);
-		}
-
-		if (showFavoritesOnly) {
-			list = list.filter((item) => favorites[item.id] ?? item.favorite);
-		}
-
-		list = [...list].sort((a, b) => {
-			if (sortBy === "name") return a.name.localeCompare(b.name);
-			return b.dateCreated.localeCompare(a.dateCreated);
-		});
-
-		return list;
-	}, [items, search, tagFilter, showFavoritesOnly, favorites, sortBy]);
-
-	const toggleSelected = (item: KnowledgeItem) => {
-		if (disabled) return;
-		const next = new Set(selectedIds);
-		if (next.has(item.id)) {
-			next.delete(item.id);
-			onChange(values.filter((v) => v.id !== item.id));
-		} else {
-			next.add(item.id);
-			onChange([
-				...values,
-				{
-					id: item.id,
-					name: item.name,
-					description: item.description,
-					type: "VECTOR",
-				},
-			]);
-		}
-		setSelectedIds(next);
-	};
-
-	const toggleFavorite = async (e: React.MouseEvent, item: KnowledgeItem) => {
-		e.stopPropagation();
-		const current = favorites[item.id] ?? item.favorite;
-		const next = !current;
-		setFavorites((prev) => ({ ...prev, [item.id]: next }));
-		try {
-			await post<{ success: boolean }>(
-				`${Env.MODULE}/api/auth/engine/setEngineFavorite`,
-				{ engineId: item.id, isFavorite: next },
-				{},
-			);
-		} catch {
-			setFavorites((prev) => ({ ...prev, [item.id]: current }));
-			toast.error("Failed to update favorite.");
-		}
-	};
-
-	const openInfo = async (e: React.MouseEvent, item: KnowledgeItem) => {
-		e.stopPropagation();
-		setInfoItem(item);
-		setDocAssets([]);
-		setDocError(null);
-		setDocLoading(true);
-		try {
-			const result = await actions.run(
-				`ListDocumentsInVectorDatabase(engine=["${item.id}"]);`,
-			);
-			const output = result?.pixelReturn?.[0]?.output;
-			const assets: EngineAsset[] = Array.isArray(output) ? output : [];
-			setDocAssets(assets.filter((a) => a?.type !== "folder"));
-		} catch (err) {
-			setDocError(
-				err instanceof Error
-					? err.message
-					: "Failed to load documents.",
-			);
-		} finally {
-			setDocLoading(false);
-		}
-	};
-
-	if (getKnowledge.status === "LOADING") {
-		return (
-			<div className="flex h-32 items-center justify-center">
-				<Spinner />
-			</div>
+		// Fetch all vector engines (same pixel as the main knowledge page)
+		const getKnowledge = usePixel<
+			{
+				app_id?: string;
+				app_name?: string;
+				app_favorite?: number;
+				database_date_created?: string;
+				database_favorite?: number;
+				description?: string;
+				tag?: string | string[];
+			}[]
+		>(
+			`MyEngines(engineTypes=['VECTOR'], metaKeys=["description","tag"]);`,
+			{
+				data: [],
+			},
 		);
-	}
 
-	return (
-		<div className="flex flex-col gap-3">
-			{/* Row 1: search + filter controls */}
-			<div className="flex flex-wrap items-center gap-2">
-				<InputGroup className="min-w-[180px] flex-1 bg-background">
-					<InputGroupInput
-						placeholder="Search knowledge sources..."
-						value={search}
-						onChange={(e) => setSearch(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === "Enter") e.preventDefault();
-						}}
-					/>
-					<InputGroupAddon>
-						<SearchIcon className="size-4" />
-					</InputGroupAddon>
-				</InputGroup>
+		// Normalize raw pixel response into typed items
+		const items: KnowledgeItem[] = useMemo(() => {
+			if (!getKnowledge.data) return [];
+			return getKnowledge.data.map((item) => {
+				const rawTag = item.tag;
+				const tags = Array.isArray(rawTag)
+					? rawTag
+					: rawTag
+						? [rawTag]
+						: [];
+				return {
+					id: item.app_id || "",
+					name: item.app_name || "Untitled",
+					description: item.description || "",
+					tags,
+					dateCreated: item.database_date_created || "",
+					favorite:
+						item.app_favorite === 1 || item.database_favorite === 1,
+				};
+			});
+		}, [getKnowledge.data]);
 
-				{/* Tag filter */}
-				{allTags.length > 0 && (
+		// All unique tags across all items (for the filter popover)
+		const allTags = useMemo(() => {
+			const set = new Set<string>();
+			items.forEach((item) => {
+				item.tags.forEach((t) => {
+					if (t) set.add(t);
+				});
+			});
+			return Array.from(set).sort();
+		}, [items]);
+
+		// IDs of currently attached knowledge sources (local state to avoid re-render loops)
+		const [selectedIds, setSelectedIds] = useState<Set<string>>(
+			() => new Set(values.map((v) => v.id)),
+		);
+
+		// Sync selectedIds when the values prop changes from the parent
+		useEffect(() => {
+			setSelectedIds(new Set(values.map((v) => v.id)));
+		}, [values]);
+
+		// Apply search + tag filter + favorites filter + sort
+		const filtered = useMemo(() => {
+			let list = items;
+
+			if (search.trim()) {
+				const q = search.toLowerCase();
+				list = list.filter(
+					(item) =>
+						item.name.toLowerCase().includes(q) ||
+						item.description.toLowerCase().includes(q) ||
+						item.tags.some((t) => t.toLowerCase().includes(q)),
+				);
+			}
+
+			if (tagFilter.length > 0) {
+				list = list.filter((item) =>
+					tagFilter.some((f) =>
+						item.tags.some(
+							(t) => t.toLowerCase() === f.toLowerCase(),
+						),
+					),
+				);
+			}
+
+			if (showFavoritesOnly) {
+				list = list.filter(
+					(item) => favorites[item.id] ?? item.favorite,
+				);
+			}
+
+			list = [...list].sort((a, b) => {
+				if (sortBy === "name") return a.name.localeCompare(b.name);
+				return b.dateCreated.localeCompare(a.dateCreated);
+			});
+
+			return list;
+		}, [items, search, tagFilter, showFavoritesOnly, favorites, sortBy]);
+
+		const toggleSelected = (item: KnowledgeItem) => {
+			if (disabled) return;
+			const next = new Set(selectedIds);
+			if (next.has(item.id)) {
+				next.delete(item.id);
+				onChange(values.filter((v) => v.id !== item.id));
+			} else {
+				next.add(item.id);
+				onChange([
+					...values,
+					{
+						id: item.id,
+						name: item.name,
+						description: item.description,
+						type: "VECTOR",
+					},
+				]);
+			}
+			setSelectedIds(next);
+		};
+
+		const toggleFavorite = async (
+			e: React.MouseEvent,
+			item: KnowledgeItem,
+		) => {
+			e.stopPropagation();
+			const current = favorites[item.id] ?? item.favorite;
+			const next = !current;
+			setFavorites((prev) => ({ ...prev, [item.id]: next }));
+			try {
+				await post<{ success: boolean }>(
+					`${Env.MODULE}/api/auth/engine/setEngineFavorite`,
+					{ engineId: item.id, isFavorite: next },
+					{},
+				);
+			} catch {
+				setFavorites((prev) => ({ ...prev, [item.id]: current }));
+				toast.error("Failed to update favorite.");
+			}
+		};
+
+		const openInfo = async (e: React.MouseEvent, item: KnowledgeItem) => {
+			e.stopPropagation();
+			setInfoItem(item);
+			setDocAssets([]);
+			setDocError(null);
+			setDocLoading(true);
+			try {
+				const result = await actions.run(
+					`ListDocumentsInVectorDatabase(engine=["${item.id}"]);`,
+				);
+				const output = result?.pixelReturn?.[0]?.output;
+				const assets: EngineAsset[] = Array.isArray(output)
+					? output
+					: [];
+				setDocAssets(assets.filter((a) => a?.type !== "folder"));
+			} catch (err) {
+				setDocError(
+					err instanceof Error
+						? err.message
+						: "Failed to load documents.",
+				);
+			} finally {
+				setDocLoading(false);
+			}
+		};
+
+		if (getKnowledge.status === "LOADING") {
+			return (
+				<div className="flex h-32 items-center justify-center">
+					<Spinner />
+				</div>
+			);
+		}
+
+		return (
+			<div className="flex flex-col gap-3">
+				{/* Row 1: search + filter controls */}
+				<div className="flex flex-wrap items-center gap-2">
+					<InputGroup className="min-w-[180px] flex-1 bg-background">
+						<InputGroupInput
+							placeholder="Search knowledge sources..."
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") e.preventDefault();
+							}}
+						/>
+						<InputGroupAddon>
+							<SearchIcon className="size-4" />
+						</InputGroupAddon>
+					</InputGroup>
+
+					{/* Tag filter */}
+					{allTags.length > 0 && (
+						<Popover>
+							<PopoverTrigger asChild>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+								>
+									{tagFilter.length === 0
+										? "Tags"
+										: `Tags (${tagFilter.length})`}
+									<ChevronDownIcon className="ml-1 h-4 w-4" />
+								</Button>
+							</PopoverTrigger>
+							<PopoverContent className="w-52 p-0" align="start">
+								<Command>
+									<CommandInput placeholder="Search tags…" />
+									<CommandList className="max-h-48">
+										<CommandEmpty>
+											No tags found.
+										</CommandEmpty>
+										<CommandGroup>
+											{allTags.map((tag) => (
+												<CommandItem
+													key={tag}
+													onSelect={() =>
+														setTagFilter((prev) =>
+															prev.includes(tag)
+																? prev.filter(
+																		(t) =>
+																			t !==
+																			tag,
+																	)
+																: [
+																		...prev,
+																		tag,
+																	],
+														)
+													}
+												>
+													<Checkbox
+														checked={tagFilter.includes(
+															tag,
+														)}
+														className="mr-2"
+													/>
+													{tag}
+												</CommandItem>
+											))}
+										</CommandGroup>
+									</CommandList>
+								</Command>
+							</PopoverContent>
+						</Popover>
+					)}
+
+					{/* Favorites toggle */}
+					<Button
+						type="button"
+						variant={showFavoritesOnly ? "secondary" : "outline"}
+						size="sm"
+						onClick={() => setShowFavoritesOnly((v) => !v)}
+					>
+						<BookmarkIcon
+							className={`h-4 w-4 ${showFavoritesOnly ? "fill-current" : ""}`}
+						/>
+						Favorites
+					</Button>
+
+					{/* Sort */}
 					<Popover>
 						<PopoverTrigger asChild>
 							<Button type="button" variant="outline" size="sm">
-								{tagFilter.length === 0
-									? "Tags"
-									: `Tags (${tagFilter.length})`}
+								{sortBy === "name"
+									? "Sort: Name"
+									: "Sort: Date"}
 								<ChevronDownIcon className="ml-1 h-4 w-4" />
 							</Button>
 						</PopoverTrigger>
-						<PopoverContent className="w-52 p-0" align="start">
-							<Command>
-								<CommandInput placeholder="Search tags…" />
-								<CommandList className="max-h-48">
-									<CommandEmpty>No tags found.</CommandEmpty>
-									<CommandGroup>
-										{allTags.map((tag) => (
-											<CommandItem
-												key={tag}
-												onSelect={() =>
-													setTagFilter((prev) =>
-														prev.includes(tag)
-															? prev.filter(
-																	(t) =>
-																		t !==
-																		tag,
-																)
-															: [...prev, tag],
-													)
-												}
-											>
-												<Checkbox
-													checked={tagFilter.includes(
-														tag,
-													)}
-													className="mr-2"
-												/>
-												{tag}
-											</CommandItem>
-										))}
-									</CommandGroup>
-								</CommandList>
-							</Command>
+						<PopoverContent className="w-40 p-1" align="start">
+							<Button
+								type="button"
+								variant={
+									sortBy === "name" ? "secondary" : "ghost"
+								}
+								size="sm"
+								className="w-full justify-start"
+								onClick={() => setSortBy("name")}
+							>
+								Name (A–Z)
+							</Button>
+							<Button
+								type="button"
+								variant={
+									sortBy === "date" ? "secondary" : "ghost"
+								}
+								size="sm"
+								className="w-full justify-start"
+								onClick={() => setSortBy("date")}
+							>
+								Date (newest)
+							</Button>
 						</PopoverContent>
 					</Popover>
+
+					{/* New knowledge source */}
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={() => setNewKnowledgeOpen(true)}
+						disabled={disabled}
+					>
+						<PlusIcon className="size-4" />
+						New
+					</Button>
+				</div>
+
+				{/* Scrollable list */}
+				<div className="h-80 overflow-y-auto rounded-lg border border-border">
+					{filtered.length === 0 ? (
+						<div className="flex h-32 items-center justify-center text-muted-foreground text-sm">
+							{search || tagFilter.length > 0 || showFavoritesOnly
+								? "No results match your filters."
+								: "No knowledge sources available."}
+						</div>
+					) : (
+						<div className="divide-y divide-border">
+							{filtered.map((item) => {
+								const isSelected = selectedIds.has(item.id);
+								const isFav =
+									favorites[item.id] ?? item.favorite;
+								return (
+									<button
+										key={item.id}
+										type="button"
+										onClick={() => toggleSelected(item)}
+										className={`flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition hover:bg-muted/40 ${disabled ? "pointer-events-none opacity-60" : ""}`}
+									>
+										{/* Plain div checkbox - avoids Radix usePresence ref loop */}
+										<div
+											aria-hidden="true"
+											className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] border shadow-xs ${isSelected ? "border-primary bg-primary text-primary-foreground" : "border-input bg-transparent dark:bg-input/30"}`}
+										>
+											{isSelected && (
+												<CheckIcon className="h-3 w-3" />
+											)}
+										</div>
+										{/* Name + description + tags */}
+										<div className="min-w-0 flex-1 space-y-1">
+											<div className="flex items-center">
+												<p className="truncate font-medium text-sm leading-none">
+													{item.name}
+												</p>
+												<Button
+													type="button"
+													variant="ghost"
+													size="icon-sm"
+													className="ml-2 shrink-0 text-muted-foreground hover:text-primary"
+													onClick={(e) =>
+														openInfo(e, item)
+													}
+												>
+													<InfoIcon className="h-3.5 w-3.5" />
+												</Button>
+											</div>
+											{item.description && (
+												<p className="line-clamp-1 text-muted-foreground text-xs">
+													{item.description}
+												</p>
+											)}
+											{item.tags.length > 0 && (
+												<div className="flex flex-wrap gap-1 pt-0.5">
+													{item.tags.map((tag) => (
+														<Badge
+															key={tag}
+															variant="secondary"
+															className="text-xs"
+														>
+															{tag}
+														</Badge>
+													))}
+												</div>
+											)}
+										</div>
+										{item.dateCreated && (
+											<span className="shrink-0 whitespace-nowrap text-muted-foreground text-xs tabular-nums">
+												{formatDateTime(
+													item.dateCreated,
+												)}
+											</span>
+										)}
+										<Button
+											type="button"
+											variant="ghost"
+											size="icon-sm"
+											onClick={(e) =>
+												toggleFavorite(e, item)
+											}
+											className="shrink-0"
+											disabled={disabled}
+										>
+											<BookmarkIcon
+												className={`h-4 w-4 ${isFav ? "fill-current text-primary" : "text-muted-foreground"}`}
+											/>
+										</Button>
+									</button>
+								);
+							})}
+						</div>
+					)}
+				</div>
+
+				{/* Selection summary */}
+				{selectedIds.size > 0 && (
+					<p className="text-muted-foreground text-xs">
+						{selectedIds.size} knowledge source
+						{selectedIds.size !== 1 ? "s" : ""} selected
+					</p>
 				)}
 
-				{/* Favorites toggle */}
-				<Button
-					type="button"
-					variant={showFavoritesOnly ? "secondary" : "outline"}
-					size="sm"
-					onClick={() => setShowFavoritesOnly((v) => !v)}
+				{/* Create new knowledge overlay */}
+				<NewKnowledgeOverlay
+					open={newKnowledgeOpen}
+					onClose={(newKnowledge) => {
+						if (newKnowledge) {
+							onChange([...values, newKnowledge]);
+							getKnowledge.refresh();
+						}
+						setNewKnowledgeOpen(false);
+					}}
+				/>
+
+				{/* Document list modal */}
+				<Dialog
+					open={!!infoItem}
+					onOpenChange={(open) => {
+						if (!open) {
+							setInfoItem(null);
+							setDocAssets([]);
+							setDocError(null);
+						}
+					}}
 				>
-					<BookmarkIcon
-						className={`h-4 w-4 ${showFavoritesOnly ? "fill-current" : ""}`}
-					/>
-					Favorites
-				</Button>
+					<DialogContent
+						className="max-w-2xl"
+						aria-describedby={undefined}
+					>
+						<DialogHeader>
+							<DialogTitle>{infoItem?.name}</DialogTitle>
+						</DialogHeader>
+						<div className="space-y-4">
+							{/* Description + tags */}
+							{infoItem?.description && (
+								<p className="text-muted-foreground text-sm">
+									{infoItem.description}
+								</p>
+							)}
+							{infoItem?.tags && infoItem.tags.length > 0 && (
+								<div className="flex flex-wrap gap-1">
+									{infoItem.tags.map((tag) => (
+										<Badge
+											key={tag}
+											variant="secondary"
+											className="text-xs"
+										>
+											{tag}
+										</Badge>
+									))}
+								</div>
+							)}
+							{infoItem?.dateCreated && (
+								<p className="text-muted-foreground text-xs">
+									Created{" "}
+									{formatDateTime(infoItem.dateCreated)}
+								</p>
+							)}
 
-				{/* Sort */}
-				<Popover>
-					<PopoverTrigger asChild>
-						<Button type="button" variant="outline" size="sm">
-							{sortBy === "name" ? "Sort: Name" : "Sort: Date"}
-							<ChevronDownIcon className="ml-1 h-4 w-4" />
-						</Button>
-					</PopoverTrigger>
-					<PopoverContent className="w-40 p-1" align="start">
-						<Button
-							type="button"
-							variant={sortBy === "name" ? "secondary" : "ghost"}
-							size="sm"
-							className="w-full justify-start"
-							onClick={() => setSortBy("name")}
-						>
-							Name (A–Z)
-						</Button>
-						<Button
-							type="button"
-							variant={sortBy === "date" ? "secondary" : "ghost"}
-							size="sm"
-							className="w-full justify-start"
-							onClick={() => setSortBy("date")}
-						>
-							Date (newest)
-						</Button>
-					</PopoverContent>
-				</Popover>
-
-				{/* New knowledge source */}
-				<Button
-					type="button"
-					variant="outline"
-					size="sm"
-					onClick={() => setNewKnowledgeOpen(true)}
-					disabled={disabled}
-				>
-					<PlusIcon className="size-4" />
-					New
-				</Button>
-			</div>
-
-			{/* Scrollable list */}
-			<div className="h-80 overflow-y-auto rounded-lg border border-border">
-				{filtered.length === 0 ? (
-					<div className="flex h-32 items-center justify-center text-muted-foreground text-sm">
-						{search || tagFilter.length > 0 || showFavoritesOnly
-							? "No results match your filters."
-							: "No knowledge sources available."}
-					</div>
-				) : (
-					<div className="divide-y divide-border">
-						{filtered.map((item) => {
-							const isSelected = selectedIds.has(item.id);
-							const isFav = favorites[item.id] ?? item.favorite;
-							return (
-								<button
-									key={item.id}
-									type="button"
-									onClick={() => toggleSelected(item)}
-									className={`flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition hover:bg-muted/40 ${disabled ? "pointer-events-none opacity-60" : ""}`}
-								>
-									{/* Plain div checkbox - avoids Radix usePresence ref loop */}
-									<div
-										aria-hidden="true"
-										className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] border shadow-xs ${isSelected ? "border-primary bg-primary text-primary-foreground" : "border-input bg-transparent dark:bg-input/30"}`}
-									>
-										{isSelected && (
-											<CheckIcon className="h-3 w-3" />
-										)}
-									</div>
-									{/* Name + description + tags */}
-									<div className="min-w-0 flex-1 space-y-1">
-										<div className="flex items-center">
-											<p className="truncate font-medium text-sm leading-none">
-												{item.name}
-											</p>
-											<Button
-												type="button"
-												variant="ghost"
-												size="icon-sm"
-												className="ml-2 shrink-0 text-muted-foreground hover:text-primary"
-												onClick={(e) =>
-													openInfo(e, item)
-												}
-											>
-												<InfoIcon className="h-3.5 w-3.5" />
-											</Button>
-										</div>
-										{item.description && (
-											<p className="line-clamp-1 text-muted-foreground text-xs">
-												{item.description}
-											</p>
-										)}
-										{item.tags.length > 0 && (
-											<div className="flex flex-wrap gap-1 pt-0.5">
-												{item.tags.map((tag) => (
-													<Badge
-														key={tag}
-														variant="secondary"
-														className="text-xs"
-													>
-														{tag}
-													</Badge>
-												))}
-											</div>
-										)}
-									</div>
-									{item.dateCreated && (
-										<span className="shrink-0 whitespace-nowrap text-muted-foreground text-xs tabular-nums">
-											{formatDateTime(item.dateCreated)}
+							{/* Document list */}
+							<div>
+								<p className="mb-2 font-medium text-sm">
+									Documents
+									{!docLoading && docAssets.length > 0 && (
+										<span className="ml-1.5 font-normal text-muted-foreground">
+											({docAssets.length})
 										</span>
 									)}
-									<Button
-										type="button"
-										variant="ghost"
-										size="icon-sm"
-										onClick={(e) => toggleFavorite(e, item)}
-										className="shrink-0"
-										disabled={disabled}
-									>
-										<BookmarkIcon
-											className={`h-4 w-4 ${isFav ? "fill-current text-primary" : "text-muted-foreground"}`}
-										/>
-									</Button>
-								</button>
-							);
-						})}
-					</div>
-				)}
-			</div>
-
-			{/* Selection summary */}
-			{selectedIds.size > 0 && (
-				<p className="text-muted-foreground text-xs">
-					{selectedIds.size} knowledge source
-					{selectedIds.size !== 1 ? "s" : ""} selected
-				</p>
-			)}
-
-			{/* Create new knowledge overlay */}
-			<NewKnowledgeOverlay
-				open={newKnowledgeOpen}
-				onClose={(newKnowledge) => {
-					if (newKnowledge) {
-						onChange([...values, newKnowledge]);
-						getKnowledge.refresh();
-					}
-					setNewKnowledgeOpen(false);
-				}}
-			/>
-
-			{/* Document list modal */}
-			<Dialog
-				open={!!infoItem}
-				onOpenChange={(open) => {
-					if (!open) {
-						setInfoItem(null);
-						setDocAssets([]);
-						setDocError(null);
-					}
-				}}
-			>
-				<DialogContent className="max-w-2xl">
-					<DialogHeader>
-						<DialogTitle>{infoItem?.name}</DialogTitle>
-					</DialogHeader>
-					<div className="space-y-4">
-						{/* Description + tags */}
-						{infoItem?.description && (
-							<p className="text-muted-foreground text-sm">
-								{infoItem.description}
-							</p>
-						)}
-						{infoItem?.tags && infoItem.tags.length > 0 && (
-							<div className="flex flex-wrap gap-1">
-								{infoItem.tags.map((tag) => (
-									<Badge
-										key={tag}
-										variant="secondary"
-										className="text-xs"
-									>
-										{tag}
-									</Badge>
-								))}
-							</div>
-						)}
-						{infoItem?.dateCreated && (
-							<p className="text-muted-foreground text-xs">
-								Created {formatDateTime(infoItem.dateCreated)}
-							</p>
-						)}
-
-						{/* Document list */}
-						<div>
-							<p className="mb-2 font-medium text-sm">
-								Documents
-								{!docLoading && docAssets.length > 0 && (
-									<span className="ml-1.5 font-normal text-muted-foreground">
-										({docAssets.length})
-									</span>
+								</p>
+								{docLoading ? (
+									<div className="flex items-center gap-2 text-muted-foreground text-sm">
+										<Spinner className="size-3" />
+										Loading…
+									</div>
+								) : docError ? (
+									<p className="text-destructive text-sm">
+										{docError}
+									</p>
+								) : docAssets.length === 0 ? (
+									<p className="text-muted-foreground text-sm">
+										No documents found.
+									</p>
+								) : (
+									<ScrollArea className="h-52 rounded-md border">
+										<table className="w-full table-fixed text-sm">
+											<thead>
+												<tr className="border-b text-muted-foreground text-xs">
+													<th className="px-4 pt-2 pb-2 text-left font-medium">
+														Name
+													</th>
+													<th className="w-36 px-3 pt-2 pb-2 text-left font-medium">
+														Date Uploaded
+													</th>
+													<th className="w-20 px-4 pt-2 pb-2 text-right font-medium">
+														Size
+													</th>
+												</tr>
+											</thead>
+											<tbody>
+												{docAssets.map((f, idx) => {
+													const name =
+														f.fileName ||
+														f.name ||
+														(f.path
+															? f.path
+																	.split(
+																		/[/\\]/,
+																	)
+																	.pop()
+															: "") ||
+														"Untitled";
+													return (
+														<tr
+															key={`${f.path || name}-${idx}`}
+															className="border-b transition last:border-0 hover:bg-muted/40"
+														>
+															<td className="px-4 py-2">
+																<div className="flex min-w-0 items-center gap-2">
+																	{getFileIcon(
+																		name,
+																	)}
+																	<span className="break-all font-medium text-xs">
+																		{name}
+																	</span>
+																</div>
+															</td>
+															<td className="w-36 px-3 py-2 text-muted-foreground text-xs tabular-nums">
+																{f.lastModified
+																	? formatDateTime(
+																			f.lastModified,
+																		)
+																	: "—"}
+															</td>
+															<td className="w-20 px-4 py-2 text-right text-muted-foreground text-xs tabular-nums">
+																{f.fileSize !=
+																null
+																	? formatFileSize(
+																			f.fileSize,
+																		)
+																	: "—"}
+															</td>
+														</tr>
+													);
+												})}
+											</tbody>
+										</table>
+									</ScrollArea>
 								)}
-							</p>
-							{docLoading ? (
-								<div className="flex items-center gap-2 text-muted-foreground text-sm">
-									<Spinner className="size-3" />
-									Loading…
-								</div>
-							) : docError ? (
-								<p className="text-destructive text-sm">
-									{docError}
-								</p>
-							) : docAssets.length === 0 ? (
-								<p className="text-muted-foreground text-sm">
-									No documents found.
-								</p>
-							) : (
-								<ScrollArea className="h-52 rounded-md border">
-									<table className="w-full table-fixed text-sm">
-										<thead>
-											<tr className="border-b text-muted-foreground text-xs">
-												<th className="px-4 pt-2 pb-2 text-left font-medium">
-													Name
-												</th>
-												<th className="w-36 px-3 pt-2 pb-2 text-left font-medium">
-													Date Uploaded
-												</th>
-												<th className="w-20 px-4 pt-2 pb-2 text-right font-medium">
-													Size
-												</th>
-											</tr>
-										</thead>
-										<tbody>
-											{docAssets.map((f, idx) => {
-												const name =
-													f.fileName ||
-													f.name ||
-													(f.path
-														? f.path
-																.split(/[/\\]/)
-																.pop()
-														: "") ||
-													"Untitled";
-												return (
-													<tr
-														key={`${f.path || name}-${idx}`}
-														className="border-b transition last:border-0 hover:bg-muted/40"
-													>
-														<td className="px-4 py-2">
-															<div className="flex min-w-0 items-center gap-2">
-																{getFileIcon(
-																	name,
-																)}
-																<span className="break-all font-medium text-xs">
-																	{name}
-																</span>
-															</div>
-														</td>
-														<td className="w-36 px-3 py-2 text-muted-foreground text-xs tabular-nums">
-															{f.lastModified
-																? formatDateTime(
-																		f.lastModified,
-																	)
-																: "—"}
-														</td>
-														<td className="w-20 px-4 py-2 text-right text-muted-foreground text-xs tabular-nums">
-															{f.fileSize != null
-																? formatFileSize(
-																		f.fileSize,
-																	)
-																: "—"}
-														</td>
-													</tr>
-												);
-											})}
-										</tbody>
-									</table>
-								</ScrollArea>
-							)}
+							</div>
 						</div>
-					</div>
-				</DialogContent>
-			</Dialog>
-		</div>
-	);
-};
+					</DialogContent>
+				</Dialog>
+			</div>
+		);
+	},
+);

--- a/packages/playground/src/components/workspace/workspace-form.tsx
+++ b/packages/playground/src/components/workspace/workspace-form.tsx
@@ -346,7 +346,7 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 							</TabsTrigger>
 							<TabsTrigger value="prompt">
 								<FileTextIcon />
-								Prompt
+								Instructions
 							</TabsTrigger>
 							{!isNew && (
 								<TabsTrigger value="membership">

--- a/packages/playground/src/components/workspace/workspace-form.tsx
+++ b/packages/playground/src/components/workspace/workspace-form.tsx
@@ -8,7 +8,7 @@ import {
 	UsersRound,
 	X,
 } from "lucide-react";
-import { useEffect, useId, useState } from "react";
+import { useCallback, useEffect, useId, useState } from "react";
 import { useTranslation } from "@semoss/i18n";
 import { Env, post, useInsight } from "@semoss/sdk/react";
 import {
@@ -147,6 +147,15 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 			setIsTogglingFavorite(false);
 		}
 	};
+
+	const handleKnowledgeChange = useCallback(
+		(vals: MCPConfig[]) => setKnowledge(vals),
+		[],
+	);
+	const handleToolboxChange = useCallback(
+		(mcps: MCPConfig[]) => setToolbox(mcps),
+		[],
+	);
 
 	/**
 	 * Method that is called to create or update the workspace
@@ -423,7 +432,7 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 							<KnowledgeSelector
 								values={knowledge}
 								disabled={isLoading}
-								onChange={(vals) => setKnowledge(vals)}
+								onChange={handleKnowledgeChange}
 							/>
 						</TabsContent>
 
@@ -445,7 +454,7 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 								type="TOOLBOX"
 								values={toolbox}
 								disabled={isLoading}
-								onChange={(mcps) => setToolbox(mcps)}
+								onChange={handleToolboxChange}
 							/>
 						</TabsContent>
 

--- a/packages/playground/src/components/workspace/workspace-form.tsx
+++ b/packages/playground/src/components/workspace/workspace-form.tsx
@@ -1,4 +1,13 @@
-import { Bookmark, X } from "lucide-react";
+import {
+	Bookmark,
+	BookOpenIcon,
+	FileTextIcon,
+	HammerIcon,
+	PlusIcon,
+	SearchIcon,
+	UsersRound,
+	X,
+} from "lucide-react";
 import { useEffect, useId, useState } from "react";
 import { useTranslation } from "@semoss/i18n";
 import { Env, post, useInsight } from "@semoss/sdk/react";
@@ -8,18 +17,28 @@ import {
 	Field,
 	FieldGroup,
 	FieldLabel,
-	FieldSeparator,
 	Input,
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
 	Spinner,
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
 	Textarea,
 	Tooltip,
 	TooltipContent,
 	TooltipProvider,
 	TooltipTrigger,
 	toast,
+	useDebouncedValue,
 } from "@semoss/ui/next";
-import { MCPSelector, NewKnowledgeOverlay } from "@/components";
-import { useChat } from "@/hooks";
+import { MCPSelector } from "@/components";
+import { PaginationButtons } from "@/components/common/pagination-buttons";
+import { KnowledgeSelector } from "@/components/workspace/knowledge-selector";
+import { WorkspaceMembersList } from "@/components/workspace/members/workspace-members-list";
+import { useChat, usePagination } from "@/hooks";
 import type { MCPConfig, Workspace } from "@/types";
 import { formatDateTime } from "@/utility";
 
@@ -67,7 +86,15 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 		useState<boolean>(false);
 
 	const [isLoading, setIsLoading] = useState<boolean>(false);
-	const [isKnowledgeOverlayOpen, setIsKnowledgeOverlayOpen] = useState(false);
+
+	// Tab state
+	const [tab, setTab] = useState<string>("knowledge");
+
+	// Membership tab state (edit mode only)
+	const [isSharingModalOpen, setIsSharingModalOpen] = useState(false);
+	const [memberSearch, setMemberSearch] = useState("");
+	const debouncedMemberSearch = useDebouncedValue(memberSearch);
+	const pagination = usePagination();
 
 	/**
 	 * Library Hooks
@@ -175,33 +202,7 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 	return (
 		<TooltipProvider>
 			<form onSubmit={onSubmit} className="flex w-full flex-col gap-6">
-				{/* System Prompt — prominent at top */}
-				<div className="rounded-xl border border-border bg-muted/30 p-5">
-					<div className="mb-3 flex items-center justify-between">
-						<label
-							htmlFor={instructionId}
-							className="font-semibold text-base text-foreground"
-						>
-							{t("workspace:form.instructionsLabel")}
-						</label>
-						<span className="text-muted-foreground text-xs">
-							Defines the agent&apos;s behavior and persona
-						</span>
-					</div>
-					<Textarea
-						id={instructionId}
-						placeholder={t("common:placeholders.enterInstructions")}
-						value={instructions.replace(/\\n/g, "\n")}
-						onChange={(e) => setInstructions(e.target.value)}
-						rows={8}
-						className="resize-y"
-						data-testid="workspaceForm-system_prompt-txt"
-					/>
-				</div>
-
-				<FieldSeparator />
-
-				{/* Name, Description, Tags, Favorite */}
+				{/* Basic info: Name, Description, Tags, Favorite — always above tabs */}
 				<FieldGroup>
 					<div className="flex items-start gap-3">
 						<div className="flex-1">
@@ -327,58 +328,140 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 					</Field>
 				</FieldGroup>
 
-				<FieldSeparator />
-
-				{/* Knowledge and Toolbox */}
-				<FieldGroup>
-					<Field>
-						<FieldLabel
-							onClick={(event) => {
-								event.preventDefault();
-								event.stopPropagation();
-								setIsKnowledgeOverlayOpen(true);
-							}}
-						>
-							<div className="flex-1">
+				{/* Tabs: Knowledge, Toolbox, Prompt, Membership */}
+				<Tabs
+					value={tab}
+					onValueChange={setTab}
+					className="flex flex-col gap-4"
+				>
+					<div className="flex items-center justify-between gap-4">
+						<TabsList>
+							<TabsTrigger value="knowledge">
+								<BookOpenIcon />
 								{t("workspace:form.knowledgeLabel")}
+							</TabsTrigger>
+							<TabsTrigger value="toolbox">
+								<HammerIcon />
+								{t("workspace:form.toolboxLabel")}
+							</TabsTrigger>
+							<TabsTrigger value="prompt">
+								<FileTextIcon />
+								Prompt
+							</TabsTrigger>
+							{!isNew && (
+								<TabsTrigger value="membership">
+									<UsersRound />
+									Membership
+								</TabsTrigger>
+							)}
+						</TabsList>
+						{tab === "membership" && !isNew && (
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => setIsSharingModalOpen(true)}
+							>
+								<PlusIcon />
+								{t("workspace:sharing.title")}
+							</Button>
+						)}
+					</div>
+
+					{/* Bordered card wrapping all tab content */}
+					<div className="overflow-hidden rounded-xl border border-border bg-card">
+						{/* Search bar — membership tab only */}
+						{tab === "membership" && !isNew && (
+							<div className="border-border border-b bg-primary-foreground p-4">
+								<InputGroup className="bg-background">
+									<InputGroupInput
+										placeholder={t("common:buttons.search")}
+										value={memberSearch}
+										onChange={(e) =>
+											setMemberSearch(e.target.value)
+										}
+									/>
+									<InputGroupAddon>
+										<SearchIcon />
+									</InputGroupAddon>
+								</InputGroup>
 							</div>
-						</FieldLabel>
+						)}
 
-						<MCPSelector
-							type="KNOWLEDGE"
-							values={knowledge}
-							disabled={isLoading}
-							onChange={(knowledge) => setKnowledge(knowledge)}
-						/>
+						<TabsContent value="knowledge" className="p-4">
+							<KnowledgeSelector
+								values={knowledge}
+								disabled={isLoading}
+								onChange={(vals) => setKnowledge(vals)}
+							/>
+						</TabsContent>
 
-						<NewKnowledgeOverlay
-							open={isKnowledgeOverlayOpen}
-							onClose={(knowledge) => {
-								if (knowledge) {
-									setKnowledge((prev) => [
-										...prev,
-										knowledge,
-									]);
-								}
-								setIsKnowledgeOverlayOpen(false);
-							}}
-						/>
-					</Field>
-					<Field>
-						<FieldLabel>
-							{t("workspace:form.toolboxLabel")}
-						</FieldLabel>
-						<MCPSelector
-							type="TOOLBOX"
-							values={toolbox}
-							disabled={isLoading}
-							onChange={(mcps) => setToolbox(mcps)}
-						/>
-					</Field>
-				</FieldGroup>
+						<TabsContent value="toolbox" className="p-4">
+							<MCPSelector
+								type="TOOLBOX"
+								values={toolbox}
+								disabled={isLoading}
+								onChange={(mcps) => setToolbox(mcps)}
+							/>
+						</TabsContent>
+
+						<TabsContent value="prompt" className="p-4">
+							<div className="flex flex-col gap-2">
+								<label
+									htmlFor={instructionId}
+									className="text-muted-foreground text-xs"
+								>
+									Defines the agent&apos;s behavior and
+									persona
+								</label>
+								<Textarea
+									id={instructionId}
+									placeholder={t(
+										"common:placeholders.enterInstructions",
+									)}
+									value={instructions.replace(/\\n/g, "\n")}
+									onChange={(e) =>
+										setInstructions(e.target.value)
+									}
+									rows={10}
+									className="resize-y"
+									data-testid="workspaceForm-system_prompt-txt"
+								/>
+							</div>
+						</TabsContent>
+
+						{!isNew && values?.workspace_id && (
+							<TabsContent
+								value="membership"
+								className="w-full overflow-hidden"
+							>
+								<WorkspaceMembersList
+									workspaceId={values.workspace_id}
+									search={debouncedMemberSearch}
+									paginationControl={pagination}
+									isSharingModalOpen={isSharingModalOpen}
+									onSharingModalClose={() =>
+										setIsSharingModalOpen(false)
+									}
+								/>
+							</TabsContent>
+						)}
+					</div>
+
+					{/* Pagination — membership tab only */}
+					{tab === "membership" && !isNew && (
+						<div className="flex w-full flex-row items-center justify-end gap-2 border-border border-t bg-primary-foreground px-4 py-3">
+							<PaginationButtons {...pagination} />
+						</div>
+					)}
+				</Tabs>
 
 				<div className="flex items-center justify-between">
-					<Button variant="ghost" onClick={() => onClose()}>
+					<Button
+						type="button"
+						variant="ghost"
+						onClick={() => onClose()}
+					>
 						{t("common:buttons.back")}
 					</Button>
 					<Button

--- a/packages/playground/src/components/workspace/workspace-form.tsx
+++ b/packages/playground/src/components/workspace/workspace-form.tsx
@@ -1,13 +1,21 @@
+import { Bookmark, X } from "lucide-react";
 import { useEffect, useId, useState } from "react";
 import { useTranslation } from "@semoss/i18n";
+import { Env, post, useInsight } from "@semoss/sdk/react";
 import {
+	Badge,
 	Button,
 	Field,
 	FieldGroup,
 	FieldLabel,
 	FieldSeparator,
 	Input,
+	Spinner,
 	Textarea,
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
 	toast,
 } from "@semoss/ui/next";
 import { MCPSelector, NewKnowledgeOverlay } from "@/components";
@@ -27,12 +35,26 @@ interface WorkspaceFormProps {
 	onClose: (workspaceId?: string) => void;
 }
 
+const formatDateTime = (dateStr: string): string => {
+	const d = new Date(dateStr.replace(" ", "T"));
+	if (isNaN(d.getTime())) return dateStr;
+	return d.toLocaleString(undefined, {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+		hour12: true,
+	});
+};
+
 export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 	isNew,
 	values,
 	onClose,
 }) => {
 	const { t } = useTranslation(["workspace", "common", "notifications"]);
+	const { actions } = useInsight();
 
 	/**
 	 * IDs
@@ -40,6 +62,7 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 	const nameId = useId();
 	const descriptionId = useId();
 	const instructionId = useId();
+	const tagInputId = useId();
 
 	/**
 	 * State
@@ -49,6 +72,11 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 	const [instructions, setInstructions] = useState<string>("");
 	const [toolbox, setToolbox] = useState<MCPConfig[]>([]);
 	const [knowledge, setKnowledge] = useState<MCPConfig[]>([]);
+	const [tags, setTags] = useState<string[]>([]);
+	const [tagInput, setTagInput] = useState<string>("");
+	const [isFavorite, setIsFavorite] = useState<boolean>(false);
+	const [isTogglingFavorite, setIsTogglingFavorite] =
+		useState<boolean>(false);
 
 	const [isLoading, setIsLoading] = useState<boolean>(false);
 	const [isKnowledgeOverlayOpen, setIsKnowledgeOverlayOpen] = useState(false);
@@ -63,9 +91,47 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 		setName(values?.name || "");
 		setDescription(values?.description || "");
 		setInstructions(values?.system_prompt || "");
-		setKnowledge(values?.mcp.filter((mcp) => mcp.type === "VECTOR") || []);
-		setToolbox(values?.mcp.filter((mcp) => mcp.type !== "VECTOR") || []);
+		setKnowledge(values?.mcp?.filter((mcp) => mcp.type === "VECTOR") || []);
+		setToolbox(values?.mcp?.filter((mcp) => mcp.type !== "VECTOR") || []);
+		setTags(values?.tag || []);
 	}, [values]);
+
+	const addTag = () => {
+		const trimmed = tagInput.trim();
+		if (trimmed && !tags.includes(trimmed)) {
+			setTags((prev) => [...prev, trimmed]);
+		}
+		setTagInput("");
+	};
+
+	const removeTag = (tag: string) => {
+		setTags((prev) => prev.filter((t) => t !== tag));
+	};
+
+	const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Enter" || e.key === ",") {
+			e.preventDefault();
+			addTag();
+		}
+	};
+
+	const toggleFavorite = async () => {
+		if (isNew || !values?.workspace_id) return;
+		const next = !isFavorite;
+		setIsTogglingFavorite(true);
+		try {
+			await post<{ success: boolean }>(
+				`${Env.MODULE}/api/auth/project/setProjectFavorite`,
+				{ projectId: values.workspace_id, isFavorite: next },
+				{},
+			);
+			setIsFavorite(next);
+		} catch {
+			toast.error("Failed to update favorite status.");
+		} finally {
+			setIsTogglingFavorite(false);
+		}
+	};
 
 	/**
 	 * Method that is called to create or update the workspace
@@ -74,7 +140,6 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 		e.preventDefault();
 
 		try {
-			// start the loading screen
 			setIsLoading(true);
 
 			const updated: Omit<Workspace, "workspace_id" | "date_created"> = {
@@ -91,124 +156,254 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 				output = await chat.editWorkspace(values.workspace_id, updated);
 			}
 
-			// get new app id and return in the onclose
+			// Save tags via SetProjectMetadata
+			const projectId = isNew ? output : values.workspace_id;
+			if (projectId && tags.length > 0) {
+				try {
+					await actions.run(
+						`SetProjectMetadata(project=["${projectId}"], meta=[{"tag":${JSON.stringify(tags)}}], jsonCleanup=[true]);`,
+					);
+				} catch {
+					// non-fatal: workspace saved, tags may not have saved
+					toast.error(
+						"Agent saved but tags could not be updated. Try editing again.",
+					);
+				}
+			}
+
 			onClose(output);
 		} catch (e) {
 			console.error(e);
-
 			toast.error(
 				e instanceof Error
 					? e.message
 					: t("notifications:workspace.saveError"),
 			);
 		} finally {
-			// stop the loading screen
 			setIsLoading(false);
 		}
 	};
 
 	return (
-		<form onSubmit={onSubmit} className="flex w-full flex-col gap-6">
-			<FieldGroup>
-				<Field>
-					<FieldLabel htmlFor={nameId}>
-						{t("workspace:form.nameLabel")}
-					</FieldLabel>
-					<Input
-						id={nameId}
-						placeholder={t("common:placeholders.enterName")}
-						value={name}
-						disabled={isLoading}
-						onChange={(e) => setName(e.target.value)}
-						data-testid="workspaceForm-textField-name"
-					/>
-				</Field>
-				<Field>
-					<FieldLabel htmlFor={descriptionId}>
-						{t("workspace:form.descriptionLabel")}
-					</FieldLabel>
-					<Input
-						id={descriptionId}
-						placeholder={t("common:placeholders.enterDescription")}
-						value={description}
-						disabled={isLoading}
-						onChange={(e) => setDescription(e.target.value)}
-						data-testid="workspaceForm-description-txt"
-					/>
-				</Field>
-			</FieldGroup>
-			<FieldSeparator />
-			<FieldGroup>
-				<Field>
-					<FieldLabel htmlFor={instructionId}>
-						{t("workspace:form.instructionsLabel")}
-					</FieldLabel>
+		<TooltipProvider>
+			<form onSubmit={onSubmit} className="flex w-full flex-col gap-6">
+				{/* System Prompt — prominent at top */}
+				<div className="rounded-xl border border-border bg-muted/30 p-5">
+					<div className="mb-3 flex items-center justify-between">
+						<label
+							htmlFor={instructionId}
+							className="font-semibold text-base text-foreground"
+						>
+							{t("workspace:form.instructionsLabel")}
+						</label>
+						<span className="text-muted-foreground text-xs">
+							Defines the agent&apos;s behavior and persona
+						</span>
+					</div>
 					<Textarea
 						id={instructionId}
 						placeholder={t("common:placeholders.enterInstructions")}
 						value={instructions.replace(/\\n/g, "\n")}
 						onChange={(e) => setInstructions(e.target.value)}
-						rows={4}
+						rows={8}
+						className="resize-y"
 						data-testid="workspaceForm-system_prompt-txt"
 					/>
-				</Field>
-				<Field>
-					<FieldLabel
-						onClick={(event) => {
-							event.preventDefault();
-							event.stopPropagation();
+				</div>
 
-							setIsKnowledgeOverlayOpen(true);
-						}}
-					>
+				<FieldSeparator />
+
+				{/* Name, Description, Tags, Favorite */}
+				<FieldGroup>
+					<div className="flex items-start gap-3">
 						<div className="flex-1">
-							{t("workspace:form.knowledgeLabel")}
+							<Field>
+								<FieldLabel htmlFor={nameId}>
+									{t("workspace:form.nameLabel")}
+								</FieldLabel>
+								<Input
+									id={nameId}
+									placeholder={t(
+										"common:placeholders.enterName",
+									)}
+									value={name}
+									disabled={isLoading}
+									onChange={(e) => setName(e.target.value)}
+									data-testid="workspaceForm-textField-name"
+								/>
+							</Field>
 						</div>
-					</FieldLabel>
+						{/* Favorite toggle — only shown when editing */}
+						{!isNew && values?.workspace_id && (
+							<div className="mt-6 flex items-center gap-2">
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Button
+											type="button"
+											variant="outline"
+											size="icon"
+											onClick={toggleFavorite}
+											disabled={
+												isLoading || isTogglingFavorite
+											}
+										>
+											{isTogglingFavorite ? (
+												<Spinner className="size-4" />
+											) : (
+												<Bookmark
+													className={`h-5 w-5 ${isFavorite ? "fill-current text-primary" : "text-muted-foreground"}`}
+												/>
+											)}
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent>
+										{isFavorite
+											? "Remove from favorites"
+											: "Add to favorites"}
+									</TooltipContent>
+								</Tooltip>
+								{values?.date_created && (
+									<span className="whitespace-nowrap text-muted-foreground text-xs">
+										Created{" "}
+										{formatDateTime(values.date_created)}
+									</span>
+								)}
+							</div>
+						)}
+					</div>
 
-					<MCPSelector
-						type="KNOWLEDGE"
-						values={knowledge}
-						disabled={isLoading}
-						onChange={(knowledge) => setKnowledge(knowledge)}
-					/>
+					<Field>
+						<FieldLabel htmlFor={descriptionId}>
+							{t("workspace:form.descriptionLabel")}
+						</FieldLabel>
+						<Input
+							id={descriptionId}
+							placeholder={t(
+								"common:placeholders.enterDescription",
+							)}
+							value={description}
+							disabled={isLoading}
+							onChange={(e) => setDescription(e.target.value)}
+							data-testid="workspaceForm-description-txt"
+						/>
+					</Field>
 
-					<NewKnowledgeOverlay
-						open={isKnowledgeOverlayOpen}
-						onClose={(knowledge) => {
-							// update it
-							if (knowledge) {
-								setKnowledge((prev) => [...prev, knowledge]);
-							}
+					{/* Tags */}
+					<Field>
+						<FieldLabel htmlFor={tagInputId}>Tags</FieldLabel>
+						<div className="flex flex-col gap-2">
+							<div className="flex gap-2">
+								<Input
+									id={tagInputId}
+									placeholder="Type a tag and press Enter"
+									value={tagInput}
+									disabled={isLoading}
+									onChange={(e) =>
+										setTagInput(e.target.value)
+									}
+									onKeyDown={handleTagKeyDown}
+									onBlur={addTag}
+								/>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={addTag}
+									disabled={isLoading || !tagInput.trim()}
+								>
+									Add
+								</Button>
+							</div>
+							{tags.length > 0 && (
+								<div className="flex flex-wrap gap-1">
+									{tags.map((tag) => (
+										<Badge
+											key={tag}
+											variant="secondary"
+											className="gap-1 text-sm"
+										>
+											{tag}
+											<button
+												type="button"
+												onClick={() => removeTag(tag)}
+												className="ml-1 rounded-full hover:text-destructive"
+												aria-label={`Remove tag ${tag}`}
+											>
+												<X className="h-3 w-3" />
+											</button>
+										</Badge>
+									))}
+								</div>
+							)}
+						</div>
+					</Field>
+				</FieldGroup>
 
-							setIsKnowledgeOverlayOpen(false);
-						}}
-					/>
-				</Field>
-				<Field>
-					<FieldLabel>{t("workspace:form.toolboxLabel")}</FieldLabel>
-					<MCPSelector
-						type="TOOLBOX"
-						values={toolbox}
-						disabled={isLoading}
-						onChange={(mcps) => setToolbox(mcps)}
-					/>
-				</Field>
-			</FieldGroup>
-			<div className="flex items-center justify-between">
-				<Button variant="ghost" onClick={() => onClose()}>
-					{t("common:buttons.back")}
-				</Button>
-				<Button
-					disabled={isLoading || !name}
-					data-testid="workspaceForm-submit-btn"
-					type="submit"
-				>
-					{isNew
-						? t("workspace:actions.create")
-						: t("workspace:actions.save")}
-				</Button>
-			</div>
-		</form>
+				<FieldSeparator />
+
+				{/* Knowledge and Toolbox */}
+				<FieldGroup>
+					<Field>
+						<FieldLabel
+							onClick={(event) => {
+								event.preventDefault();
+								event.stopPropagation();
+								setIsKnowledgeOverlayOpen(true);
+							}}
+						>
+							<div className="flex-1">
+								{t("workspace:form.knowledgeLabel")}
+							</div>
+						</FieldLabel>
+
+						<MCPSelector
+							type="KNOWLEDGE"
+							values={knowledge}
+							disabled={isLoading}
+							onChange={(knowledge) => setKnowledge(knowledge)}
+						/>
+
+						<NewKnowledgeOverlay
+							open={isKnowledgeOverlayOpen}
+							onClose={(knowledge) => {
+								if (knowledge) {
+									setKnowledge((prev) => [
+										...prev,
+										knowledge,
+									]);
+								}
+								setIsKnowledgeOverlayOpen(false);
+							}}
+						/>
+					</Field>
+					<Field>
+						<FieldLabel>
+							{t("workspace:form.toolboxLabel")}
+						</FieldLabel>
+						<MCPSelector
+							type="TOOLBOX"
+							values={toolbox}
+							disabled={isLoading}
+							onChange={(mcps) => setToolbox(mcps)}
+						/>
+					</Field>
+				</FieldGroup>
+
+				<div className="flex items-center justify-between">
+					<Button variant="ghost" onClick={() => onClose()}>
+						{t("common:buttons.back")}
+					</Button>
+					<Button
+						disabled={isLoading || !name}
+						data-testid="workspaceForm-submit-btn"
+						type="submit"
+					>
+						{isNew
+							? t("workspace:actions.create")
+							: t("workspace:actions.save")}
+					</Button>
+				</div>
+			</form>
+		</TooltipProvider>
 	);
 };

--- a/packages/playground/src/components/workspace/workspace-form.tsx
+++ b/packages/playground/src/components/workspace/workspace-form.tsx
@@ -21,6 +21,7 @@ import {
 import { MCPSelector, NewKnowledgeOverlay } from "@/components";
 import { useChat } from "@/hooks";
 import type { MCPConfig, Workspace } from "@/types";
+import { formatDateTime } from "@/utility";
 
 interface WorkspaceFormProps {
 	/**
@@ -34,19 +35,6 @@ interface WorkspaceFormProps {
 	/** Callback that is fired when the form is closed or submitted. If it is successful, it will return an id */
 	onClose: (workspaceId?: string) => void;
 }
-
-const formatDateTime = (dateStr: string): string => {
-	const d = new Date(dateStr.replace(" ", "T"));
-	if (isNaN(d.getTime())) return dateStr;
-	return d.toLocaleString(undefined, {
-		month: "short",
-		day: "numeric",
-		year: "numeric",
-		hour: "numeric",
-		minute: "2-digit",
-		hour12: true,
-	});
-};
 
 export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 	isNew,

--- a/packages/playground/src/components/workspace/workspace-form.tsx
+++ b/packages/playground/src/components/workspace/workspace-form.tsx
@@ -202,9 +202,10 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 	return (
 		<TooltipProvider>
 			<form onSubmit={onSubmit} className="flex w-full flex-col gap-6">
-				{/* Basic info: Name, Description, Tags, Favorite — always above tabs */}
+				{/* Basic info: Name + Tags on one row, Description below */}
 				<FieldGroup>
 					<div className="flex items-start gap-3">
+						{/* Name */}
 						<div className="flex-1">
 							<Field>
 								<FieldLabel htmlFor={nameId}>
@@ -222,6 +223,51 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 								/>
 							</Field>
 						</div>
+
+						{/* Tags — inline badge input */}
+						<div className="w-1/3 shrink-0">
+							<Field>
+								<FieldLabel htmlFor={tagInputId}>
+									Tags
+								</FieldLabel>
+								<div className="flex min-h-[38px] flex-wrap items-center gap-1.5 rounded-md border border-input px-2 py-1.5">
+									{tags.map((tag) => (
+										<Badge
+											key={tag}
+											variant="secondary"
+											className="gap-1 text-xs"
+										>
+											{tag}
+											<button
+												type="button"
+												onClick={() => removeTag(tag)}
+												className="ml-0.5 rounded-full hover:text-destructive"
+												aria-label={`Remove tag ${tag}`}
+											>
+												<X className="h-3 w-3" />
+											</button>
+										</Badge>
+									))}
+									<input
+										id={tagInputId}
+										className="min-w-[60px] flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+										placeholder={
+											tags.length === 0
+												? "Add tags..."
+												: ""
+										}
+										value={tagInput}
+										disabled={isLoading}
+										onChange={(e) =>
+											setTagInput(e.target.value)
+										}
+										onKeyDown={handleTagKeyDown}
+										onBlur={addTag}
+									/>
+								</div>
+							</Field>
+						</div>
+
 						{/* Favorite toggle — only shown when editing */}
 						{!isNew && values?.workspace_id && (
 							<div className="mt-6 flex items-center gap-2">
@@ -276,56 +322,6 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 							data-testid="workspaceForm-description-txt"
 						/>
 					</Field>
-
-					{/* Tags */}
-					<Field>
-						<FieldLabel htmlFor={tagInputId}>Tags</FieldLabel>
-						<div className="flex flex-col gap-2">
-							<div className="flex gap-2">
-								<Input
-									id={tagInputId}
-									placeholder="Type a tag and press Enter"
-									value={tagInput}
-									disabled={isLoading}
-									onChange={(e) =>
-										setTagInput(e.target.value)
-									}
-									onKeyDown={handleTagKeyDown}
-									onBlur={addTag}
-								/>
-								<Button
-									type="button"
-									variant="outline"
-									size="sm"
-									onClick={addTag}
-									disabled={isLoading || !tagInput.trim()}
-								>
-									Add
-								</Button>
-							</div>
-							{tags.length > 0 && (
-								<div className="flex flex-wrap gap-1">
-									{tags.map((tag) => (
-										<Badge
-											key={tag}
-											variant="secondary"
-											className="gap-1 text-sm"
-										>
-											{tag}
-											<button
-												type="button"
-												onClick={() => removeTag(tag)}
-												className="ml-1 rounded-full hover:text-destructive"
-												aria-label={`Remove tag ${tag}`}
-											>
-												<X className="h-3 w-3" />
-											</button>
-										</Badge>
-									))}
-								</div>
-							)}
-						</div>
-					</Field>
 				</FieldGroup>
 
 				{/* Tabs: Knowledge, Toolbox, Prompt, Membership */}
@@ -339,10 +335,20 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 							<TabsTrigger value="knowledge">
 								<BookOpenIcon />
 								{t("workspace:form.knowledgeLabel")}
+								{knowledge.length > 0 && (
+									<span className="ml-1 rounded-full bg-primary px-1.5 py-0.5 font-medium text-[10px] text-primary-foreground">
+										{knowledge.length}
+									</span>
+								)}
 							</TabsTrigger>
 							<TabsTrigger value="toolbox">
 								<HammerIcon />
 								{t("workspace:form.toolboxLabel")}
+								{toolbox.length > 0 && (
+									<span className="ml-1 rounded-full bg-primary px-1.5 py-0.5 font-medium text-[10px] text-primary-foreground">
+										{toolbox.length}
+									</span>
+								)}
 							</TabsTrigger>
 							<TabsTrigger value="prompt">
 								<FileTextIcon />
@@ -355,17 +361,29 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 								</TabsTrigger>
 							)}
 						</TabsList>
-						{tab === "membership" && !isNew && (
+						<div className="flex items-center gap-2">
+							{tab === "membership" && !isNew && (
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => setIsSharingModalOpen(true)}
+								>
+									<PlusIcon />
+									{t("workspace:sharing.title")}
+								</Button>
+							)}
 							<Button
-								type="button"
-								variant="outline"
+								disabled={isLoading || !name}
+								data-testid="workspaceForm-submit-btn"
+								type="submit"
 								size="sm"
-								onClick={() => setIsSharingModalOpen(true)}
 							>
-								<PlusIcon />
-								{t("workspace:sharing.title")}
+								{isNew
+									? t("workspace:actions.create")
+									: t("workspace:actions.save")}
 							</Button>
-						)}
+						</div>
 					</div>
 
 					{/* Bordered card wrapping all tab content */}
@@ -389,6 +407,19 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 						)}
 
 						<TabsContent value="knowledge" className="p-4">
+							{knowledge.length > 0 && (
+								<div className="mb-3 flex justify-end">
+									<Button
+										type="button"
+										variant="ghost"
+										size="sm"
+										onClick={() => setKnowledge([])}
+										className="text-muted-foreground text-xs"
+									>
+										Deselect all
+									</Button>
+								</div>
+							)}
 							<KnowledgeSelector
 								values={knowledge}
 								disabled={isLoading}
@@ -397,6 +428,19 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 						</TabsContent>
 
 						<TabsContent value="toolbox" className="p-4">
+							{toolbox.length > 0 && (
+								<div className="mb-3 flex justify-end">
+									<Button
+										type="button"
+										variant="ghost"
+										size="sm"
+										onClick={() => setToolbox([])}
+										className="text-muted-foreground text-xs"
+									>
+										Deselect all
+									</Button>
+								</div>
+							)}
 							<MCPSelector
 								type="TOOLBOX"
 								values={toolbox}
@@ -456,22 +500,13 @@ export const WorkspaceForm: React.FC<WorkspaceFormProps> = ({
 					)}
 				</Tabs>
 
-				<div className="flex items-center justify-between">
+				<div className="flex items-center">
 					<Button
 						type="button"
 						variant="ghost"
 						onClick={() => onClose()}
 					>
 						{t("common:buttons.back")}
-					</Button>
-					<Button
-						disabled={isLoading || !name}
-						data-testid="workspaceForm-submit-btn"
-						type="submit"
-					>
-						{isNew
-							? t("workspace:actions.create")
-							: t("workspace:actions.save")}
 					</Button>
 				</div>
 			</form>

--- a/packages/playground/src/pages/knowledge-detail-page.tsx
+++ b/packages/playground/src/pages/knowledge-detail-page.tsx
@@ -6,10 +6,6 @@ import {
 	ChevronDownIcon,
 	ChevronUpIcon,
 	DownloadIcon,
-	FileIcon,
-	FileImageIcon,
-	FileSpreadsheetIcon,
-	FileTextIcon,
 	FolderPlusIcon,
 	MessageSquarePlusIcon,
 } from "lucide-react";
@@ -54,6 +50,7 @@ import {
 import { EmbedDocumentsOverlay } from "@/components/knowledge/embed-documents-overlay";
 import { NewKnowledgeOverlay } from "@/components/knowledge/new-knowledge-mcp-overlay";
 import { useGlobalBreadcrumbs } from "@/hooks";
+import { formatFileSize, getFileIcon, parseSizeBytes } from "@/utility";
 
 type KnowledgeEngine = {
 	app_id: string;
@@ -81,47 +78,6 @@ type SearchUser = {
 	email: string;
 	type: string;
 	username: string;
-};
-
-const getFileIcon = (fileName: string) => {
-	const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
-	if (ext === "pdf")
-		return <FileTextIcon className="h-4 w-4 shrink-0 text-red-500" />;
-	if (ext === "doc" || ext === "docx")
-		return <FileTextIcon className="h-4 w-4 shrink-0 text-blue-500" />;
-	if (ext === "xls" || ext === "xlsx" || ext === "csv")
-		return (
-			<FileSpreadsheetIcon className="h-4 w-4 shrink-0 text-green-600" />
-		);
-	if (
-		ext === "png" ||
-		ext === "jpg" ||
-		ext === "jpeg" ||
-		ext === "gif" ||
-		ext === "webp" ||
-		ext === "svg"
-	)
-		return <FileImageIcon className="h-4 w-4 shrink-0 text-purple-500" />;
-	return <FileIcon className="h-4 w-4 shrink-0 text-muted-foreground" />;
-};
-
-const parseSizeBytes = (fileSize: string | number): number => {
-	const s = String(fileSize ?? "");
-	const match = s.match(/^([\d.]+)\s*(KB|MB|GB|B)?$/i);
-	if (!match) return 0;
-	const num = parseFloat(match[1]);
-	const unit = (match[2] ?? "B").toUpperCase();
-	if (unit === "GB") return num * 1024 * 1024 * 1024;
-	if (unit === "MB") return num * 1024 * 1024;
-	if (unit === "KB") return num * 1024;
-	return num;
-};
-
-const formatFileSize = (fileSize: string | number): string => {
-	const bytes = parseSizeBytes(fileSize);
-	if (bytes === 0) return String(fileSize);
-	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
-	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 };
 
 const formatDateTime = (dateStr: string): string => {

--- a/packages/playground/src/pages/workspace-detail-page.tsx
+++ b/packages/playground/src/pages/workspace-detail-page.tsx
@@ -485,7 +485,7 @@ export const WorkspaceDetailPage = observer(() => {
 							</TabsTrigger>
 							<TabsTrigger value="systemPrompt">
 								<FileTextIcon />
-								System Prompt
+								Instructions
 							</TabsTrigger>
 							<TabsTrigger value="members">
 								<UsersRound />
@@ -551,7 +551,7 @@ export const WorkspaceDetailPage = observer(() => {
 											setIsEditingSystemPrompt(true);
 										}}
 									>
-										Edit System Prompt
+										Edit Instructions
 									</Button>
 								)}
 							{tab === "systemPrompt" &&
@@ -656,8 +656,8 @@ export const WorkspaceDetailPage = observer(() => {
 										</div>
 									) : (
 										<p className="text-muted-foreground text-sm italic">
-											No system prompt configured. Click
-											&ldquo;Edit System Prompt&rdquo;
+											No instructions configured. Click
+											&ldquo;Edit Instructions&rdquo;
 											above to add one.
 										</p>
 									)}

--- a/packages/playground/src/pages/workspace-detail-page.tsx
+++ b/packages/playground/src/pages/workspace-detail-page.tsx
@@ -1,18 +1,22 @@
 import {
 	BookOpenIcon,
-	EllipsisIcon,
+	FileTextIcon,
 	HammerIcon,
 	MessagesSquareIcon,
+	Pencil,
 	PlusIcon,
 	SearchIcon,
+	Trash2,
 	UsersRound,
+	X,
 } from "lucide-react";
 import { observer } from "mobx-react-lite";
-import { useState } from "react";
-import { Link, Navigate, useNavigate, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { useTranslation } from "@semoss/i18n";
-import { usePixel } from "@semoss/sdk/react";
+import { useInsight, usePixel } from "@semoss/sdk/react";
 import {
+	Badge,
 	Button,
 	Dialog,
 	DialogContent,
@@ -20,11 +24,7 @@ import {
 	DialogFooter,
 	DialogHeader,
 	DialogTitle,
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuGroup,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
+	Input,
 	InputGroup,
 	InputGroupAddon,
 	InputGroupInput,
@@ -33,11 +33,13 @@ import {
 	TabsContent,
 	TabsList,
 	TabsTrigger,
+	Textarea,
 	toast,
 	useDebouncedValue,
 } from "@semoss/ui/next";
 import logoImage from "@/assets/img/logo.svg";
 import {
+	MCPSelector,
 	PaginationButtons,
 	WorkspaceChatList,
 	WorkspaceMCPList,
@@ -46,7 +48,7 @@ import {
 import { useGlobalBreadcrumbs, useRoot } from "@/hooks";
 import { useChat } from "@/hooks/use-chat";
 import { usePagination } from "@/hooks/use-pagination";
-import type { Workspace } from "@/types";
+import type { MCPConfig, Workspace } from "@/types";
 
 /**
  * Renders the Workspace Detail Page, displaying information about a specific workspace
@@ -62,6 +64,7 @@ export const WorkspaceDetailPage = observer(() => {
 	const { workspaceId } = useParams<{ workspaceId: string }>();
 	const navigate = useNavigate();
 	const { chat } = useChat();
+	const { actions } = useInsight();
 	const { root } = useRoot();
 	const pagination = usePagination();
 
@@ -74,6 +77,30 @@ export const WorkspaceDetailPage = observer(() => {
 	const [deleteModal, setDeleteModal] = useState<boolean>(false);
 	const [isSharingModalOpen, setIsSharingModalOpen] =
 		useState<boolean>(false);
+
+	// MCP add dialog state
+	const [addMCPOpen, setAddMCPOpen] = useState(false);
+	const [addMCPType, setAddMCPType] = useState<"KNOWLEDGE" | "TOOLBOX">(
+		"KNOWLEDGE",
+	);
+	const [pendingMCPs, setPendingMCPs] = useState<MCPConfig[]>([]);
+	const [isSavingMCPs, setIsSavingMCPs] = useState(false);
+	// incrementing this key forces WorkspaceMCPList to remount and refetch
+	const [mcpVersion, setMcpVersion] = useState(0);
+
+	// System prompt inline edit state
+	const [isEditingSystemPrompt, setIsEditingSystemPrompt] =
+		useState<boolean>(false);
+	const [systemPromptDraft, setSystemPromptDraft] = useState<string>("");
+	const [isSavingSystemPrompt, setIsSavingSystemPrompt] =
+		useState<boolean>(false);
+
+	// Header inline edit state
+	const [isEditingHeader, setIsEditingHeader] = useState<boolean>(false);
+	const [headerDescription, setHeaderDescription] = useState<string>("");
+	const [headerTags, setHeaderTags] = useState<string[]>([]);
+	const [headerTagInput, setHeaderTagInput] = useState<string>("");
+	const [isSavingHeader, setIsSavingHeader] = useState<boolean>(false);
 
 	/**
 	 * Library Hooks
@@ -93,6 +120,14 @@ export const WorkspaceDetailPage = observer(() => {
 				);
 			},
 		},
+	);
+
+	// Fetch workspace tags separately (GetWorkspace does not support metaKeys)
+	const getProjectMeta = usePixel<{ tag?: string | string[] }>(
+		workspaceId
+			? `GetProjectMetadata(project=["${workspaceId}"], metaKeys=["tag"]);`
+			: "",
+		{ data: null },
 	);
 
 	// set the breadcrumbs
@@ -115,6 +150,117 @@ export const WorkspaceDetailPage = observer(() => {
 			},
 		],
 	});
+
+	const openAddMCP = (type: "KNOWLEDGE" | "TOOLBOX") => {
+		if (!getWorkspace.data) return;
+		const current = getWorkspace.data.mcp.filter((m) =>
+			type === "KNOWLEDGE" ? m.type === "VECTOR" : m.type !== "VECTOR",
+		);
+		setAddMCPType(type);
+		setPendingMCPs(current);
+		setAddMCPOpen(true);
+	};
+
+	const handleSaveMCPs = async () => {
+		if (!getWorkspace.data) return;
+		setIsSavingMCPs(true);
+		try {
+			const other = getWorkspace.data.mcp.filter((m) =>
+				addMCPType === "KNOWLEDGE"
+					? m.type !== "VECTOR"
+					: m.type === "VECTOR",
+			);
+			await chat.editWorkspace(workspaceId, {
+				name: getWorkspace.data.name,
+				description: getWorkspace.data.description,
+				system_prompt: getWorkspace.data.system_prompt,
+				mcp: [...pendingMCPs, ...other],
+			});
+			getWorkspace.refresh();
+			setMcpVersion((v) => v + 1);
+			setAddMCPOpen(false);
+		} catch (e) {
+			toast.error(
+				e instanceof Error
+					? e.message
+					: t("workspace:detail.failedToSave"),
+			);
+		} finally {
+			setIsSavingMCPs(false);
+		}
+	};
+
+	const handleSaveSystemPrompt = async () => {
+		if (!getWorkspace.data) return;
+		setIsSavingSystemPrompt(true);
+		try {
+			await chat.editWorkspace(workspaceId, {
+				name: getWorkspace.data.name,
+				description: getWorkspace.data.description,
+				system_prompt: systemPromptDraft,
+				mcp: getWorkspace.data.mcp,
+			});
+			getWorkspace.refresh();
+			setIsEditingSystemPrompt(false);
+		} catch (e) {
+			toast.error(
+				e instanceof Error
+					? e.message
+					: t("workspace:detail.failedToSave"),
+			);
+		} finally {
+			setIsSavingSystemPrompt(false);
+		}
+	};
+
+	useEffect(() => {
+		if (getWorkspace.data) {
+			setHeaderDescription(getWorkspace.data.description || "");
+		}
+	}, [getWorkspace.data]);
+
+	useEffect(() => {
+		if (getProjectMeta.data) {
+			const rawTag = getProjectMeta.data.tag;
+			const normalized = Array.isArray(rawTag)
+				? rawTag
+				: rawTag
+					? [rawTag]
+					: [];
+			setHeaderTags(normalized);
+		}
+	}, [getProjectMeta.data]);
+
+	const handleSaveHeader = async () => {
+		if (!getWorkspace.data) return;
+		setIsSavingHeader(true);
+		try {
+			await chat.editWorkspace(workspaceId, {
+				name: getWorkspace.data.name,
+				description: headerDescription,
+				system_prompt: getWorkspace.data.system_prompt,
+				mcp: getWorkspace.data.mcp,
+			});
+			try {
+				await actions.run(
+					`SetProjectMetadata(project=["${workspaceId}"], meta=[{"tag":${JSON.stringify(headerTags)}}], jsonCleanup=[true]);`,
+				);
+			} catch {
+				toast.error("Saved but tags could not be updated.");
+			}
+			getWorkspace.refresh();
+			getProjectMeta.refresh();
+			setIsEditingHeader(false);
+		} catch (e) {
+			toast.error(
+				e instanceof Error
+					? e.message
+					: t("workspace:detail.failedToSave"),
+			);
+		} finally {
+			setIsSavingHeader(false);
+		}
+	};
 
 	if (getWorkspace.status === "LOADING" || isLoading) {
 		return (
@@ -139,66 +285,183 @@ export const WorkspaceDetailPage = observer(() => {
 							src={root.theme?.images.logo || logoImage}
 						/>
 					</div>
-					<div className="space-y-2.5">
+					<div className="min-w-0 flex-1 space-y-1.5">
 						<div className="font-semibold text-2xl text-foreground leading-none">
 							{getWorkspace.data?.name}
 						</div>
-						<div className="text-base text-muted-foreground">
-							{getWorkspace.data?.description || ""}
-						</div>
-					</div>
-					<div className="flex-1" />
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<Button
-								variant="outline"
-								onClick={(e) => e.stopPropagation()}
-							>
-								<EllipsisIcon />
-							</Button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end">
-							<DropdownMenuGroup>
-								<DropdownMenuItem asChild>
-									<Link to={`/agent/${workspaceId}/edit`}>
-										{t("workspace:actions.edit")}
-									</Link>
-								</DropdownMenuItem>
-								<DropdownMenuItem
-									onClick={async (e) => {
-										e.stopPropagation();
-										setDeleteModal(true);
-										setIsLoading(true);
-										try {
-											await chat.deleteWorkspace(
-												workspaceId,
-											);
-
-											// go to the workspace
-											navigate("/agent");
-										} catch (e) {
-											toast.error(
-												e instanceof Error
-													? e.message
-													: t(
-															"workspace:detail.failedToDelete",
-														),
-											);
-										} finally {
-											setIsLoading(false);
+						{isEditingHeader ? (
+							<div className="flex flex-col gap-2">
+								<Input
+									value={headerDescription}
+									onChange={(e) =>
+										setHeaderDescription(e.target.value)
+									}
+									placeholder="Description"
+									disabled={isSavingHeader}
+									className="text-sm"
+								/>
+								<div className="flex min-h-[38px] flex-wrap items-center gap-1.5 rounded-md border border-input px-2 py-1.5">
+									{headerTags
+										.filter(
+											(t) => t !== "Workspace_Project",
+										)
+										.map((tag) => (
+											<Badge
+												key={tag}
+												variant="secondary"
+												className="gap-1 text-xs"
+											>
+												{tag}
+												<button
+													type="button"
+													onClick={() =>
+														setHeaderTags((prev) =>
+															prev.filter(
+																(t) =>
+																	t !== tag,
+															),
+														)
+													}
+													className="ml-0.5 rounded-full hover:text-destructive"
+												>
+													<X className="h-3 w-3" />
+												</button>
+											</Badge>
+										))}
+									<input
+										className="min-w-[80px] flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+										placeholder={
+											headerTags.filter(
+												(t) =>
+													t !== "Workspace_Project",
+											).length === 0
+												? "Add tags..."
+												: ""
 										}
-									}}
-								>
-									{t("workspace:actions.delete")}
-								</DropdownMenuItem>
-							</DropdownMenuGroup>
-						</DropdownMenuContent>
-					</DropdownMenu>
-					{/* <Button
-								variant="outline"
-							>
-								<PinIcon />
-							</Button> */}
+										value={headerTagInput}
+										disabled={isSavingHeader}
+										onChange={(e) =>
+											setHeaderTagInput(e.target.value)
+										}
+										onKeyDown={(e) => {
+											if (
+												e.key === "Enter" ||
+												e.key === ","
+											) {
+												e.preventDefault();
+												const trimmed =
+													headerTagInput.trim();
+												if (
+													trimmed &&
+													!headerTags.includes(
+														trimmed,
+													)
+												) {
+													setHeaderTags((prev) => [
+														...prev,
+														trimmed,
+													]);
+												}
+												setHeaderTagInput("");
+											}
+										}}
+										onBlur={() => {
+											const trimmed =
+												headerTagInput.trim();
+											if (
+												trimmed &&
+												!headerTags.includes(trimmed)
+											) {
+												setHeaderTags((prev) => [
+													...prev,
+													trimmed,
+												]);
+											}
+											setHeaderTagInput("");
+										}}
+									/>
+								</div>
+								<div className="flex gap-2">
+									<Button
+										variant="outline"
+										size="sm"
+										onClick={() =>
+											setIsEditingHeader(false)
+										}
+										disabled={isSavingHeader}
+									>
+										Cancel
+									</Button>
+									<Button
+										size="sm"
+										onClick={handleSaveHeader}
+										disabled={isSavingHeader}
+									>
+										{isSavingHeader ? (
+											<Spinner className="size-3" />
+										) : (
+											"Save"
+										)}
+									</Button>
+								</div>
+							</div>
+						) : (
+							<div className="flex flex-col gap-1">
+								<div className="flex items-center gap-2">
+									<span
+										className={
+											getWorkspace.data?.description
+												? "text-muted-foreground text-sm"
+												: "text-muted-foreground/50 text-sm italic"
+										}
+									>
+										{getWorkspace.data?.description ||
+											(headerTags.filter(
+												(t) =>
+													t !== "Workspace_Project",
+											).length === 0
+												? "Add description or tags..."
+												: "")}
+									</span>
+									<Button
+										variant="ghost"
+										size="icon-sm"
+										onClick={() => setIsEditingHeader(true)}
+										className="h-4 w-4 shrink-0 opacity-60"
+									>
+										<Pencil className="h-2.5 w-2.5" />
+									</Button>
+								</div>
+								{headerTags.filter(
+									(t) => t !== "Workspace_Project",
+								).length > 0 && (
+									<div className="flex flex-wrap gap-1">
+										{headerTags
+											.filter(
+												(t) =>
+													t !== "Workspace_Project",
+											)
+											.map((tag) => (
+												<Badge
+													key={tag}
+													variant="secondary"
+													className="text-xs"
+												>
+													{tag}
+												</Badge>
+											))}
+									</div>
+								)}
+							</div>
+						)}
+					</div>
+					<Button
+						variant="outline"
+						onClick={() => setDeleteModal(true)}
+						title={t("workspace:actions.delete")}
+					>
+						<Trash2 className="h-4 w-4" />
+					</Button>
 				</div>
 
 				<Tabs
@@ -220,6 +483,10 @@ export const WorkspaceDetailPage = observer(() => {
 								<HammerIcon />
 								{t("workspace:detail.tabs.toolbox")}
 							</TabsTrigger>
+							<TabsTrigger value="systemPrompt">
+								<FileTextIcon />
+								System Prompt
+							</TabsTrigger>
 							<TabsTrigger value="members">
 								<UsersRound />
 								{t("workspace:detail.tabs.members")}
@@ -237,17 +504,80 @@ export const WorkspaceDetailPage = observer(() => {
 					</div>
 					<div className="flex min-h-0 w-full flex-1 flex-col items-start overflow-hidden rounded-xl border border-border bg-card">
 						<div className="flex w-full flex-row gap-2 border-border border-b bg-primary-foreground p-4">
-							<InputGroup className="bg-background">
-								<InputGroupInput
-									placeholder={t("common:buttons.search")}
-									value={search}
-									onChange={(e) => setSearch(e.target.value)}
-								/>
-								<InputGroupAddon>
-									<SearchIcon />
-								</InputGroupAddon>
-							</InputGroup>
-							{/* Tab-specific actions go here */}
+							{tab !== "systemPrompt" && (
+								<InputGroup className="bg-background">
+									<InputGroupInput
+										placeholder={t("common:buttons.search")}
+										value={search}
+										onChange={(e) =>
+											setSearch(e.target.value)
+										}
+									/>
+									<InputGroupAddon>
+										<SearchIcon />
+									</InputGroupAddon>
+								</InputGroup>
+							)}
+							{/* Tab-specific actions */}
+							{tab === "knowledge" && (
+								<Button
+									variant="outline"
+									onClick={() => openAddMCP("KNOWLEDGE")}
+								>
+									<PlusIcon />
+									Add Knowledge
+								</Button>
+							)}
+							{tab === "toolbox" && (
+								<Button
+									variant="outline"
+									onClick={() => openAddMCP("TOOLBOX")}
+								>
+									<PlusIcon />
+									Add Toolbox
+								</Button>
+							)}
+							{tab === "systemPrompt" &&
+								!isEditingSystemPrompt && (
+									<Button
+										variant="outline"
+										onClick={() => {
+											setSystemPromptDraft(
+												getWorkspace.data?.system_prompt?.replace(
+													/\\+n/g,
+													"\n",
+												) || "",
+											);
+											setIsEditingSystemPrompt(true);
+										}}
+									>
+										Edit System Prompt
+									</Button>
+								)}
+							{tab === "systemPrompt" &&
+								isEditingSystemPrompt && (
+									<>
+										<Button
+											variant="outline"
+											onClick={() =>
+												setIsEditingSystemPrompt(false)
+											}
+											disabled={isSavingSystemPrompt}
+										>
+											{t("common:buttons.cancel")}
+										</Button>
+										<Button
+											onClick={handleSaveSystemPrompt}
+											disabled={isSavingSystemPrompt}
+										>
+											{isSavingSystemPrompt ? (
+												<Spinner className="size-4" />
+											) : (
+												t("common:buttons.save")
+											)}
+										</Button>
+									</>
+								)}
 							{tab === "members" ? (
 								<Button
 									variant="outline"
@@ -276,6 +606,7 @@ export const WorkspaceDetailPage = observer(() => {
 						>
 							{tab === "knowledge" && (
 								<WorkspaceMCPList
+									key={`${workspaceId}-knowledge-${mcpVersion}`}
 									type="KNOWLEDGE"
 									workspaceId={workspaceId}
 									search={debouncedSearch}
@@ -288,10 +619,49 @@ export const WorkspaceDetailPage = observer(() => {
 						>
 							{tab === "toolbox" && (
 								<WorkspaceMCPList
+									key={`${workspaceId}-toolbox-${mcpVersion}`}
 									type="TOOLBOX"
 									workspaceId={workspaceId}
 									search={debouncedSearch}
 								/>
+							)}
+						</TabsContent>
+						<TabsContent
+							value="systemPrompt"
+							className="w-full overflow-hidden"
+						>
+							{tab === "systemPrompt" && (
+								<div className="flex h-full w-full flex-col p-6">
+									{isEditingSystemPrompt ? (
+										<Textarea
+											value={systemPromptDraft}
+											onChange={(e) =>
+												setSystemPromptDraft(
+													e.target.value,
+												)
+											}
+											rows={16}
+											className="resize-y text-sm"
+											placeholder="Describe the agent's role, behavior, and any constraints..."
+											autoFocus
+										/>
+									) : getWorkspace.data?.system_prompt ? (
+										<div className="rounded-lg border border-border bg-muted/30 p-4">
+											<p className="whitespace-pre-wrap text-sm leading-relaxed">
+												{getWorkspace.data.system_prompt.replace(
+													/\\+n/g,
+													"\n",
+												)}
+											</p>
+										</div>
+									) : (
+										<p className="text-muted-foreground text-sm italic">
+											No system prompt configured. Click
+											&ldquo;Edit System Prompt&rdquo;
+											above to add one.
+										</p>
+									)}
+								</div>
 							)}
 						</TabsContent>
 						<TabsContent
@@ -319,6 +689,8 @@ export const WorkspaceDetailPage = observer(() => {
 					</div>
 				</Tabs>
 			</div>
+
+			{/* Delete confirmation dialog */}
 			<Dialog open={deleteModal} onOpenChange={setDeleteModal}>
 				<DialogContent>
 					<DialogHeader>
@@ -347,12 +719,9 @@ export const WorkspaceDetailPage = observer(() => {
 							data-testid={`workspace-detail-page--confirm-delete-btn`}
 							onClick={async (e) => {
 								e.stopPropagation();
-
 								setIsLoading(true);
 								try {
 									await chat.deleteWorkspace(workspaceId);
-
-									// go to the workspace
 									navigate("/agent");
 								} catch (e) {
 									toast.error(
@@ -368,6 +737,52 @@ export const WorkspaceDetailPage = observer(() => {
 							}}
 						>
 							{t("workspace:actions.delete")}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Add Knowledge / Toolbox dialog */}
+			<Dialog
+				open={addMCPOpen}
+				onOpenChange={(open) => {
+					if (!open) setAddMCPOpen(false);
+				}}
+			>
+				<DialogContent className="max-w-2xl">
+					<DialogHeader>
+						<DialogTitle>
+							{addMCPType === "KNOWLEDGE"
+								? "Add Knowledge"
+								: "Add Toolbox"}
+						</DialogTitle>
+						<DialogDescription>
+							{addMCPType === "KNOWLEDGE"
+								? "Select knowledge sources to attach to this agent."
+								: "Select toolbox items to attach to this agent."}
+						</DialogDescription>
+					</DialogHeader>
+					<MCPSelector
+						type={addMCPType}
+						values={pendingMCPs}
+						onChange={setPendingMCPs}
+					/>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setAddMCPOpen(false)}
+						>
+							{t("common:buttons.cancel")}
+						</Button>
+						<Button
+							onClick={handleSaveMCPs}
+							disabled={isSavingMCPs}
+						>
+							{isSavingMCPs ? (
+								<Spinner className="size-4" />
+							) : (
+								t("common:buttons.save")
+							)}
 						</Button>
 					</DialogFooter>
 				</DialogContent>

--- a/packages/playground/src/pages/workspace-page.tsx
+++ b/packages/playground/src/pages/workspace-page.tsx
@@ -54,19 +54,7 @@ import {
 import workspaceImage from "@/assets/img/workspace.png";
 import { useChat, useGlobalBreadcrumbs, useRoot } from "@/hooks";
 import type { App, Workspace } from "@/types";
-
-const formatDateTime = (dateStr: string): string => {
-	const d = new Date(dateStr.replace(" ", "T"));
-	if (isNaN(d.getTime())) return dateStr;
-	return d.toLocaleString(undefined, {
-		month: "short",
-		day: "numeric",
-		year: "numeric",
-		hour: "numeric",
-		minute: "2-digit",
-		hour12: true,
-	});
-};
+import { formatDateTime } from "@/utility";
 
 /**
  * Renders the WorkspacePage, allowing users to access their workspace or discover new ones

--- a/packages/playground/src/pages/workspace-page.tsx
+++ b/packages/playground/src/pages/workspace-page.tsx
@@ -1,25 +1,72 @@
-import { SearchIcon } from "lucide-react";
-import { observer } from "mobx-react-lite";
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { useTranslation } from "@semoss/i18n";
-import { useIteratorPixel } from "@semoss/sdk/react";
 import {
+	Bookmark,
+	ChevronDown,
+	Ellipsis,
+	SearchIcon,
+	SquarePen,
+} from "lucide-react";
+import { observer } from "mobx-react-lite";
+import { useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useTranslation } from "@semoss/i18n";
+import { Env, post, useInsight, useIteratorPixel } from "@semoss/sdk/react";
+import {
+	Badge,
 	Button,
+	Card,
+	CardContent,
+	Checkbox,
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuGroup,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+	Input,
 	InputGroup,
 	InputGroupAddon,
 	InputGroupInput,
 	Muted,
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
 	ScrollArea,
 	Spinner,
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
 	toast,
 	useDebouncedValue,
 	useInfiniteScroll,
 } from "@semoss/ui/next";
 import workspaceImage from "@/assets/img/workspace.png";
-import { WorkspaceCard } from "@/components";
 import { useChat, useGlobalBreadcrumbs, useRoot } from "@/hooks";
-import type { App } from "@/types";
+import type { App, Workspace } from "@/types";
+
+const formatDateTime = (dateStr: string): string => {
+	const d = new Date(dateStr.replace(" ", "T"));
+	if (isNaN(d.getTime())) return dateStr;
+	return d.toLocaleString(undefined, {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+		hour12: true,
+	});
+};
 
 /**
  * Renders the WorkspacePage, allowing users to access their workspace or discover new ones
@@ -30,6 +77,9 @@ export const WorkspacePage = observer(() => {
 	const { t } = useTranslation(["workspace", "notifications", "common"]);
 	const { root } = useRoot();
 	const navigate = useNavigate();
+	const { chat } = useChat();
+	const { actions } = useInsight();
+
 	// set the breadcrumbs
 	useGlobalBreadcrumbs({
 		breadcrumbs: [
@@ -45,34 +95,37 @@ export const WorkspacePage = observer(() => {
 	});
 
 	const [search, setSearch] = useState("");
+	const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
+	const [sortBy, setSortBy] = useState<"name" | "date">("name");
+	const [tagFilter, setTagFilter] = useState<string[]>([]);
+	const [permissionFilter, setPermissionFilter] = useState<number[]>([]);
+	const [favorites, setFavorites] = useState<Record<string, boolean>>({});
+	const [deleteTarget, setDeleteTarget] = useState<App | null>(null);
+	const [cloneTarget, setCloneTarget] = useState<App | null>(null);
+	const [cloneName, setCloneName] = useState<string>("");
+	const [isCloning, setIsCloning] = useState<boolean>(false);
+
 	const debouncedSearch = useDebouncedValue(search);
-	const { chat } = useChat();
 
 	/**
 	 * Get all of the workspaces with lazy loading
 	 */
 	const getWorkspaces = useIteratorPixel<App[], App>(
 		(limit, offset) =>
-			`MyProjects(${debouncedSearch ? `filterWord=["<encode>${debouncedSearch}</encode>"], ` : ""} type = "WORKSPACE", limit=[${limit}], offset=[${offset}]);`,
+			`MyProjects(metaKeys=["tag","description"], ${debouncedSearch ? `filterWord=["<encode>${debouncedSearch}</encode>"], ` : ""}${showFavoritesOnly ? "onlyFavorites=[true], " : ""}type="WORKSPACE", limit=[${limit}], offset=[${offset}]);`,
 		(response) => {
-			// if its less than the limit, we know its the end
 			if (response.length < 25) {
 				return -1;
 			}
-
 			return Infinity;
 		},
-		(response) => {
-			return response;
-		},
-		{
-			limit: 25,
-		},
-		[debouncedSearch],
+		(response) => response,
+		{ limit: 25 },
+		[debouncedSearch, showFavoritesOnly],
 	);
 
 	/**
-	 * Setup infinite scroll for the command list
+	 * Setup infinite scroll
 	 */
 	const { setScroll } = useInfiniteScroll({
 		disabled: getWorkspaces.isLoading || !getWorkspaces.hasMore,
@@ -81,85 +134,563 @@ export const WorkspacePage = observer(() => {
 		},
 	});
 
+	/**
+	 * Derive unique tag list from all loaded workspaces
+	 */
+	const allTags = useMemo(() => {
+		const tags = new Set<string>();
+		getWorkspaces.data.forEach((w) => {
+			const wTags = Array.isArray(w.tag)
+				? w.tag
+				: w.tag
+					? [w.tag as string]
+					: [];
+			wTags
+				.filter((t) => t !== "Workspace_Project")
+				.forEach((tag) => {
+					if (tag) tags.add(String(tag));
+				});
+		});
+		return Array.from(tags).sort();
+	}, [getWorkspaces.data]);
+
+	/**
+	 * Client-side tag filter + sort on the already-loaded data
+	 */
+	const filtered = useMemo(() => {
+		return getWorkspaces.data
+			.filter((w) => {
+				if (tagFilter.length === 0 && permissionFilter.length === 0)
+					return true;
+				const wTags = Array.isArray(w.tag)
+					? w.tag
+					: w.tag
+						? [w.tag as string]
+						: [];
+				const tagOk =
+					tagFilter.length === 0 ||
+					tagFilter.some((t) => wTags.map(String).includes(t));
+				const permOk =
+					permissionFilter.length === 0 ||
+					permissionFilter.includes(w.permission ?? -1);
+				return tagOk && permOk;
+			})
+			.sort((a, b) => {
+				if (sortBy === "name") {
+					return a.project_name.localeCompare(b.project_name);
+				}
+				return b.project_date_created.localeCompare(
+					a.project_date_created,
+				);
+			});
+	}, [getWorkspaces.data, tagFilter, permissionFilter, sortBy]);
+
+	const toggleFavorite = async (e: React.MouseEvent, w: App) => {
+		e.stopPropagation();
+		const current = favorites[w.project_id] ?? Boolean(w.project_favorite);
+		const next = !current;
+		setFavorites((prev) => ({ ...prev, [w.project_id]: next }));
+		try {
+			await post<{ success: boolean }>(
+				`${Env.MODULE}/api/auth/project/setProjectFavorite`,
+				{ projectId: w.project_id, isFavorite: next },
+				{},
+			);
+		} catch {
+			setFavorites((prev) => ({ ...prev, [w.project_id]: current }));
+		}
+	};
+
+	const handleDelete = async () => {
+		if (!deleteTarget) return;
+		try {
+			await chat.deleteWorkspace(deleteTarget.project_id);
+			setDeleteTarget(null);
+			getWorkspaces.reset();
+		} catch (e) {
+			toast.error(
+				e instanceof Error
+					? e.message
+					: t("notifications:workspace.deleteError"),
+			);
+		}
+	};
+
+	const handleClone = async () => {
+		if (!cloneTarget || !cloneName.trim()) return;
+		setIsCloning(true);
+		try {
+			const wsResult = await actions.run<[Workspace]>(
+				`GetWorkspace(workspaceId=["${cloneTarget.project_id}"]);`,
+			);
+			const source = wsResult.pixelReturn[0].output;
+			const newId = await chat.addWorkspace({
+				name: cloneName.trim(),
+				description: source.description || "",
+				system_prompt: source.system_prompt || "",
+				mcp: source.mcp || [],
+			});
+			try {
+				const metaResult = await actions.run<
+					[{ tag?: string | string[] }]
+				>(
+					`GetProjectMetadata(project=["${cloneTarget.project_id}"], metaKeys=["tag"]);`,
+				);
+				const rawTag = metaResult.pixelReturn[0].output?.tag;
+				const tags = Array.isArray(rawTag)
+					? rawTag
+					: rawTag
+						? [rawTag as string]
+						: [];
+				if (tags.length > 0) {
+					await actions.run(
+						`SetProjectMetadata(project=["${newId}"], meta=[{"tag":${JSON.stringify(tags)}}], jsonCleanup=[true]);`,
+					);
+				}
+			} catch {
+				// non-fatal: tags did not copy
+			}
+			toast.success(`"${cloneName.trim()}" created`);
+			setCloneTarget(null);
+			setCloneName("");
+			navigate(`/agent/${newId}`);
+		} catch (e) {
+			toast.error(
+				e instanceof Error ? e.message : "Failed to clone agent",
+			);
+		} finally {
+			setIsCloning(false);
+		}
+	};
+
 	return (
-		<div className="relative h-full w-full overflow-hidden">
-			<div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-12 px-12 pt-8 pb-4">
-				<div className="flex w-full rounded-lg bg-primary/10">
-					<div className="flex flex-1 flex-col gap-4 p-6 font-sans">
-						<div className="font-medium text-primary text-xl leading-normal">
-							{t("workspace:welcomeTitle")}
+		<TooltipProvider>
+			<div className="relative h-full w-full overflow-hidden">
+				<div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-6 px-12 pt-8 pb-4">
+					{/* Welcome banner */}
+					<div className="flex w-full rounded-lg bg-primary/10">
+						<div className="flex flex-1 flex-col gap-4 p-6 font-sans">
+							<div className="font-medium text-primary text-xl leading-normal">
+								{t("workspace:welcomeTitle")}
+							</div>
+							<div className="font-normal text-base text-primary leading-normal">
+								{t("workspace:welcomeDescription")}
+							</div>
 						</div>
-						<div className="font-normal text-base text-primary leading-normal">
-							{t("workspace:welcomeDescription")}
+						<div className="relative hidden w-[351px] overflow-hidden rounded-r-lg lg:block">
+							<img
+								src={
+									root.theme.images.workspace ||
+									workspaceImage
+								}
+								alt={t("workspace:images.agentIllustration")}
+								className="-translate-y-1/2 absolute top-1/2 left-0 h-[351px] w-full select-none object-cover"
+							/>
 						</div>
+					</div>
+
+					{/* Toolbar */}
+					<div className="flex flex-wrap items-center gap-2">
+						<InputGroup className="min-w-[220px] flex-1 bg-background">
+							<InputGroupInput
+								placeholder={t("common:buttons.search")}
+								value={search}
+								onChange={(e) => setSearch(e.target.value)}
+							/>
+							<InputGroupAddon>
+								<SearchIcon />
+							</InputGroupAddon>
+						</InputGroup>
+
+						{/* Tags filter */}
+						<Popover>
+							<PopoverTrigger asChild>
+								<Button variant="outline" size="sm">
+									{tagFilter.length === 0
+										? "Tags"
+										: `Tags (${tagFilter.length})`}
+									<ChevronDown className="ml-1 h-4 w-4" />
+								</Button>
+							</PopoverTrigger>
+							<PopoverContent className="w-56 p-0" align="start">
+								<Command>
+									<CommandInput placeholder="Search tags…" />
+									<CommandList className="max-h-[50vh]">
+										<CommandEmpty>
+											No tags found.
+										</CommandEmpty>
+										<CommandGroup>
+											{allTags.map((tag) => (
+												<CommandItem
+													key={tag}
+													onSelect={() =>
+														setTagFilter((prev) =>
+															prev.includes(tag)
+																? prev.filter(
+																		(t) =>
+																			t !==
+																			tag,
+																	)
+																: [
+																		...prev,
+																		tag,
+																	],
+														)
+													}
+												>
+													<Checkbox
+														checked={tagFilter.includes(
+															tag,
+														)}
+														className="mr-2"
+													/>
+													{tag}
+												</CommandItem>
+											))}
+										</CommandGroup>
+									</CommandList>
+								</Command>
+							</PopoverContent>
+						</Popover>
+
+						{/* Permission filter */}
+						<Popover>
+							<PopoverTrigger asChild>
+								<Button variant="outline" size="sm">
+									{permissionFilter.length === 0
+										? "Role"
+										: `Role (${permissionFilter.length})`}
+									<ChevronDown className="ml-1 h-4 w-4" />
+								</Button>
+							</PopoverTrigger>
+							<PopoverContent className="w-44 p-1" align="start">
+								{(
+									[
+										{ label: "Author", value: 1 },
+										{ label: "Editor", value: 2 },
+										{ label: "Read Only", value: 3 },
+									] as { label: string; value: number }[]
+								).map(({ label, value }) => (
+									<button
+										key={value}
+										type="button"
+										className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-muted"
+										onClick={() =>
+											setPermissionFilter((prev) =>
+												prev.includes(value)
+													? prev.filter(
+															(p) => p !== value,
+														)
+													: [...prev, value],
+											)
+										}
+									>
+										<Checkbox
+											checked={permissionFilter.includes(
+												value,
+											)}
+											className="pointer-events-none"
+										/>
+										{label}
+									</button>
+								))}
+							</PopoverContent>
+						</Popover>
+
+						{/* Favorites toggle */}
 						<Button
-							onClick={() => navigate("/agent/new")}
-							className="w-auto"
+							variant={
+								showFavoritesOnly ? "secondary" : "outline"
+							}
+							size="sm"
+							onClick={() => setShowFavoritesOnly((v) => !v)}
 						>
+							<Bookmark
+								className={
+									showFavoritesOnly
+										? "h-4 w-4 fill-current"
+										: "h-4 w-4"
+								}
+							/>
+							Favorites
+						</Button>
+
+						{/* Sort */}
+						<Popover>
+							<PopoverTrigger asChild>
+								<Button variant="outline" size="sm">
+									{sortBy === "name"
+										? "Sort: Name"
+										: "Sort: Date"}
+									<ChevronDown className="ml-1 h-4 w-4" />
+								</Button>
+							</PopoverTrigger>
+							<PopoverContent className="w-44 p-1" align="start">
+								<Button
+									variant={
+										sortBy === "name"
+											? "secondary"
+											: "ghost"
+									}
+									size="sm"
+									className="w-full justify-start"
+									onClick={() => setSortBy("name")}
+								>
+									Name (A-Z)
+								</Button>
+								<Button
+									variant={
+										sortBy === "date"
+											? "secondary"
+											: "ghost"
+									}
+									size="sm"
+									className="w-full justify-start"
+									onClick={() => setSortBy("date")}
+								>
+									Date (newest)
+								</Button>
+							</PopoverContent>
+						</Popover>
+
+						<Button onClick={() => navigate("/agent/new")}>
 							{t("workspace:actions.createAgent")}
 						</Button>
 					</div>
-					{/* Image appears only on large screens and above */}
-					<div className="relative hidden w-[351px] overflow-hidden rounded-r-lg lg:block">
-						<img
-							src={root.theme.images.workspace || workspaceImage}
-							alt={t("workspace:images.agentIllustration")}
-							className="-translate-y-1/2 absolute top-1/2 left-0 h-[351px] w-full select-none object-cover"
-						/>
-					</div>
-				</div>
 
-				<div className="flex flex-col gap-4 overflow-auto">
-					<InputGroup className="bg-background">
-						<InputGroupInput
-							placeholder={t("common:buttons.search")}
-							value={search}
-							onChange={(e) => setSearch(e.target.value)}
-						/>
-						<InputGroupAddon>
-							<SearchIcon />
-						</InputGroupAddon>
-					</InputGroup>
-
+					{/* Agent list */}
 					<ScrollArea
 						className="flex-1 overflow-auto"
 						viewportRef={(ele) => setScroll(ele)}
 					>
-						{getWorkspaces.data.length === 0 ? (
+						{getWorkspaces.isLoading &&
+						getWorkspaces.data.length === 0 ? (
+							<div className="flex items-center justify-center py-12">
+								<Spinner />
+							</div>
+						) : filtered.length === 0 ? (
 							<div className="flex items-center justify-center py-12">
 								<Muted>
 									{t("workspace:messages.noResults")}
 								</Muted>
 							</div>
 						) : (
-							<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:gap-x-8">
-								{getWorkspaces.data.map((w) => (
-									<WorkspaceCard
-										key={w.project_id}
-										workspace={{
-											workspace_id: w.project_id,
-											name: w.project_name,
-											description: w.description,
-										}}
-										onDeleteClick={async () => {
-											try {
-												await chat.deleteWorkspace(
-													w.project_id,
-												);
-
-												getWorkspaces.reset();
-											} catch (e) {
-												toast.error(
-													e instanceof Error
-														? e.message
-														: t(
-																"notifications:workspace.deleteError",
-															),
-												);
+							<div className="flex max-w-3xl flex-col gap-2">
+								{filtered.map((w) => {
+									const isFav =
+										favorites[w.project_id] ??
+										Boolean(w.project_favorite);
+									const wTags = Array.isArray(w.tag)
+										? w.tag
+										: w.tag
+											? [w.tag as string]
+											: [];
+									return (
+										<button
+											type="button"
+											key={w.project_id}
+											className="w-full text-left"
+											onClick={() =>
+												navigate(
+													`/agent/${w.project_id}`,
+												)
 											}
-										}}
-									/>
-								))}
+										>
+											<Card className="group transition hover:bg-muted/40">
+												<CardContent className="flex items-center gap-4 py-3">
+													<div className="min-w-0 flex-1">
+														<Tooltip>
+															<TooltipTrigger
+																asChild
+															>
+																<p className="min-w-0 truncate font-medium text-sm">
+																	{
+																		w.project_name
+																	}
+																</p>
+															</TooltipTrigger>
+															<TooltipContent>
+																{w.project_name}
+															</TooltipContent>
+														</Tooltip>
+														{wTags.filter(
+															(t) =>
+																t !==
+																"Workspace_Project",
+														).length > 0 && (
+															<div className="mt-0.5 flex flex-wrap gap-1">
+																{wTags
+																	.filter(
+																		(t) =>
+																			t !==
+																			"Workspace_Project",
+																	)
+																	.map(
+																		(
+																			tag,
+																		) => (
+																			<Badge
+																				key={
+																					tag
+																				}
+																				variant="secondary"
+																				className="text-xs"
+																			>
+																				{
+																					tag
+																				}
+																			</Badge>
+																		),
+																	)}
+															</div>
+														)}
+														{w.description && (
+															<p className="truncate text-muted-foreground text-xs">
+																{w.description}
+															</p>
+														)}
+													</div>
+													{w.project_date_created && (
+														<p className="w-44 shrink-0 text-right text-muted-foreground text-xs tabular-nums">
+															{formatDateTime(
+																w.project_date_created,
+															)}
+														</p>
+													)}
+													{w.permission != null && (
+														<span
+															className={`shrink-0 rounded-full px-2 py-0.5 font-medium text-xs ${
+																w.permission ===
+																1
+																	? "bg-green-100 text-green-800"
+																	: w.permission ===
+																			2
+																		? "bg-blue-100 text-blue-800"
+																		: "bg-gray-100 text-gray-600"
+															}`}
+														>
+															{w.permission === 1
+																? "Author"
+																: w.permission ===
+																		2
+																	? "Editor"
+																	: "Read Only"}
+														</span>
+													)}
+													<div className="flex shrink-0 items-center gap-1">
+														<Tooltip>
+															<TooltipTrigger
+																asChild
+															>
+																<Button
+																	variant="ghost"
+																	size="icon-sm"
+																	onClick={(
+																		e,
+																	) =>
+																		toggleFavorite(
+																			e,
+																			w,
+																		)
+																	}
+																	aria-label="Toggle favorite"
+																>
+																	<Bookmark
+																		className={`h-4 w-4 ${isFav ? "fill-current text-primary" : "text-muted-foreground"}`}
+																	/>
+																</Button>
+															</TooltipTrigger>
+															<TooltipContent>
+																Favorite
+															</TooltipContent>
+														</Tooltip>
+														<Button
+															size="sm"
+															variant="outline"
+															onClick={(e) => {
+																e.stopPropagation();
+																navigate(
+																	`/new?workspaceId=${w.project_id}`,
+																);
+															}}
+														>
+															<SquarePen className="h-4 w-4" />
+															{t(
+																"workspace:actions.newChat",
+															)}
+														</Button>
+														<DropdownMenu>
+															<DropdownMenuTrigger
+																asChild
+															>
+																<Button
+																	variant="ghost"
+																	size="icon-sm"
+																	onClick={(
+																		e,
+																	) =>
+																		e.stopPropagation()
+																	}
+																>
+																	<Ellipsis className="h-4 w-4" />
+																</Button>
+															</DropdownMenuTrigger>
+															<DropdownMenuContent align="end">
+																<DropdownMenuGroup>
+																	<DropdownMenuItem
+																		onClick={(
+																			e,
+																		) =>
+																			e.stopPropagation()
+																		}
+																		asChild
+																	>
+																		<Link
+																			to={`/agent/${w.project_id}`}
+																		>
+																			{t(
+																				"workspace:actions.edit",
+																			)}
+																		</Link>
+																	</DropdownMenuItem>
+																	<DropdownMenuItem
+																		onClick={(
+																			e,
+																		) => {
+																			e.stopPropagation();
+																			setCloneTarget(
+																				w,
+																			);
+																			setCloneName(
+																				`${w.project_name}_copy`,
+																			);
+																		}}
+																	>
+																		Clone
+																	</DropdownMenuItem>
+																	<DropdownMenuItem
+																		onClick={(
+																			e,
+																		) => {
+																			e.stopPropagation();
+																			setDeleteTarget(
+																				w,
+																			);
+																		}}
+																	>
+																		{t(
+																			"workspace:actions.delete",
+																		)}
+																	</DropdownMenuItem>
+																</DropdownMenuGroup>
+															</DropdownMenuContent>
+														</DropdownMenu>
+													</div>
+												</CardContent>
+											</Card>
+										</button>
+									);
+								})}
 							</div>
 						)}
 
@@ -173,6 +704,91 @@ export const WorkspacePage = observer(() => {
 					</ScrollArea>
 				</div>
 			</div>
-		</div>
+
+			{/* Delete confirmation dialog */}
+			<Dialog
+				open={deleteTarget !== null}
+				onOpenChange={(open) => {
+					if (!open) setDeleteTarget(null);
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>
+							{t("workspace:card.deleteConfirmTitle")}
+						</DialogTitle>
+						<DialogDescription>
+							{t("workspace:card.deleteConfirmDescription", {
+								name: deleteTarget?.project_name,
+							})}
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setDeleteTarget(null)}
+						>
+							{t("common:buttons.cancel")}
+						</Button>
+						<Button variant="destructive" onClick={handleDelete}>
+							{t("workspace:actions.delete")}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Clone dialog */}
+			<Dialog
+				open={cloneTarget !== null}
+				onOpenChange={(open) => {
+					if (!open) {
+						setCloneTarget(null);
+						setCloneName("");
+					}
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Clone Agent</DialogTitle>
+						<DialogDescription>
+							Create a copy of &ldquo;{cloneTarget?.project_name}
+							&rdquo; with a new name.
+						</DialogDescription>
+					</DialogHeader>
+					<Input
+						value={cloneName}
+						onChange={(e) => setCloneName(e.target.value)}
+						placeholder="New agent name"
+						disabled={isCloning}
+						onKeyDown={(e) => {
+							if (e.key === "Enter" && cloneName.trim())
+								handleClone();
+						}}
+					/>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => {
+								setCloneTarget(null);
+								setCloneName("");
+							}}
+							disabled={isCloning}
+						>
+							{t("common:buttons.cancel")}
+						</Button>
+						<Button
+							onClick={handleClone}
+							disabled={isCloning || !cloneName.trim()}
+						>
+							{isCloning ? (
+								<Spinner className="size-4" />
+							) : (
+								"Clone"
+							)}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</TooltipProvider>
 	);
 });

--- a/packages/playground/src/types.d.ts
+++ b/packages/playground/src/types.d.ts
@@ -11,6 +11,9 @@ export interface App {
 	description?: string;
 	project_date_created: string;
 	project_type: string;
+	project_favorite?: string;
+	permission?: number;
+	tag?: string | string[];
 }
 
 export interface Workspace {
@@ -20,6 +23,7 @@ export interface Workspace {
 	description: string;
 	system_prompt: string;
 	mcp: MCPConfig[];
+	tag?: string[];
 }
 
 /**

--- a/packages/playground/src/utility/utils.ts
+++ b/packages/playground/src/utility/utils.ts
@@ -50,3 +50,23 @@ export const toInitials = (str: string | undefined) => {
 		words[0].charAt(0) + words[words.length - 1].charAt(0)
 	).toUpperCase();
 };
+
+/**
+ * Formats a UTC datetime string (from the API) into a human-readable local time.
+ * The API returns timestamps as "YYYY-MM-DD HH:MM:SS" with no timezone suffix,
+ * so we append "Z" to treat them as UTC before converting to local time.
+ *
+ * @param dateStr - UTC datetime string from the API
+ * @returns Formatted local datetime string, or the original string if parsing fails
+ */
+export const formatDateTime = (dateStr: string): string => {
+	const d = new Date(`${dateStr.replace(" ", "T")}Z`);
+	if (Number.isNaN(d.getTime())) return dateStr;
+	return d.toLocaleString(undefined, {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+	});
+};

--- a/packages/playground/src/utility/utils.tsx
+++ b/packages/playground/src/utility/utils.tsx
@@ -1,0 +1,134 @@
+import {
+	FileIcon,
+	FileImageIcon,
+	FileSpreadsheetIcon,
+	FileTextIcon,
+} from "lucide-react";
+
+/**
+ * Converts a snake_case or space-separated string to Title Case
+ *
+ * @param str - The string to capitalize
+ * @returns The capitalized string, or undefined if input is undefined
+ */
+export const capitalizeWords = (str: string | undefined) => {
+	if (!str) return undefined;
+	return str
+		.toLowerCase() // Normalize to lowercase first
+		.split(/[_\s]+/) // Split by underscores or spaces
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(" "); // Join with spaces for better readability
+};
+
+/**
+ * Converts a snake_case or space-separated string to Sentence case
+ *
+ * @param str - The string to convert
+ * @returns The sentence case string, or undefined if input is undefined
+ */
+export const toSentenceCase = (str: string | undefined) => {
+	if (!str) return undefined;
+	const normalized = str.replace(/[_\s]+/g, " ").toLowerCase();
+	return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+};
+
+/**
+ * Extracts the first and last initials from a name string
+ *
+ * Splits the name by whitespace and takes the first letter of the first word
+ * and the first letter of the last word. Apostrophes and hyphens are treated
+ * as part of the word.
+ *
+ * @param str - The name string to extract initials from
+ * @returns The initials in uppercase (1-2 characters), or undefined if input is undefined
+ *
+ * @example
+ * toInitials("John Doe") // "JD"
+ * toInitials("Jane Mary Smith") // "JS" (first and last only)
+ * toInitials("Bob") // "B" (single name)
+ */
+export const toInitials = (str: string | undefined) => {
+	if (!str) return undefined;
+	const words = str.trim().split(/\s+/);
+	if (words.length === 1) {
+		return words[0].charAt(0).toUpperCase();
+	}
+	return (
+		words[0].charAt(0) + words[words.length - 1].charAt(0)
+	).toUpperCase();
+};
+
+/**
+ * Parses a file size string with optional unit suffix (B, KB, MB, GB) into bytes.
+ * Returns 0 if the input cannot be parsed.
+ *
+ * @param fileSize - A number or string like "1.5 MB", "512 KB", "2048"
+ * @returns The size in bytes
+ */
+export const parseSizeBytes = (fileSize: string | number): number => {
+	const s = String(fileSize ?? "");
+	const match = s.match(/^([\d.]+)\s*(KB|MB|GB|B)?$/i);
+	if (!match) return 0;
+	const num = parseFloat(match[1]);
+	const unit = (match[2] ?? "B").toUpperCase();
+	if (unit === "GB") return num * 1024 * 1024 * 1024;
+	if (unit === "MB") return num * 1024 * 1024;
+	if (unit === "KB") return num * 1024;
+	return num;
+};
+
+/**
+ * Formats a file size value (with optional unit suffix) into a human-readable string.
+ * Input may be a raw byte count or a string like "1.5 MB", "512 KB".
+ * Output is in KB (no decimal) or MB (1 decimal).
+ *
+ * @param fileSize - A number or string representing a file size
+ * @returns A formatted string like "512 KB" or "1.5 MB"
+ */
+export const formatFileSize = (fileSize: string | number): string => {
+	const bytes = parseSizeBytes(fileSize);
+	if (bytes === 0) return String(fileSize);
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+/**
+ * Formats a UTC datetime string (from the API) into a human-readable local time.
+ * The API returns timestamps as "YYYY-MM-DD HH:MM:SS" with no timezone suffix,
+ * so we append "Z" to treat them as UTC before converting to local time.
+ *
+ * @param dateStr - UTC datetime string from the API
+ * @returns Formatted local datetime string, or the original string if parsing fails
+ */
+export const formatDateTime = (dateStr: string): string => {
+	const d = new Date(`${dateStr.replace(" ", "T")}Z`);
+	if (Number.isNaN(d.getTime())) return dateStr;
+	return d.toLocaleString(undefined, {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+	});
+};
+
+/**
+ * Returns a sized, colored Lucide icon element for a given file name based on its extension.
+ *
+ * @param fileName - The file name (e.g. "report.pdf", "data.xlsx")
+ * @returns A React element representing the file type icon
+ */
+export const getFileIcon = (fileName: string) => {
+	const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
+	if (ext === "pdf")
+		return <FileTextIcon className="h-4 w-4 shrink-0 text-red-500" />;
+	if (ext === "doc" || ext === "docx")
+		return <FileTextIcon className="h-4 w-4 shrink-0 text-blue-500" />;
+	if (ext === "xls" || ext === "xlsx" || ext === "csv")
+		return (
+			<FileSpreadsheetIcon className="h-4 w-4 shrink-0 text-green-600" />
+		);
+	if (["png", "jpg", "jpeg", "gif", "webp", "svg"].includes(ext))
+		return <FileImageIcon className="h-4 w-4 shrink-0 text-purple-500" />;
+	return <FileIcon className="h-4 w-4 shrink-0 text-muted-foreground" />;
+};


### PR DESCRIPTION
## Description
In-progress PR of updated layout on main agent page, agent detail page, and new agent page

New features:
- Clone an agent, favorite an agent
- Avoid need to scroll when creating agent
- Make agent browsing easier with favorites, sorting, metadata, tags
- Add detail to knowledge and MCP selectors to make it easier to find resources
- Make instructions easier to view and edit, treating as key component like MCPs and knowledge

## Ongoing screenshots
**Create agent page**
<img width="1015" height="853" alt="image" src="https://github.com/user-attachments/assets/567c65f2-9499-4d65-bd94-0ac118195b24" />

**Agent listing page**
<img width="1313" height="789" alt="image" src="https://github.com/user-attachments/assets/c081bca8-7b0a-4561-ac04-cb63a33254cf" />

**Agent detail page**
<img width="1307" height="556" alt="image" src="https://github.com/user-attachments/assets/119f19b2-7e03-42f6-8c7d-d8f84065097a" />

## Related PRs (unmerged)
https://github.com/SEMOSS/semoss-ui/pull/2771: Feature tools rather than apps on agent dependencies
https://github.com/SEMOSS/semoss-ui/pull/2806: Share agent dependencies

