### PR TITLE
adjusted mobile modal screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ packages/playground/theme.local.json
 
 # Ignore legacy
 packages/legacy
+
+# Claude
+CLAUDE.md

--- a/packages/playground/src/components/common/global-dialog.tsx
+++ b/packages/playground/src/components/common/global-dialog.tsx
@@ -26,11 +26,12 @@ export const GlobalDialog: React.FC = observer(() => {
 
 	return (
 		<Dialog open={visible}>
-			<DialogContent className="sm:max-w-4xl" showCloseButton={false}>
+			<DialogContent className="sm:max-w-4xl max-h-[90dvh] grid-rows-[auto_1fr_auto] overflow-hidden" showCloseButton={false}>
 				<DialogHeader>
 					<DialogTitle>{root.theme.dialog.title}</DialogTitle>
 				</DialogHeader>
 				<div
+					className="overflow-y-auto"
 					// biome-ignore lint/security/noDangerouslySetInnerHtml: read from theme db we control
 					dangerouslySetInnerHTML={{
 						__html: root.theme.dialog.content,


### PR DESCRIPTION
## Description
Updated GlobalDialog component to new DialogContent size

## Changes Made
Set DialogContent to max-height 90vh and overflow-hidden to avoid modal height from being too long for certain phones

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Go to Inspect of browser
2. Click on the "toggle device toolbar" button
3. Choose iPhone SE for Dimensions
4. Ensure the modal is not too long, and that the Acknowledge button is clickable