### PR TITLE
feat(playground): add key for alternate landing page title

### DIFF
--- a/libs/shared/src/types.ts
+++ b/libs/shared/src/types.ts
@@ -57,6 +57,16 @@ export interface ThemeMap {
 		landing: string;
 
 		/**
+		 * Alternate HTML content to show on the landing page
+		 */
+		altLanding?: string;
+
+		/**
+		 * URL search param key that triggers altLanding (e.g. "appt" matches ?appt in the URL)
+		 */
+		altLandingKey?: string;
+
+		/**
 		 * Content to show in the sidebar
 		 */
 		sidebar: {

--- a/packages/playground/src/pages/new-room-page.tsx
+++ b/packages/playground/src/pages/new-room-page.tsx
@@ -308,7 +308,14 @@ export const NewRoomPage = observer(() => {
 								className="mx-auto flex max-w-xl"
 								// biome-ignore lint/security/noDangerouslySetInnerHtml: read from theme db we control
 								dangerouslySetInnerHTML={{
-									__html: root.theme.landing,
+									__html:
+										root.theme?.altLandingKey &&
+										searchParams.has(
+											root.theme.altLandingKey,
+										) &&
+										root.theme.altLanding
+											? root.theme.altLanding
+											: root.theme.landing,
 								}}
 							/>
 						) : (

--- a/packages/playground/src/stores/root/root.store.ts
+++ b/packages/playground/src/stores/root/root.store.ts
@@ -64,6 +64,8 @@ export class RootStore {
 			},
 			footer: "",
 			landing: "",
+			altLandingKey: "",
+			altLanding: "",
 			sidebar: {
 				//workspaceAlias: "Workspace",
 				headerItems: [],
@@ -202,6 +204,9 @@ export class RootStore {
 			},
 			footer: theme?.footer || this._store.theme.footer,
 			landing: theme?.landing || this._store.theme.landing,
+			altLandingKey:
+				theme?.altLandingKey || this._store.theme.altLandingKey,
+			altLanding: theme?.altLanding || this._store.theme.altLanding,
 			sidebar: {
 				...this._store.theme.sidebar,
 				...(theme?.sidebar || {}),


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Adds new theme key for alternate landing page title

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. update admin theme with new keys
2. go to playground and add altLandingKey into the url
3. see alternate title

## Notes
<!-- Any further notes regarding changes -->