### PR TITLE
fix: destroy insight on logout

### DIFF
--- a/libs/sdk/src/stores/insight/insight.store.ts
+++ b/libs/sdk/src/stores/insight/insight.store.ts
@@ -609,6 +609,10 @@ LoadPyFromFile(alias="${alias}", filePath="temp.py");
 				// turn off authorized
 				this._store.isAuthorized = false;
 
+				// reset insight state so re-login creates a fresh insight
+				this._store.insightId = "";
+				this._store.isReady = false;
+
 				// success
 				return true;
 			} catch (error) {


### PR DESCRIPTION
Summary

Fixes native login failing after logout in SDK-based apps (playground, vet portal, etc.).

Problem

When a user logged in with native username/password, logged out, and attempted to log in again, the re-login would fail with a 400: "Could not find the insight id" error. OAuth-based logins were unaffected because they typically
trigger a page reload during the redirect flow, which resets the SDK state.

Root Cause

The logout() action in InsightStore (libs/sdk/src/stores/insight/insight.store.ts) only set isAuthorized = false but never reset insightId. On re-login, setupInsight() sent the stale insightId from the previous session to the
backend. The backend's NameServer.runPixelSync looked up that ID in InsightStore, found nothing (old session was destroyed), and returned a 400 error. This also left the SDK in an inconsistent state — isAuthorized was set to true
before setupInsight() failed, but syncInsight() never ran, trapping the user on the login page.

Fix

Reset insightId to "" and isReady to false during logout(). This ensures setupInsight() on re-login sends an empty ID, prompting the backend to create a fresh insight (the same path as the first login).

Files Changed

 - libs/sdk/src/stores/insight/insight.store.ts — Added insightId and isReady reset to logout() action

Testing

 1. Login with native username/password
 2. Use the app normally
 3. Logout
 4. Login again with native credentials
 5. Verify app loads correctly with a fresh insight
