### PR TITLE
Chat download spin individually

### DIFF
--- a/packages/playground/src/components/message/response-message.tsx
+++ b/packages/playground/src/components/message/response-message.tsx
@@ -51,7 +51,9 @@ export const ResponseMessage: React.FC<ResponseMessageProps> = observer(
 		const { root } = useRoot();
 
 		const [isDownloadDialogOpen, setIsDownloadDialogOpen] = useState(false);
-		const [isDownloading, setIsDownloading] = useState(false);
+		const [downloadingFormat, setDownloadingFormat] = useState<
+			string | null
+		>(null);
 
 		// get the parent input message
 		let inputMessage: InputMessageStore | null = null;
@@ -95,7 +97,7 @@ export const ResponseMessage: React.FC<ResponseMessageProps> = observer(
 		 * @param format - format to download (word, pdf)
 		 */
 		const downloadResponse = async (format: string) => {
-			setIsDownloading(true);
+			setDownloadingFormat(format);
 			try {
 				await message.downloadResponse(format as "word" | "pdf");
 				toast.success(
@@ -106,7 +108,7 @@ export const ResponseMessage: React.FC<ResponseMessageProps> = observer(
 				const error = e as { message: string };
 				toast.error(error.message || "Failed to download response");
 			} finally {
-				setIsDownloading(false);
+				setDownloadingFormat(null);
 			}
 		};
 
@@ -467,12 +469,12 @@ export const ResponseMessage: React.FC<ResponseMessageProps> = observer(
 									key={format.value}
 									variant="outline"
 									className="h-auto flex-col gap-1 p-4"
-									disabled={isDownloading}
+									disabled={downloadingFormat !== null}
 									onClick={() =>
 										downloadResponse(format.value)
 									}
 								>
-									{isDownloading ? (
+									{downloadingFormat === format.value ? (
 										<Loader2Icon className="size-4 animate-spin" />
 									) : (
 										<>


### PR DESCRIPTION
## Description
When downloading a chat message - the spinner would spin for both word and pdf regardless of what was clicked

## Changes Made
Only spin the download method that was clicked

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Create a chat on playground
2. Download a message as word or pdf

## Notes
<!-- Any further notes regarding changes -->