### PR TITLE
Remove theme.local.json so that it will be gitignored

### DIFF
--- a/packages/playground/theme.local.json
+++ b/packages/playground/theme.local.json
@@ -1,5 +1,0 @@
-{
-	"enableKnowledgeMCP": false,
-	"allowEmbeddingOptions": false,
-	"showPlatformLinks": false
-}


### PR DESCRIPTION
## Description
theme.local.json had been committed before it was added to the gitignore, so changes made to it were affecting all users


## Changes Made
Delete it - files in the gitignore can not be part of the repo. Now, anyone who makes theme.local.json will not have it be tracked

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->