### PR TITLE
fix: add name behind weclome in new room

### DIFF
--- a/packages/playground/src/pages/new-room-page.tsx
+++ b/packages/playground/src/pages/new-room-page.tsx
@@ -314,7 +314,7 @@ export const NewRoomPage = observer(() => {
 						) : (
 							<div className="mx-auto flex max-w-xl flex-col items-center gap-3">
 								<div className="text-center font-semibold text-4xl text-foreground leading-normal">
-									{t("room:welcome")}
+									{t("room:welcome")}, {chat.user.name}
 								</div>
 								{root.theme.description ? (
 									<div className="text-center text-muted-foreground text-sm leading-normal">


### PR DESCRIPTION
## Description
add user name behind the welcome in the new room page

## Changes Made
new-room-page.tsx 

## How to Test
the playground new room page

## Notes
NA