### PR TITLE
Code Block Copy Button- 723

### DIFF
--- a/packages/playground/src/components/message/response-message-text.tsx
+++ b/packages/playground/src/components/message/response-message-text.tsx
@@ -149,7 +149,7 @@ const createMarkdownComponents = (room?: RoomStore) => ({
 				<Tooltip>
 					<TooltipTrigger asChild>
 						<Button
-							className="absolute top-0 right-0 bg-background opacity-0 transition-opacity group-hover/response-markdown:opacity-100"
+							className="sticky top-0 right-0 float-right -ml-[120px] bg-background z-10 opacity-0 transition-opacity group-hover/response-markdown:opacity-100"
 							variant="ghost"
 							size="icon"
 							disabled={!code}


### PR DESCRIPTION
## Description
Updated the copy button that displays in a code block to stick to the top right (inside of its code block) while user scrolls, making it easier to copy the code instead of user having to scroll all the way to the top of the code block to see/hit the copy button.

## Changes Made
Made the copy button sticky and float on the top right of a code block

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Prompt to receive code back ("Give me template html/python code")
2. Hover over the code returned and view copy button on the top right
3. User can scroll down (if there's a lot of code returned) and still be able to see/hit the copy button on the top right

## Notes
<!-- Any further notes regarding changes -->