### PR TITLE
fix: change & to ? on URI for promptParam

### DIFF
--- a/packages/playground/src/pages/embed-page.tsx
+++ b/packages/playground/src/pages/embed-page.tsx
@@ -32,7 +32,7 @@ export const EmbedPage: React.FC = observer(() => {
 				const { workspaceId, knowledgeId, prompt } =
 					event.data.payload ?? {};
 				const promptParam = prompt
-					? `&prompt=${encodeURIComponent(prompt)}`
+					? `?prompt=${encodeURIComponent(prompt)}`
 					: "";
 				if (workspaceId) {
 					navigate(`/new?workspaceId=${workspaceId}`);


### PR DESCRIPTION
## Description
Hotfix for prompt library URI when using Use Prompt hook

## Changes Made
Changed "&" to "?" in the promptParam set inside of embed-page.tsx

## How to Test
1. Simply click on Use Prompt, or click into the prompt and then click on the prompt listed at the bottom of the modal and see if it navigates to the new chat page and populates the chat with the chosen prompt

## Notes
Not sure how this slipped through earlier, as the "&" appeared to be working at the time, however upon testing, it looks like the url definitely needs a "?" instead in order for the hooks to work as designed.