### PR TITLE
feat(client): file explorer tab removal on file delete

### DIFF
--- a/packages/client/src/components/app-workspace/app-file-explorer.tsx
+++ b/packages/client/src/components/app-workspace/app-file-explorer.tsx
@@ -1,6 +1,6 @@
 import { CloudUploadIcon, HammerIcon, PencilIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { download, useInsight } from "@semoss/sdk/react";
 import { FileExplorer, FileExplorerItem, FlexLayout } from "@semoss/shared";
 import {
@@ -29,6 +29,50 @@ export const AppFileExplorer: React.FC<AppFileExplorerProps> = observer(
 		const insight = useInsight();
 
 		const [isPublishing, setIsPublishing] = useState(false);
+
+		/**
+		 * Remove tabs that are open for a file that has been deleted. If it's a directory, remove all tabs that are open for files within that directory
+		 * @param deletedPath the path of the deleted file or directory
+		 * @param isDirectory whether the deleted path is a directory
+		 */
+		const removeDeletedTabs = useCallback(
+			(deletedPath: string, isDirectory: boolean) => {
+				const model = node.getModel();
+				const deletedPathWithSlash =
+					isDirectory && !deletedPath.endsWith("/")
+						? `${deletedPath}/`
+						: deletedPath;
+				const tabsToRemove: string[] = [];
+
+				model.visitNodes((currentNode) => {
+					if (!(currentNode instanceof FlexLayout.TabNode)) {
+						return;
+					}
+					
+					const config = currentNode.getConfig() as
+					| { path?: string; data?: { path?: string } }
+					| undefined;
+					const path = config?.path || config?.data?.path;
+					console.log("VISITING NODE >>>", currentNode.getId(), " >> ", currentNode.getConfig, " >> ", path);
+					if (!path) {
+						return;
+					}
+					console.log("TESTING >>>", deletedPath, path, isDirectory, config);
+					if (
+						isDirectory
+							? path === deletedPath || path.startsWith(deletedPathWithSlash)
+							: path === deletedPath
+					) {
+						tabsToRemove.push(currentNode.getId());
+					}
+				});
+
+				tabsToRemove.forEach((tabId) => {
+					model.doAction(FlexLayout.Actions.deleteTab(tabId));
+				});
+			},
+			[node],
+		);
 
 		/**
 		 * Add a node to the layout
@@ -117,6 +161,7 @@ export const AppFileExplorer: React.FC<AppFileExplorerProps> = observer(
 				name: name,
 				component: "mcpJsonEditor",
 				config: {
+					path: itemPath,
 					data: {
 						initialData: json,
 						onSave: async (data, path) => {
@@ -333,6 +378,11 @@ export const AppFileExplorer: React.FC<AppFileExplorerProps> = observer(
 									action: async (item) => {
 										await insight.actions.run(
 											`DeleteAppAssets(project=["${app}"], filePath=["${item.path}"]);`,
+										);
+
+										removeDeletedTabs(
+											item.path,
+											item.type === "directory",
 										);
 
 										refresh();

--- a/packages/client/src/components/engine-workspace/engine-file-explorer.tsx
+++ b/packages/client/src/components/engine-workspace/engine-file-explorer.tsx
@@ -29,6 +29,51 @@ export const EngineFileExplorer: React.FC<EngineFileExplorerProps> = observer(
 		const isStorageViewer = config.explorerMode === "STORAGE";
 
 		/**
+		 * Remove tabs that are open for a file that has been deleted. If it's a directory, remove all tabs that are open for files within that directory
+		 * @param deletedPath the path of the deleted file or directory
+		 * @param isDirectory whether the deleted path is a directory
+		 */
+		const removeDeletedTabs = useCallback(
+			(deletedPath: string, isDirectory: boolean) => {
+				const model = node.getModel();
+				const deletedPathWithSlash =
+					isDirectory && !deletedPath.endsWith("/")
+						? `${deletedPath}/`
+						: deletedPath;
+				const tabsToRemove: string[] = [];
+
+				model.visitNodes((currentNode) => {
+					console.log("VISITING NODE >>>", currentNode.getId(), " >> ", !(currentNode instanceof FlexLayout.TabNode));
+					if (!(currentNode instanceof FlexLayout.TabNode)) {
+						return;
+					}
+
+					const config = currentNode.getConfig() as
+						| { path?: string }
+						| undefined;
+					const path = config?.path;
+					if (!path) {
+						return;
+					}
+					console.log("TESTING >>>", deletedPath, path, isDirectory);
+					if (
+						isDirectory
+							? path === deletedPath ||
+								path.startsWith(deletedPathWithSlash)
+							: path === deletedPath
+					) {
+						tabsToRemove.push(currentNode.getId());
+					}
+				});
+
+				tabsToRemove.forEach((tabId) => {
+					model.doAction(FlexLayout.Actions.deleteTab(tabId));
+				});
+			},
+			[node],
+		);
+
+		/**
 		 * Add a node to the layout
 		 * @param nodeId
 		 * @param options
@@ -300,7 +345,10 @@ export const EngineFileExplorer: React.FC<EngineFileExplorerProps> = observer(
 								await insight.actions.run(
 									`DeleteEngineAssets(engine=["${engine}"], filePath=["${item.path}"]);`,
 								);
-
+								removeDeletedTabs(
+									item.path,
+									item.type === "directory",
+								);
 								refresh();
 							},
 						});


### PR DESCRIPTION
## Description
In file explorer the file should be removed from the right panel immediately after it is deleted from the left panel.

## Changes Made
Written new removal function on both engine and app file explorer
