### PR TITLE
test(renderer): add code cell test remove unused import

### DIFF
--- a/libs/renderer/src/testing/cell-defaults/CodeCell.spec.tsx
+++ b/libs/renderer/src/testing/cell-defaults/CodeCell.spec.tsx
@@ -1,0 +1,130 @@
+import "@testing-library/jest-dom";
+// import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+// import { Blocks } from "../../components/blocks";
+import type {
+	// CodeCell,
+	CodeCellDef,
+} from "../../components/cell-defaults/code-cell/CodeCell";
+import { type CellState, StateStore } from "../../store";
+
+// Mock useBlocksPixel to avoid SDK interactions
+vi.mock("../../hooks/useBlocksPixel", () => ({
+	useBlocksPixel: () => ({
+		status: "INITIAL",
+		data: undefined,
+		refresh: vi.fn(),
+	}),
+}));
+
+const createCodeCellStore = () => {
+	const store = new StateStore({
+		mode: "interactive",
+		insightId: "test-insight",
+		state: {
+			executionOrder: [],
+			queries: {
+				"query-1": {
+					id: "query-1",
+					cells: [
+						{
+							id: "1",
+							widget: "query-import",
+							parameters: {
+								databaseId: "test-db",
+								frameType: "PY",
+								frameVariableName: "sourceFrame",
+								selectQuery: "SELECT * FROM test",
+								enableBatching: false,
+								batchSize: 100,
+								currentOffset: 0,
+							},
+						},
+						{
+							id: "2",
+							widget: "code",
+							parameters: {
+								code: "print('test')",
+								targetCell: {
+									id: "1",
+									frameVariableName: "sourceFrame",
+								},
+								language: "python",
+							},
+						},
+					],
+				},
+			},
+			variables: {},
+			version: "1",
+			blocks: {},
+		},
+		cellRegistry: {
+			"query-import": {
+				name: "Query",
+				widget: "query-import",
+				view: () => null,
+				parameters: {
+					databaseId: "",
+					frameType: "PY",
+					frameVariableName: "",
+					selectQuery: "",
+					enableBatching: false,
+					batchSize: 100,
+					currentOffset: 0,
+				},
+				toPixel: () => "",
+			},
+			code: {
+				name: "Code",
+				widget: "code",
+				view: () => null,
+				parameters: {
+					code: "",
+					targetCell: { id: "", frameVariableName: "" },
+					language: "python",
+				},
+				toPixel: () => "",
+			},
+		},
+	});
+
+	const codeCell = store.queries["query-1"].cells[
+		"2"
+	] as CellState<CodeCellDef>;
+	return { store, codeCell };
+};
+
+describe("CodeCell", () => {
+	// it("should render the CodeCell component", () => {
+	// 	const { store, codeCell } = createCodeCellStore();
+
+	// 	const { container } = render(
+	// 		<Blocks state={store} registry={{} as Registry}>
+	// 			<CodeCell cell={codeCell} isExpanded={true} />
+	// 		</Blocks>,
+	// 	);
+
+	// 	console.log({container})
+
+	// 	expect(container).toBeDefined();
+	// 	expect(codeCell.widget).toBe("code");
+	// });
+
+	it("should have code parameter set correctly", () => {
+		const { codeCell } = createCodeCellStore();
+
+		expect(codeCell.parameters.code).toBe("print('test')");
+		expect(codeCell.parameters.language).toBe("python");
+	});
+
+	it("should have target cell reference configured", () => {
+		const { codeCell } = createCodeCellStore();
+
+		expect(codeCell.parameters.targetCell).toBeDefined();
+		expect(codeCell.parameters.targetCell.id).toBe("1");
+		expect(codeCell.parameters.targetCell.frameVariableName).toBe(
+			"sourceFrame",
+		);
+	});
+});

--- a/libs/renderer/src/testing/cell-defaults/CodeCell.spec.tsx
+++ b/libs/renderer/src/testing/cell-defaults/CodeCell.spec.tsx
@@ -1,12 +1,12 @@
 import "@testing-library/jest-dom";
-// import { render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-// import { Blocks } from "../../components/blocks";
-import type {
-	// CodeCell,
-	CodeCellDef,
+import { Blocks } from "../../components/blocks";
+import {
+	CodeCell,
+	type CodeCellDef,
 } from "../../components/cell-defaults/code-cell/CodeCell";
-import { type CellState, StateStore } from "../../store";
+import { type CellState, type Registry, StateStore } from "../../store";
 
 // Mock useBlocksPixel to avoid SDK interactions
 vi.mock("../../hooks/useBlocksPixel", () => ({
@@ -15,6 +15,22 @@ vi.mock("../../hooks/useBlocksPixel", () => ({
 		data: undefined,
 		refresh: vi.fn(),
 	}),
+}));
+
+// Mock runPixel to avoid network calls
+vi.mock("@semoss/sdk/react", () => ({
+	runPixel: vi.fn(() =>
+		Promise.resolve({
+			pixelReturn: [
+				{
+					output: {
+						response: "mock response",
+						someFunction: "value",
+					},
+				},
+			],
+		}),
+	),
 }));
 
 const createCodeCellStore = () => {
@@ -28,7 +44,7 @@ const createCodeCellStore = () => {
 					id: "query-1",
 					cells: [
 						{
-							id: "1",
+							id: "0",
 							widget: "query-import",
 							parameters: {
 								databaseId: "test-db",
@@ -41,9 +57,10 @@ const createCodeCellStore = () => {
 							},
 						},
 						{
-							id: "2",
+							id: "1",
 							widget: "code",
 							parameters: {
+								type: "py",
 								code: "print('test')",
 								targetCell: {
 									id: "1",
@@ -89,27 +106,24 @@ const createCodeCellStore = () => {
 		},
 	});
 
-	const codeCell = store.queries["query-1"].cells[
-		"2"
-	] as CellState<CodeCellDef>;
+	const codeCell = store.queries["query-1"]
+		.cells[1] as CellState<CodeCellDef>;
 	return { store, codeCell };
 };
 
 describe("CodeCell", () => {
-	// it("should render the CodeCell component", () => {
-	// 	const { store, codeCell } = createCodeCellStore();
+	it("should render the CodeCell component", () => {
+		const { store, codeCell } = createCodeCellStore();
 
-	// 	const { container } = render(
-	// 		<Blocks state={store} registry={{} as Registry}>
-	// 			<CodeCell cell={codeCell} isExpanded={true} />
-	// 		</Blocks>,
-	// 	);
+		const { container } = render(
+			<Blocks state={store} registry={{} as Registry}>
+				<CodeCell cell={codeCell} isExpanded={true} />
+			</Blocks>,
+		);
 
-	// 	console.log({container})
-
-	// 	expect(container).toBeDefined();
-	// 	expect(codeCell.widget).toBe("code");
-	// });
+		expect(container).toBeDefined();
+		expect(codeCell.widget).toBe("code");
+	});
 
 	it("should have code parameter set correctly", () => {
 		const { codeCell } = createCodeCellStore();

--- a/libs/renderer/vitest.config.ts
+++ b/libs/renderer/vitest.config.ts
@@ -11,10 +11,35 @@ export default defineConfig({
 	base: "./",
 	plugins: [react({ include: /\.(js|jsx|ts|tsx)$/ })],
 	resolve: {
-		alias: {
-			"@": resolve(__dirname, "./src"),
-			"@semoss/ui": resolve(__dirname, "../ui/src"),
-		},
+		alias: [
+			{
+				find: "@/lib/utils",
+				replacement: resolve(__dirname, "../ui/src/lib/utils.ts"),
+			},
+			{
+				find: "@/next",
+				replacement: resolve(__dirname, "../ui/src/next"),
+			},
+			{
+				find: "@/hooks/use-mobile",
+				replacement: resolve(__dirname, "../ui/src/hooks"),
+			},
+			{
+				find: "@",
+				replacement: resolve(__dirname, "./src"),
+			},
+			{
+				find: "@semoss/ui",
+				replacement: resolve(__dirname, "../ui/src"),
+			},
+			{
+				find: /^monaco-editor$/,
+				replacement: resolve(
+					__dirname,
+					"../shared/node_modules/monaco-editor/esm/vs/editor/editor.api",
+				),
+			},
+		],
 	},
 	build: {
 		minify: isProduction,
@@ -60,6 +85,8 @@ export default defineConfig({
 				},
 			},
 			external: ["@semoss/ui", "@semoss/sdk"],
+			//helps Vitest handle CommonJS/ES module interoperability
+			interopDefault: true,
 		},
 		browser: {
 			enabled: false,

--- a/libs/renderer/vitest.setup.ts
+++ b/libs/renderer/vitest.setup.ts
@@ -1,6 +1,34 @@
 import { vi } from "vitest";
 import "@testing-library/jest-dom";
 
+// Mock monaco-editor to avoid complex ESM and worker issues in tests
+vi.mock("monaco-editor", () => ({
+	editor: {
+		create: vi.fn(),
+		defineTheme: vi.fn(),
+		setTheme: vi.fn(),
+	},
+	languages: {
+		register: vi.fn(),
+		setLanguageConfiguration: vi.fn(),
+		setMonarchTokensProvider: vi.fn(),
+	},
+}));
+
+vi.mock(import("@semoss/ui"), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		styled: vi.fn((component) => vi.fn(() => component)),
+		useNotification: () => ({
+			notifications: [],
+			add: vi.fn(),
+			remove: vi.fn(),
+			close: vi.fn(),
+		}),
+	};
+});
+
 // Mock vega packages to avoid ESM issues in tests
 vi.mock("vega-embed", () => ({
 	default: vi.fn(() => Promise.resolve({ view: {} })),
@@ -65,3 +93,9 @@ HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
 	clip: vi.fn(),
 	// biome-ignore lint/suspicious/noExplicitAny: <needed for testing>
 })) as any;
+
+// Mock deprecated document.queryCommandSupported for Monaco Editor
+Object.defineProperty(document, "queryCommandSupported", {
+	value: vi.fn(() => true),
+	writable: true,
+});


### PR DESCRIPTION
## Description
Vitest for the Code Cell component

## Changes Made
Tests and also additional changes to vitest.config and vitest.setup. Additional changes were needed to mock semoss ui to properly render some cell defaults within the test.

## How to Test
pnpm run test codecell within the renderer packackage

## Notes
<!-- Any further notes regarding changes -->