### PR TITLE
Allow custom sidebar to navigate to internal route (Playground)

### DIFF
--- a/packages/playground/src/components/common/global-nav-item.tsx
+++ b/packages/playground/src/components/common/global-nav-item.tsx
@@ -53,6 +53,30 @@ export const GlobalNavItem: React.FC<GlobalNavItemProps> = ({
 		);
 	}
 
+	// Hash routes (e.g. "#/knowledge") navigate within the app via React Router
+	if (url?.startsWith("#/")) {
+		const internalPath = url.slice(1); // "#/knowledge" → "/knowledge"
+		return (
+			<SidebarMenuItem>
+				<SidebarMenuButton
+					asChild
+					isActive={!!matchPath(internalPath, pathname)}
+				>
+					<Link to={internalPath} aria-label={name}>
+						{icon ? (
+							<img
+								className="size-4 select-none"
+								src={icon}
+								alt={name}
+							/>
+						) : null}
+						{name}
+					</Link>
+				</SidebarMenuButton>
+			</SidebarMenuItem>
+		);
+	}
+
 	return (
 		<SidebarMenuItem>
 			<SidebarMenuButton asChild>


### PR DESCRIPTION
## Description
This PR allows internal routes to be set within a custom sidebar theme. Previously, only external routes (e.g., other apps) functioned correctly. Internal routes either loaded in a new tab (embed = false) or loaded the full page, duplicating content. 

This is important if the main playground app does not have that route enabled in the location you want it. 

Example theme:

```
"sidebar": {
      "headerItems": [{
          "path": "f12d0a5c-ad70-4f20-812b-333a4fbcc763",
          "name": "Knowledge",
          "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaH...",
          "url": "#/knowledge"
        }]
}
```

## Changes Made
Update to `packages/playground/src/components/common/global-nav-item.tsx`

## How to Test
Set custom navigation in theme database (example shown above). Check that internal route (e.g., `#/knowledge` or `#/agent`) loads and navigates seamlessly from the sidebar.
<img width="1132" height="724" alt="image" src="https://github.com/user-attachments/assets/6087323f-1c24-48eb-8b6a-18635d79bb34" />

