### PR TITLE
fix overflow text in chat

### DIFF
--- a/packages/playground/src/components/room/room-input.tsx
+++ b/packages/playground/src/components/room/room-input.tsx
@@ -374,6 +374,10 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 											}
 										}}
 									/>
+									<div
+										aria-hidden="true"
+										className="pointer-events-none absolute inset-x-px bottom-px z-10 h-12 rounded-b-md bg-background"
+									/>
 								</div>
 							}
 							ErrorBoundary={LexicalErrorBoundary}


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Changes Made
Put background behind buttons of chat that block overflow text

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Put a large block of text inside the chat until there is overflow, scroll up and down fully, and make sure no overflow text shows behind buttons