### PR TITLE
duplicate keys on load fix

### DIFF
--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -351,9 +351,9 @@ export const GlobalNav = observer(() => {
 							</SidebarMenuButton>
 						</SidebarMenuItem>
 					)}
-					{root.theme.sidebar.headerItems.map((item) => (
+					{root.theme.sidebar.headerItems.map((item, index) => (
 						<GlobalNavItem
-							key={item.path}
+							key={`header-${index}`}
 							name={item.name}
 							icon={item.icon}
 							path={item.path}
@@ -403,7 +403,7 @@ export const GlobalNav = observer(() => {
 							</SidebarGroupLabel>
 							<SidebarGroupContent>
 								<SidebarMenu>
-									{rooms.map((room) => {
+									{rooms.map((room, index) => {
 										const roomId = room.ROOM_ID;
 										const name =
 											room.ROOM_NAME ||
@@ -420,7 +420,7 @@ export const GlobalNav = observer(() => {
 
 										return (
 											<SidebarMenuItem
-												key={roomId}
+												key={`${roomId}-${index}`}
 												className="group/room relative flex"
 											>
 												{isEditing ? (
@@ -603,9 +603,9 @@ export const GlobalNav = observer(() => {
 			<SidebarFooter>
 				<Separator className="group-data-[collapsible=icon]:hidden" />
 				<SidebarMenu className="gap-2 px-2 pt-2 group-data-[collapsible=icon]:hidden">
-					{root.theme.sidebar.footerItems.map((item) => (
+					{root.theme.sidebar.footerItems.map((item, index) => (
 						<GlobalNavItem
-							key={item.path}
+							key={`footer-${index}`}
 							name={item.name}
 							icon={item.icon}
 							path={item.path}


### PR DESCRIPTION
## Description
Currently there is a duplicate key warning in the global-nav.tsx that comes up every time the app loads. This MR solves that warning.

## Changes Made
Made all keys in global-nav.tsx completely unique in order to resolve the warning

## How to Test
1. Start the application, go to Inspect > Console, and verify this warning is no longer there.

Example of the warning:
<img width="1907" height="983" alt="Screenshot 2026-03-24 113434" src="https://github.com/user-attachments/assets/82b0af99-3375-45b5-a7f2-7e4883901495" />
