### PR TITLE
Block quote imported from wrong library

### DIFF
--- a/packages/playground/src/components/message/response-message-text.tsx
+++ b/packages/playground/src/components/message/response-message-text.tsx
@@ -2,7 +2,6 @@ import {
 	ChevronDownIcon,
 	ChevronUpIcon,
 	CopyIcon,
-	Quote,
 	SkipForwardIcon,
 } from "lucide-react";
 import { observer } from "mobx-react-lite";
@@ -21,6 +20,7 @@ import {
 	H4,
 	Markdown,
 	P,
+	Quote,
 	ScrollArea,
 	ScrollBar,
 	Separator,


### PR DESCRIPTION
## Description
Fix block quotes so the text is shown

## Changes Made
Import quote from semoss-sdk instead of lucide. This was causing all block quotes to render as an icon instead of text

## Before
<img width="1122" height="600" alt="image" src="https://github.com/user-attachments/assets/373d8997-86fb-44b2-9fe8-8d17a362b314" />

## After
<img width="876" height="555" alt="image" src="https://github.com/user-attachments/assets/f5822acd-c37d-4cc7-9ea1-d72eed9ee108" />