### PR TITLE
UI time stamp hot fix

### DIFF
--- a/libs/i18n/src/resources/locales/ar/playground/sidebar.json
+++ b/libs/i18n/src/resources/locales/ar/playground/sidebar.json
@@ -6,7 +6,9 @@
 		"favorites": "المفضلة",
 		"today": "اليوم",
 		"yesterday": "أمس",
+		"fewDaysAgo": "منذ بضعة أيام",
 		"lastWeek": "الأسبوع الماضي",
+		"thisMonth": "هذا الشهر",
 		"lastMonth": "الشهر الماضي",
 		"older": "أقدم"
 	},

--- a/libs/i18n/src/resources/locales/en/playground/sidebar.json
+++ b/libs/i18n/src/resources/locales/en/playground/sidebar.json
@@ -6,7 +6,9 @@
 		"favorites": "Favorites",
 		"today": "Today",
 		"yesterday": "Yesterday",
+		"fewDaysAgo": "Few Days Ago",
 		"lastWeek": "Last Week",
+		"thisMonth": "This Month",
 		"lastMonth": "Last Month",
 		"older": "Older"
 	},

--- a/libs/i18n/src/resources/locales/es/playground/sidebar.json
+++ b/libs/i18n/src/resources/locales/es/playground/sidebar.json
@@ -6,7 +6,9 @@
 		"favorites": "Favoritos",
 		"today": "Hoy",
 		"yesterday": "Ayer",
+		"fewDaysAgo": "Hace unos días",
 		"lastWeek": "Última semana",
+		"thisMonth": "Este mes",
 		"lastMonth": "Último mes",
 		"older": "Más antiguo"
 	},

--- a/libs/i18n/src/resources/locales/fr/playground/sidebar.json
+++ b/libs/i18n/src/resources/locales/fr/playground/sidebar.json
@@ -6,7 +6,9 @@
 		"favorites": "Favoris",
 		"today": "Aujourd'hui",
 		"yesterday": "Hier",
+		"fewDaysAgo": "Il y a quelques jours",
 		"lastWeek": "La semaine dernière",
+		"thisMonth": "Ce mois-ci",
 		"lastMonth": "Le mois dernier",
 		"older": "Plus ancien"
 	},

--- a/libs/i18n/src/resources/locales/hi/playground/sidebar.json
+++ b/libs/i18n/src/resources/locales/hi/playground/sidebar.json
@@ -6,7 +6,9 @@
 		"favorites": "पसंदीदा",
 		"today": "आज",
 		"yesterday": "कल",
+		"fewDaysAgo": "कुछ दिन पहले",
 		"lastWeek": "पिछले सप्ताह",
+		"thisMonth": "इस महीने",
 		"lastMonth": "पिछले महीने",
 		"older": "पुराना"
 	},

--- a/libs/i18n/src/resources/locales/ja/playground/sidebar.json
+++ b/libs/i18n/src/resources/locales/ja/playground/sidebar.json
@@ -6,7 +6,9 @@
 		"favorites": "お気に入り",
 		"today": "今日",
 		"yesterday": "昨日",
+		"fewDaysAgo": "数日前",
 		"lastWeek": "先週",
+		"thisMonth": "今月",
 		"lastMonth": "先月",
 		"older": "それ以前"
 	},

--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -67,7 +67,9 @@ export const GlobalNav = observer(() => {
 		t("buckets.favorites"),
 		t("buckets.today"),
 		t("buckets.yesterday"),
+		t("buckets.fewDaysAgo"),
 		t("buckets.lastWeek"),
+		t("buckets.thisMonth"),
 		t("buckets.lastMonth"),
 		t("buckets.older"),
 	] as const;
@@ -203,7 +205,7 @@ export const GlobalNav = observer(() => {
 	 */
 	const bucketedRooms = getRooms.data.reduce(
 		(acc, val) => {
-			const d = dayjs(val.DATE_CREATED);
+			const d = dayjs(val.DATE_CREATED + "Z");
 
 			// Pinned rooms only go in Favorites bucket
 			if (val.PINNED) {
@@ -216,9 +218,13 @@ export const GlobalNav = observer(() => {
 				acc[t("buckets.today")].push(val);
 			} else if (systemDate.subtract(1, "day").isSame(d, "day")) {
 				acc[t("buckets.yesterday")].push(val);
-			} else if (systemDate.isSame(d, "week")) {
+			} else if (d.isAfter(systemDate.subtract(3, "day"))) {
+				acc[t("buckets.fewDaysAgo")].push(val);
+			} else if (d.isAfter(systemDate.subtract(7, "day"))) {
 				acc[t("buckets.lastWeek")].push(val);
 			} else if (systemDate.isSame(d, "month")) {
+				acc[t("buckets.thisMonth")].push(val);
+			} else if (systemDate.subtract(1, "month").isSame(d, "month")) {
 				acc[t("buckets.lastMonth")].push(val);
 			} else {
 				acc[t("buckets.older")].push(val);
@@ -230,7 +236,9 @@ export const GlobalNav = observer(() => {
 			[t("buckets.favorites")]: [],
 			[t("buckets.today")]: [],
 			[t("buckets.yesterday")]: [],
+			[t("buckets.fewDaysAgo")]: [],
 			[t("buckets.lastWeek")]: [],
+			[t("buckets.thisMonth")]: [],
 			[t("buckets.lastMonth")]: [],
 			[t("buckets.older")]: [],
 		} as Record<string, typeof getRooms.data>,
@@ -410,7 +418,7 @@ export const GlobalNav = observer(() => {
 											t("messages.untitled");
 										const date = root.theme.sidebar
 											.chatHistoryDate
-											? new Date(room.DATE_CREATED).toLocaleString(undefined, {
+											? new Date(room.DATE_CREATED + 'Z').toLocaleString(undefined, {
 													month: "numeric",
 													day: "numeric",
 													year: "numeric",

--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -410,9 +410,14 @@ export const GlobalNav = observer(() => {
 											t("messages.untitled");
 										const date = root.theme.sidebar
 											.chatHistoryDate
-											? dayjs(room.DATE_CREATED).format(
-													"M/D/YYYY h:mm a",
-												)
+											? new Date(room.DATE_CREATED).toLocaleString(undefined, {
+													month: "numeric",
+													day: "numeric",
+													year: "numeric",
+													hour: "numeric",
+													minute: "2-digit",
+													hour12: true,
+												})
 											: null;
 										const isFavorite = room.PINNED || false;
 										const isEditing =
@@ -464,13 +469,13 @@ export const GlobalNav = observer(() => {
 															}
 														>
 															<Link
-																className={`flex h-auto flex-col items-start p-2 ${date ? "gap-0.5" : ""}`}
+																className={`flex h-auto flex-col items-start p-2 ${date ? "gap-1" : ""}`}
 																to={`/room/${roomId}`}
 																aria-label={
 																	"Select room"
 																}
 															>
-																<span className="truncate font-medium text-sm leading-none">
+																<span className="truncate font-medium text-sm leading-tight">
 																	{name}
 																</span>
 																{date && (

--- a/packages/playground/src/pages/knowledge-page.tsx
+++ b/packages/playground/src/pages/knowledge-page.tsx
@@ -64,7 +64,7 @@ type EngineAsset = {
 };
 
 const formatDateTime = (dateStr: string): string => {
-	const d = new Date(dateStr.replace(" ", "T"));
+	const d = new Date(dateStr.replace(" ", "Z"));
 	if (isNaN(d.getTime())) return dateStr;
 	return d.toLocaleString(undefined, {
 		month: "short",


### PR DESCRIPTION
## Description
<!--Update to sidebar timestamp-->

## Changes Made
<!-- 
1. Increased gap/spacing between chat history title and timestamp beneath it
2. Time coming from database in 'UTC' added 'Z' to display in user local time
3. Updated the 'Today', 'Last Week', 'Last Month', etc categories so the chat history sessions fall in under correct category 

 -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. View Timestamp on sidebar and make sure correct time is displaying. Can test by creating a new chat and refreshing the page. View the chat session date/time in the sidebar and confirm
2. Make sure it falls under the correct category ('Today', 'Yesterday', 'Few Days Ago', 'Last Week', 'This Month', 'Last Month', 'Older'

## Notes
<img width="620" height="351" alt="image" src="https://github.com/user-attachments/assets/0bd210f8-f3e0-45e3-b7cd-3911831812a5" />