### PR TITLE
fix: chat area now only autoscrolls to bottom when inside text change…

### DIFF
--- a/packages/playground/src/components/room/room-input.tsx
+++ b/packages/playground/src/components/room/room-input.tsx
@@ -175,6 +175,7 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 		const editorRef = useRef<LexicalEditor>(null);
 		const fileRef = useRef<HTMLInputElement>(null);
 		const contentEditableRef = useRef<HTMLDivElement>(null);
+		const prevTextRef = useRef<string>("");
 
 		const [isDragging, setIsDragging] = useState(false);
 		const [files, setFiles] = useState<File[]>([]);
@@ -478,22 +479,23 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 						<OnChangePlugin
 							onChange={(editorState) => {
 								editorState.read(() => {
-									// get the root
 									const root = $getRoot();
+									const nextText = root.getTextContent();
 
 									// set empty state
-									setIsEmpty(
-										root.getTextContent().trim().length ===
-											0,
-									);
+									setIsEmpty(nextText.trim().length === 0);
 
-									// Scroll to bottom after content changes
-									setTimeout(() => {
-										if (contentEditableRef.current) {
-											contentEditableRef.current.scrollTop =
-												contentEditableRef.current.scrollHeight;
-										}
-									}, 0);
+									// Only scroll to bottom when text content changes,
+									// not on selection-only changes (e.g. drag-to-select)
+									if (prevTextRef.current !== nextText) {
+										prevTextRef.current = nextText;
+										setTimeout(() => {
+											if (contentEditableRef.current) {
+												contentEditableRef.current.scrollTop =
+													contentEditableRef.current.scrollHeight;
+											}
+										}, 0);
+									}
 								});
 							}}
 						/>


### PR DESCRIPTION
## Description
This is a fix made for an earlier fix for the chat area OnChangePlugin that controls the autoscroll. The previous fix made it so that any text change or selection change in the chat area would autoscroll to the bottom. This fix eliminates the selection change part so the user can freely select large blocks of text without dealing with autoscroll.

## Changes Made
All are made to OnChangePlugin

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Go to chat, enter a large block of code, and ensure that you can freely select the code with your mouse without any autoscroll impeding it.
2. Also ensure the autoscroll to bottom on text change still works as intended.

## Notes
<img width="1920" height="1080" alt="Screenshot 2026-04-08 at 10 53 37 AM" src="https://github.com/user-attachments/assets/744261ed-c3ec-410c-80be-5dccda3ad978" />
<img width="1920" height="1080" alt="Screenshot 2026-04-08 at 10 54 26 AM" src="https://github.com/user-attachments/assets/f05b0e00-1925-40d6-8d24-6fab0bb9cdfb" />
