### PR TITLE
fix(client): replace useNotification with toast, fix panel close, fix block label styling

### DIFF
--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/App.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/App.tsx
@@ -1,13 +1,14 @@
 import { useState } from "react";
 import { upload, usePixel } from "@semoss/sdk/react";
-import { FileDropzone, Typography, useNotification } from "@semoss/ui";
+import { FileDropzone, Typography } from "@semoss/ui";
+import { toast } from "@semoss/ui/next";
 import { getImageFiles, imageExtensions } from "../utils";
 import SelectedItem from "./SelectedItem";
 import SelectImage from "./SelectImage";
 
 const AppTab = ({ id, data, setData, appId, insightId }) => {
-	const notification = useNotification();
 	const [isLoading, setIsLoading] = useState(false);
+	// biome-ignore lint/suspicious/noExplicitAny: pixel response shape uses any
 	const getAssets = usePixel<{ status: string; data: any }>(
 		`BrowseAppAssets(project=["${appId}"], filePath=["/"]);`,
 	);
@@ -21,18 +22,12 @@ const AppTab = ({ id, data, setData, appId, insightId }) => {
 			uploadRes = await upload(file, insightId, appId, "version/assets/");
 			setData("title", "");
 			setData("src", uploadRes[0]);
-			notification.add({
-				color: "success",
-				message: "Image uploaded successfully",
-			});
+			toast.success("Image uploaded successfully");
 			if (!uploadRes) {
 				throw new Error("Error missing uploading image");
 			}
 		} catch (e) {
-			notification.add({
-				color: "error",
-				message: "Error uploading image",
-			});
+			toast.error("Error uploading image");
 			console.error(e);
 		} finally {
 			setIsLoading(false);

--- a/packages/client/src/components/blocks-workspace/panels/SelectedBlockPanel.tsx
+++ b/packages/client/src/components/blocks-workspace/panels/SelectedBlockPanel.tsx
@@ -521,7 +521,7 @@ export const SelectedBlockPanel = observer(() => {
 								<TabsTrigger
 									value="0"
 									className="h-[38px] flex-1 px-4 py-2"
-									data-testId={
+									data-testid={
 										"selectedBlockPanel-settings-toggle"
 									}
 								>
@@ -530,7 +530,7 @@ export const SelectedBlockPanel = observer(() => {
 								<TabsTrigger
 									value="1"
 									className="h-[38px] flex-1 px-4 py-2"
-									data-testId={
+									data-testid={
 										"selectedBlockPanel-appearance-toggle"
 									}
 								>

--- a/packages/client/src/components/common/TextEditor/TextEditorCodeGeneration.tsx
+++ b/packages/client/src/components/common/TextEditor/TextEditorCodeGeneration.tsx
@@ -1,5 +1,5 @@
 import { AutoAwesome, ContentCopyOutlined } from "@mui/icons-material/";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import {
 	Button,
 	Menu,
@@ -10,9 +10,9 @@ import {
 	styled,
 	TextField,
 	Typography,
-	useNotification,
 } from "@semoss/ui";
-import { useLLM, usePixel, useRootStore } from "@/hooks";
+import { toast } from "@semoss/ui/next";
+import { useLLM, useRootStore } from "@/hooks";
 
 const StyledGenerateButton = styled(Button, {
 	shouldForwardProp: (prop) => prop !== "full",
@@ -63,8 +63,6 @@ const StyledSkeletonContainer = styled("div")(() => ({
 export const TextEditorCodeGeneration = () => {
 	const { modelId, modelOptions, setModel: setModelId } = useLLM();
 	const { monolithStore } = useRootStore();
-	const notification = useNotification();
-
 	const [isLoading, setIsLoading] = useState(false);
 	const [isOpen, setIsOpen] = useState(false);
 	const [code, setCode] = useState("");
@@ -110,11 +108,7 @@ export const TextEditorCodeGeneration = () => {
 			// }
 		} catch (e) {
 			console.log(e);
-
-			notification.add({
-				color: "error",
-				message: e.message,
-			});
+			toast.error(e.message);
 		} finally {
 			// turn off loading
 			setIsLoading(false);
@@ -129,15 +123,9 @@ export const TextEditorCodeGeneration = () => {
 		try {
 			await navigator.clipboard.writeText(text);
 
-			notification.add({
-				color: "success",
-				message: "Successfully copied code",
-			});
-		} catch (e) {
-			notification.add({
-				color: "error",
-				message: "Unable to copy code",
-			});
+			toast.success("Successfully copied code");
+		} catch (_e) {
+			toast.error("Unable to copy code");
 		}
 	};
 
@@ -190,15 +178,13 @@ export const TextEditorCodeGeneration = () => {
 							rows={3}
 						></TextField>
 						{isLoading ? (
-							<>
-								<StyledSkeletonContainer>
-									<Skeleton
-										variant={"rectangular"}
-										width={"100%"}
-										height={"100%"}
-									/>
-								</StyledSkeletonContainer>
-							</>
+							<StyledSkeletonContainer>
+								<Skeleton
+									variant={"rectangular"}
+									width={"100%"}
+									height={"100%"}
+								/>
+							</StyledSkeletonContainer>
 						) : null}
 						{!isLoading && code ? (
 							<div>

--- a/packages/client/src/components/designer/AddBlocksMenuCard.tsx
+++ b/packages/client/src/components/designer/AddBlocksMenuCard.tsx
@@ -10,14 +10,12 @@ import {
 	Box,
 	ButtonGroup,
 	Card,
-	Icon,
 	IconButton,
 	Stack,
 	styled,
 	Tooltip,
-	Typography,
-	useNotification,
 } from "@semoss/ui";
+import { toast } from "@semoss/ui/next";
 import { useDesigner, useRootStore } from "@/hooks";
 import type {
 	BlockLocalStorageData,
@@ -34,15 +32,6 @@ const StyledCard = styled(Card)({
 	borderRadius: "6px",
 	justifyContent: "center",
 });
-
-const StyledTypography = styled(Typography)(({ theme }) => ({
-	color: theme.palette.secondary.dark,
-	width: addBlocksCardWidth,
-	userSelect: "none",
-	textAlign: "center",
-	overflowWrap: "anywhere",
-	alignItems: "center",
-}));
 
 const StyledDiv = styled("div")({
 	position: "relative",
@@ -105,7 +94,6 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 	const { item, isCommunity, handleOnTrashClick } = props;
 	const { state } = useBlocks();
 	const { designer } = useDesigner();
-	const notification = useNotification();
 	const { configStore } = useRootStore();
 
 	const [imageSrc, _setImageSrc] = useState(null);
@@ -195,11 +183,9 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 
 		if (sw.widget === "iteration") {
 			if (sw.slots.children.children.length) {
-				notification.add({
-					color: "error",
-					message:
-						"Please delete block within iterator before adding another child",
-				});
+				toast.error(
+					"Please delete block within iterator before adding another child",
+				);
 				return;
 			}
 		}
@@ -225,11 +211,9 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 					}
 					if (parent.widget === "iteration") {
 						if (parent.slots.children.children.length) {
-							notification.add({
-								color: "error",
-								message:
-									"Please delete block within iterator before adding another child",
-							});
+							toast.error(
+								"Please delete block within iterator before adding another child",
+							);
 							designer.deactivateDrag();
 							return;
 						}
@@ -305,7 +289,6 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 		item.name,
 		item.json,
 		isCommunity,
-		notification,
 		designer.drag.active,
 		designer.drag.placeholderAction,
 		designer,
@@ -332,36 +315,36 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 			height="100%"
 			justifyContent="flex-end"
 		>
-			<StyledTypography
-				component="div"
-				variant="body2"
-				fontWeight="medium"
-				align="center"
+			<div
+				className="flex select-none flex-wrap items-center justify-center gap-1 text-center font-medium text-foreground text-xs"
+				style={{ width: addBlocksCardWidth, overflowWrap: "anywhere" }}
 			>
-				<Stack
-					direction={"row"}
-					gap={1}
-					alignContent={"center"}
-					justifyContent={"center"}
-					flexWrap={"wrap"}
-				>
-					{item.name}
-					{item.recentChanges && (
-						<Tooltip title={item.recentChanges}>
-							<Icon color={"info"} fontSize="small">
-								<InfoOutlined />
-							</Icon>
-						</Tooltip>
-					)}
-					{item.isBeta && (
-						<Tooltip title={"This block is currently in beta"}>
-							<Icon color={"warning"} fontSize="small">
-								<ReportRounded />
-							</Icon>
-						</Tooltip>
-					)}
-				</Stack>
-			</StyledTypography>
+				{item.name}
+				{item.recentChanges && (
+					<Tooltip title={item.recentChanges}>
+						<span
+							style={{
+								display: "inline-flex",
+								alignItems: "center",
+							}}
+						>
+							<InfoOutlined fontSize="small" color="info" />
+						</span>
+					</Tooltip>
+				)}
+				{item.isBeta && (
+					<Tooltip title={"This block is currently in beta"}>
+						<span
+							style={{
+								display: "inline-flex",
+								alignItems: "center",
+							}}
+						>
+							<ReportRounded fontSize="small" color="warning" />
+						</span>
+					</Tooltip>
+				)}
+			</div>
 			<StyledDiv
 				onMouseEnter={() => setHovered(true)}
 				onMouseLeave={() => setHovered(false)}

--- a/packages/client/src/components/designer/AddClientBlockModal.tsx
+++ b/packages/client/src/components/designer/AddClientBlockModal.tsx
@@ -7,16 +7,14 @@ import {
 	Autocomplete,
 	Box,
 	Button,
-	createFilterOptions,
 	IconButton,
 	Modal,
-	RadioGroup,
 	styled,
 	TextField,
 	Tooltip,
 	Typography,
-	useNotification,
 } from "@semoss/ui";
+import { toast } from "@semoss/ui/next";
 import { useRootStore } from "@/hooks";
 import { getBlockElement } from "@/stores";
 import { SECTION_ORDER } from "../blocks-workspace/menus/default-menu";
@@ -56,6 +54,7 @@ const StyledButtonGroupIconButton = styled(IconButton)(({ theme }) => ({
 
 interface EditDetailsModalProps {
 	isOpen: boolean;
+	// biome-ignore lint/suspicious/noExplicitAny: complex nested block shape
 	selected: any;
 	onClose: (reset?: boolean) => void;
 	isEdit?: boolean;
@@ -67,9 +66,11 @@ interface AddAsClientBlockTypes {
 	section: string;
 	helperText: string;
 	visibility: "private" | "public";
+	// biome-ignore lint/suspicious/noExplicitAny: block JSON is untyped
 	block_json: any;
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: generic dict type
 type Dict<T = any> = Record<string, T>;
 
 interface ScanResult {
@@ -89,24 +90,26 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 	const { isOpen, selected, onClose, isEdit, block_json } = props;
 	const { control, setValue, reset, handleSubmit } =
 		useForm<AddAsClientBlockTypes>({ defaultValues: AddAsClientBlock });
-	const { monolithStore, configStore } = useRootStore();
-	const { registry, state } = useBlocks();
-	const notification = useNotification();
+	const { monolithStore } = useRootStore();
+	const { state } = useBlocks();
 	const allowedKeys = ["widget", "data", "listeners", "slots", "id"];
 	const [showPreviewModal, setShowPreviewModal] = useState(false);
 	const [imageDimensions, setImageDimensions] = useState<{
 		width: number;
 		height: number;
 	}>({ width: 0, height: 0 });
+	// biome-ignore lint/suspicious/noExplicitAny: block item shape varies
 	const [localBlockItem, setLocalBlockItem] = useState<any>([]);
 	const [imagePreview, setImagePreview] = useState<string | null>(null);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional mount-only
 	useEffect(() => {
 		if (block_json) {
 			setLocalBlockItem(structuredClone(block_json));
 		}
 	}, []);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — isOpen triggers re-sync
 	useEffect(() => {
 		if (isEdit && block_json) {
 			setValue("name", block_json.name ?? "");
@@ -115,7 +118,9 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 		}
 	}, [isEdit, block_json, setValue, isOpen]);
 
+	// biome-ignore lint/suspicious/noExplicitAny: block JSON is untyped
 	const handleLayersPanelUpdate = (updatedJson: any) => {
+		// biome-ignore lint/suspicious/noExplicitAny: block JSON is untyped
 		setLocalBlockItem((prev: any) => ({
 			...prev,
 			json: updatedJson.json,
@@ -123,6 +128,7 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 	};
 
 	const handleFieldChange = (field: string, value: string) => {
+		// biome-ignore lint/suspicious/noExplicitAny: block item shape varies
 		setLocalBlockItem((prev: any) => ({
 			...prev,
 			[field]: value,
@@ -132,10 +138,10 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 	/**
 	 * Recursively processes the slots of a block to retain only the allowed keys.
 	 *
-	 * @param {any} value - The slots or part of slots to process.
-	 * @param {Record<string, any>} blocks - The entire blocks object for reference.
-	 * @returns {any} Processed slots with only allowed keys retained.
+	 * @param value - The slots or part of slots to process.
+	 * @param blocks - The entire blocks object for reference.
 	 */
+	// biome-ignore lint/suspicious/noExplicitAny: recursive slot structure is untyped
 	const processSlots = (value: any, blocks: Record<string, any>): any => {
 		// Check if the current value is an array
 		if (Array.isArray(value)) {
@@ -168,6 +174,7 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 	};
 
 	const scanBlocks = (
+		// biome-ignore lint/suspicious/noExplicitAny: block structure is untyped
 		blocks: any,
 		allQueries: Dict,
 		allVariables: Dict,
@@ -178,8 +185,10 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 		const mustacheRE = /{{\s*([^{}\s]+?)\s*}}/g;
 
 		/** push-based walk = no recursion, cycle-safe */
+		// biome-ignore lint/suspicious/noExplicitAny: generic walk over untyped block tree
 		function walk(root: any) {
 			const seen = new WeakSet<object>();
+			// biome-ignore lint/suspicious/noExplicitAny: untyped stack
 			const stack: any[] = [root];
 
 			while (stack.length) {
@@ -200,8 +209,11 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 					seen.add(node);
 
 					const queryId =
+						// biome-ignore lint/suspicious/noExplicitAny: untyped node
 						(node as any).payload?.queryId ??
+						// biome-ignore lint/suspicious/noExplicitAny: untyped node
 						(node as any).queryId ??
+						// biome-ignore lint/suspicious/noExplicitAny: untyped node
 						(node as any).id;
 
 					// query found, maybe add
@@ -230,6 +242,7 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 				/* ---------- strings ---------- */
 				if (typeof node === "string") {
 					let m: RegExpExecArray | null;
+					// biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop pattern
 					while ((m = mustacheRE.exec(node))) {
 						const rootId = m[1].split(".")[0]; // trim .prop chain
 						if (rootId in allQueries) qIds.add(rootId);
@@ -247,6 +260,7 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 		const queue = Array.from(qIds);
 
 		while (queue.length) {
+			// biome-ignore lint/style/noNonNullAssertion: queue.length check ensures non-null
 			const qId = queue.pop()!;
 			if (processed.has(qId)) continue;
 			processed.add(qId);
@@ -319,15 +333,9 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 			const { output, operationType } = response.pixelReturn[0];
 
 			if (operationType.indexOf("ERROR") === -1) {
-				notification.add({
-					color: "success",
-					message: "Successfully added document",
-				});
+				toast.success("Successfully added document");
 			} else {
-				notification.add({
-					color: "error",
-					message: output,
-				});
+				toast.error(output);
 			}
 
 			reset(AddAsClientBlock);
@@ -339,7 +347,7 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 	const handleSaveAsClientBlock = async () => {
 		const itemToSave = localBlockItem;
 		if (!itemToSave) return;
-		const updatedClientBlock = {
+		const _updatedClientBlock = {
 			widget: itemToSave.json?.widget,
 			data: itemToSave.json?.data,
 			listeners: itemToSave.json?.listeners,
@@ -381,7 +389,7 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 		onClose();
 		setShowPreviewModal(false);
 	};
-	const handleInputValidations = (val: string, field: string) => {
+	const handleInputValidations = (val: string, _field: string) => {
 		if (!/^[a-zA-Z_-]*$/.test(val)) {
 			return false;
 		}
@@ -391,7 +399,7 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 	/** html2canvas to PNG conversion */
 	const handleCanvasPreview = async () => {
 		const block = state.blocks[selected];
-		if (block && block.id) {
+		if (block?.id) {
 			const element = getBlockElement(block.id) as HTMLElement;
 			if (element) {
 				// Capture the element's dimensions

--- a/packages/client/src/components/designer/DeleteDuplicateMask.tsx
+++ b/packages/client/src/components/designer/DeleteDuplicateMask.tsx
@@ -18,13 +18,8 @@ import {
 	INPUT_BLOCK_TYPES,
 	useBlocks,
 } from "@semoss/renderer";
-import {
-	ButtonGroup,
-	IconButton,
-	styled,
-	Tooltip,
-	useNotification,
-} from "@semoss/ui";
+import { ButtonGroup, IconButton, styled, Tooltip } from "@semoss/ui";
+import { toast } from "@semoss/ui/next";
 import { useDesigner, useRootStore } from "@/hooks";
 import { getBlockElement, getRelativeSize } from "@/stores";
 import { getDependencyCells } from "@/utility/dependencyScanner";
@@ -94,7 +89,6 @@ export const DeleteDuplicateMask = observer(
 		// get the store
 		const { registry, state } = useBlocks();
 		const { designer } = useDesigner();
-		const notification = useNotification();
 		const { configStore } = useRootStore();
 
 		// get the block
@@ -319,10 +313,9 @@ export const DeleteDuplicateMask = observer(
 
 			const parentBlock = state.getBlock(block.parent.id);
 			if (parentBlock.widget === "iteration") {
-				notification.add({
-					color: "error",
-					message: `Unable to duplicate ${block.widget} within an Iterator Block`,
-				});
+				toast.error(
+					`Unable to duplicate ${block.widget} within an Iterator Block`,
+				);
 				return;
 			}
 

--- a/packages/client/src/components/designer/FormMenu.tsx
+++ b/packages/client/src/components/designer/FormMenu.tsx
@@ -15,8 +15,8 @@ import {
 	ToggleTabsGroup,
 	Tooltip,
 	Typography,
-	useNotification,
 } from "@semoss/ui";
+import { toast } from "@semoss/ui/next";
 import type { DesignerMenuItem } from "../blocks-workspace/menus/menu-types";
 import { BlockCardContent, blockCardWidth } from "./BlockMenuCardContent";
 
@@ -169,7 +169,7 @@ const FormMenuBlockCard: React.FC<FormMenuCardProps> = ({
 				<Stack
 					direction={"row"}
 					gap={1}
-					alignContent={"center"}
+					alignItems={"center"}
 					justifyContent={"center"}
 					flexWrap={"wrap"}
 				>
@@ -222,8 +222,6 @@ export const FormMenu: React.FC<FormMenuProps> = ({
 	onSelect,
 	title = "Add blocks to form",
 }) => {
-	const notification = useNotification();
-
 	const [search, setSearch] = useState("");
 	const [mode, setMode] = useState<MODE>("SYSTEM");
 	const [communityBlocks, setCommunityBlocks] = useState<DesignerMenuItem[]>(
@@ -241,11 +239,9 @@ export const FormMenu: React.FC<FormMenuProps> = ({
 			const { pixelReturn, errors } = res;
 
 			if (errors?.length) {
-				notification.add({
-					color: "error",
-					message:
-						errors.join("") || "Error loading community blocks",
-				});
+				toast.error(
+					errors.join("") || "Error loading community blocks",
+				);
 				setLoadingCommunity(false);
 				return;
 			}
@@ -263,15 +259,12 @@ export const FormMenu: React.FC<FormMenuProps> = ({
 			}
 		} catch (e) {
 			console.error(e);
-			notification.add({
-				color: "error",
-				message: "Error loading community blocks",
-			});
+			toast.error("Error loading community blocks");
 		} finally {
 			setLoadingCommunity(false);
 			setHasLoadedCommunity(true);
 		}
-	}, [hasLoadedCommunity, notification]);
+	}, [hasLoadedCommunity]);
 
 	useEffect(() => {
 		if (mode === "COMMUNITY") {

--- a/packages/client/src/components/designer/SelectedMask.tsx
+++ b/packages/client/src/components/designer/SelectedMask.tsx
@@ -2,7 +2,8 @@ import { DragIndicator } from "@mui/icons-material";
 import { observer } from "mobx-react-lite";
 import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 import { ActionMessages, useBlocks } from "@semoss/renderer";
-import { Stack, styled, Typography, useNotification } from "@semoss/ui";
+import { Stack, styled, Typography } from "@semoss/ui";
+import { toast } from "@semoss/ui/next";
 import { useDesigner } from "@/hooks";
 import { getBlockElement, getRelativeSize } from "@/stores";
 import { BlockSettingsRegistry } from "../blocks-workspace/blocks";
@@ -47,9 +48,9 @@ interface SelectedMaskProps {
  */
 export const SelectedMask = observer((props: SelectedMaskProps) => {
 	const { screenEle } = props;
-	const notification = useNotification();
 
 	// create the state
+
 	const [size, setSize] = useState<{
 		top: number;
 		left: number;
@@ -168,11 +169,9 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 							const parent = state.getBlock(sw.parent.id);
 							if (parent.widget === "iteration") {
 								if (parent.slots.children.children.length) {
-									notification.add({
-										color: "error",
-										message:
-											"Please delete block within iterator before adding another child",
-									});
+									toast.error(
+										"Please delete block within iterator before adding another child",
+									);
 									designer.deactivateDrag();
 									return;
 								}
@@ -235,11 +234,9 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 						const parent = state.getBlock(sw.parent.id);
 						if (parent.widget === "iteration") {
 							if (parent.slots.children.children.length) {
-								notification.add({
-									color: "error",
-									message:
-										"Please delete block within iterator before adding another child",
-								});
+								toast.error(
+									"Please delete block within iterator before adding another child",
+								);
 								designer.deactivateDrag();
 								return;
 							}
@@ -320,17 +317,20 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 	};
 
 	// update the mask when the screen is resized
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional mount-only listener
 	useEffect(() => {
 		window.addEventListener("resize", repositionMask);
 	}, []);
 
 	// block resized is a custom event emitted by SizeSettings
 	// so we know to updated the mask when width/height changes
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional mount-only listener
 	useEffect(() => {
 		window.addEventListener("blockResized", repositionMask);
 	}, []);
 
 	// get the root, watch changes, and reposition the mask
+	// biome-ignore lint/correctness/useExhaustiveDependencies: repositionMask is stable
 	useLayoutEffect(() => {
 		const observer = new MutationObserver(() => {
 			repositionMask();
@@ -366,7 +366,7 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 
 	const handleRename = (id: string): string => {
 		const block = state.getBlock(id);
-		if (block && block?.data?.id) {
+		if (block?.data?.id) {
 			return block.data.id as string;
 		}
 		return id;
@@ -375,7 +375,7 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 	if (designer.selectedBlocks.length > 1) {
 		return (
 			<>
-				{designer.selectedBlocks.map((id, index) => {
+				{designer.selectedBlocks.map((id, _index) => {
 					const blockElement = getBlockElement(id);
 					if (!blockElement) return null;
 

--- a/packages/client/src/components/engine/FeedbackButtons.tsx
+++ b/packages/client/src/components/engine/FeedbackButtons.tsx
@@ -1,6 +1,7 @@
 import { ThumbDownOffAlt, ThumbUpOffAlt } from "@mui/icons-material";
 import { useState } from "react";
-import { IconButton, Stack, styled, useNotification } from "@semoss/ui";
+import { IconButton, Stack, styled } from "@semoss/ui";
+import { toast } from "@semoss/ui/next";
 
 interface FeedbackButtonsProps {
 	messageId: string;
@@ -18,8 +19,6 @@ export const FeedbackButtons: React.FC<FeedbackButtonsProps> = ({
 	onFeedbackCall,
 	initialValue = null,
 }) => {
-	const notification = useNotification();
-
 	const [feedback, setFeedback] = useState<"true" | "false" | null>(
 		initialValue,
 	);
@@ -30,10 +29,7 @@ export const FeedbackButtons: React.FC<FeedbackButtonsProps> = ({
 		setFeedback(value);
 		onFeedbackCall(messageId, value);
 
-		notification.add({
-			color: "success",
-			message: "Successfully added feedback",
-		});
+		toast.success("Successfully added feedback");
 	};
 
 	return (

--- a/packages/client/src/components/engine/generic-engine-cards.tsx
+++ b/packages/client/src/components/engine/generic-engine-cards.tsx
@@ -472,7 +472,7 @@ export const EngineLandscapeCard = (props: DatabaseCardProps) => {
 	return (
 		<Card
 			onClick={() => onClick?.(id)}
-			data-testId={formatToDataTestId(
+			data-testid={formatToDataTestId(
 				`genericEngineCards-${type}-${name}`,
 			)}
 			className="flex h-auto w-full max-w-full flex-col items-start justify-center gap-1.5 overflow-hidden rounded-lg border bg-card p-3 shadow-md hover:cursor-pointer sm:p-3.5"

--- a/packages/client/src/components/import/function/function-import-form.tsx
+++ b/packages/client/src/components/import/function/function-import-form.tsx
@@ -857,13 +857,13 @@ export const FunctionForm = ({
 								<div className="flex flex-1 flex-col gap-1">
 									<H4
 										className="font-semibold text-base tracking-tight"
-										data-testId="function-importForm-category-title"
+										data-testid="function-importForm-category-title"
 									>
 										{category}
 									</H4>
 									<Muted
 										className="text-muted-foreground text-sm leading-6"
-										data-testId="model-importForm-category-description"
+										data-testid="model-importForm-category-description"
 									>
 										{categoryDescriptions[category] ??
 											"No description available."}

--- a/packages/client/src/components/import/function/function-title-card.tsx
+++ b/packages/client/src/components/import/function/function-title-card.tsx
@@ -76,7 +76,7 @@ export const FunctionTitleCard = ({
 			)}
 			onClick={handleCardClick}
 			onKeyDown={handleCardKeyDown}
-			data-testId={formatToDataTestId(
+			data-testid={formatToDataTestId(
 				`importPageContent-connect-to-${selectedFunction.name}-img`,
 			)}
 			role="button"

--- a/packages/client/src/components/import/guardrail/guardrail-import-form.tsx
+++ b/packages/client/src/components/import/guardrail/guardrail-import-form.tsx
@@ -1117,13 +1117,13 @@ export const GuardrailForm = ({
 								<div className="flex flex-1 flex-col gap-1">
 									<H4
 										className="font-semibold text-base tracking-tight"
-										data-testId="guardrail-importForm-category-title"
+										data-testid="guardrail-importForm-category-title"
 									>
 										{category}
 									</H4>
 									<Muted
 										className="text-muted-foreground text-sm leading-6"
-										data-testId="model-importForm-category-description"
+										data-testid="model-importForm-category-description"
 									>
 										{categoryDescriptions[category] ??
 											"No description available."}

--- a/packages/client/src/components/import/guardrail/guardrail-title-card.tsx
+++ b/packages/client/src/components/import/guardrail/guardrail-title-card.tsx
@@ -76,7 +76,7 @@ export const GuardrailTitleCard: React.FC<GuardrailTileCardProps> = ({
 			)}
 			onClick={handleCardClick}
 			onKeyDown={handleCardKeyDown}
-			data-testId={formatToDataTestId(
+			data-testid={formatToDataTestId(
 				`importPageContent-connect-to-${guardrail.name}-img`,
 			)}
 			role="button"

--- a/packages/client/src/components/import/model/model-import-form.tsx
+++ b/packages/client/src/components/import/model/model-import-form.tsx
@@ -799,13 +799,13 @@ export const ModelImportForm = (props: ModelImportFormProps) => {
 						<div className="flex flex-1 flex-col gap-1">
 							<H4
 								className="font-semibold text-base tracking-tight"
-								data-testId={`model-importForm-category-title`}
+								data-testid={`model-importForm-category-title`}
 							>
 								{category}
 							</H4>
 							<Muted
 								className="text-muted-foreground text-sm leading-6"
-								data-testId={`model-importForm-category-description`}
+								data-testid={`model-importForm-category-description`}
 							>
 								{importableModelsCategory[selectedProvider]?.[
 									category
@@ -828,14 +828,14 @@ export const ModelImportForm = (props: ModelImportFormProps) => {
 						onOpenChange={setAdvancedOpen}
 					>
 						<div className="flex flex-row items-center justify-between gap-2">
-							<H4 data-testId="model-advanced-settings-title">
+							<H4 data-testid="model-advanced-settings-title">
 								Advanced Settings
 							</H4>
 							<CollapsibleTrigger asChild>
 								<Button
 									variant="ghost"
 									size="icon"
-									data-testId="model-advanced-settings-toggle"
+									data-testid="model-advanced-settings-toggle"
 								>
 									{advancedOpen ? (
 										<ChevronUp className="size-4" />
@@ -850,7 +850,7 @@ export const ModelImportForm = (props: ModelImportFormProps) => {
 								<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
 									{/* Left: Category title + description */}
 									<div className="flex flex-1 flex-col gap-1">
-										<Muted data-testId="model-advanced-settings-description">
+										<Muted data-testid="model-advanced-settings-description">
 											Add advanced settings here
 										</Muted>
 									</div>
@@ -867,7 +867,7 @@ export const ModelImportForm = (props: ModelImportFormProps) => {
 			)}
 			<div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-end">
 				<Button
-					data-testId="model-importForm-connect-button"
+					data-testid="model-importForm-connect-button"
 					variant="default"
 					className="flex w-full items-center justify-center gap-2 px-4 py-2 sm:w-[147px]"
 					type="submit"

--- a/packages/client/src/components/import/model/model-tile-card.tsx
+++ b/packages/client/src/components/import/model/model-tile-card.tsx
@@ -160,7 +160,7 @@ export const ModelTileCard: React.FC<ModelTileCardProps> = ({
 			)}
 			onClick={handleCardClick}
 			onKeyDown={handleCardKeyDown}
-			data-testId={formatToDataTestId(
+			data-testid={formatToDataTestId(
 				`importPageContent-connect-to-${model.name}-img`,
 			)}
 			role="button"
@@ -190,7 +190,7 @@ export const ModelTileCard: React.FC<ModelTileCardProps> = ({
 						{!model.disable && model.embedding && (
 							<Badge
 								variant="default"
-								data-testId={formatToDataTestId(
+								data-testid={formatToDataTestId(
 									`importPageContent-${model.name}-embeddings-tag`,
 								)}
 							>
@@ -200,7 +200,7 @@ export const ModelTileCard: React.FC<ModelTileCardProps> = ({
 						{!model.disable && model.image && (
 							<Badge
 								className="rounded-2xl border-none bg-primary/10 px-2.5 font-semibold text-[13px] text-primary"
-								data-testId={formatToDataTestId(
+								data-testid={formatToDataTestId(
 									`importPageContent-${model.name}-image-tag`,
 								)}
 							>
@@ -210,7 +210,7 @@ export const ModelTileCard: React.FC<ModelTileCardProps> = ({
 						{!model.disable && model.audio && (
 							<Badge
 								className="rounded-2xl border-none bg-primary/10 px-2.5 font-semibold text-[13px] text-primary"
-								data-testId={formatToDataTestId(
+								data-testid={formatToDataTestId(
 									`importPageContent-${model.name}-audio-tag`,
 								)}
 							>

--- a/packages/client/src/components/import/vector/vector-import-form.tsx
+++ b/packages/client/src/components/import/vector/vector-import-form.tsx
@@ -769,13 +769,13 @@ export const VectorForm = ({
 								<div className="flex flex-1 flex-col gap-1">
 									<H4
 										className="font-semibold text-base tracking-tight"
-										data-testId="vector-importForm-category-title"
+										data-testid="vector-importForm-category-title"
 									>
 										{category}
 									</H4>
 									<Muted
 										className="text-muted-foreground text-sm leading-6"
-										data-testId="model-importForm-category-description"
+										data-testid="model-importForm-category-description"
 									>
 										{categoryDescriptions[category] ??
 											"No description available."}

--- a/packages/client/src/components/import/vector/vector-title-card.tsx
+++ b/packages/client/src/components/import/vector/vector-title-card.tsx
@@ -76,7 +76,7 @@ export const VectorTitleCard: React.FC<VectorTileCardProps> = ({
 			)}
 			onClick={handleCardClick}
 			onKeyDown={handleCardKeyDown}
-			data-testId={formatToDataTestId(
+			data-testid={formatToDataTestId(
 				`importPageContent-connect-to-${vector.name}-img`,
 			)}
 			role="button"

--- a/packages/client/src/components/notebook/AddVariableModal.tsx
+++ b/packages/client/src/components/notebook/AddVariableModal.tsx
@@ -1,6 +1,5 @@
 import { useId, useState } from "react";
 import { ActionMessages, useBlocks, type VariableType } from "@semoss/renderer";
-import { useNotification } from "@semoss/ui";
 import {
 	Button,
 	Dialog,
@@ -10,6 +9,7 @@ import {
 	DialogTitle,
 	Input,
 	Label,
+	toast,
 } from "@semoss/ui/next";
 
 export interface AddVariableModalProps {
@@ -42,7 +42,6 @@ export interface AddVariableModalProps {
 export const AddVariableModal = (props: AddVariableModalProps) => {
 	const { open, type, to, cellId, onClose } = props;
 	const { state } = useBlocks();
-	const notification = useNotification();
 
 	const aliasId = useId();
 	const [newAlias, setNewAlias] = useState("");
@@ -89,12 +88,13 @@ export const AddVariableModal = (props: AddVariableModalProps) => {
 								},
 							});
 
-							notification.add({
-								color: success ? "success" : "error",
-								message: success
-									? `Successfully added ${newAlias}`
-									: `Unable to add ${newAlias}, due to syntax or a duplicated alias`,
-							});
+							if (success) {
+								toast.success(`Successfully added ${newAlias}`);
+							} else {
+								toast.error(
+									`Unable to add ${newAlias}, due to syntax or a duplicated alias`,
+								);
+							}
 
 							if (success) {
 								onClose();

--- a/packages/client/src/components/notebook/AddVariablePopover.tsx
+++ b/packages/client/src/components/notebook/AddVariablePopover.tsx
@@ -27,7 +27,6 @@ import {
 	type VariableWithId,
 } from "@semoss/renderer";
 import { MonacoEditor } from "@semoss/shared";
-import { useNotification } from "@semoss/ui";
 import {
 	Alert,
 	AlertDescription,
@@ -44,6 +43,7 @@ import {
 	SelectItem,
 	SelectTrigger,
 	SelectValue,
+	toast,
 } from "@semoss/ui/next";
 import PreviewButton from "../../assets/img/PreviewRounded.png";
 // TODO: MOVE TO SDK/UTILITY LIB
@@ -122,7 +122,6 @@ interface AddVariablePopoverProps {
 export const AddVariablePopover = observer((props: AddVariablePopoverProps) => {
 	const { open, onClose, variable, engines } = props;
 	const { state } = useBlocks();
-	const notification = useNotification();
 
 	const [variableName, setVariableName] = useState("");
 	const [variableType, setVariableType] = useState<VariableType | "">("");
@@ -194,6 +193,7 @@ export const AddVariablePopover = observer((props: AddVariablePopoverProps) => {
 	/**
 	 * Select options depending on variable type
 	 */
+	// biome-ignore lint/correctness/useExhaustiveDependencies: comparisonBlocks intentionally omitted
 	const selectOptions = useMemo((): {
 		value: string;
 		label: string;
@@ -255,12 +255,14 @@ export const AddVariablePopover = observer((props: AddVariablePopoverProps) => {
 	const isPointerType = (type: string) =>
 		["block", "query", "cell", "LLM Comparison"].includes(type);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: isPointerType/isEngineType are stable
 	const selectValue = useMemo(() => {
 		if (isPointerType(variableType)) return variablePointer;
 		if (isEngineType(variableType)) return engine?.engine_id ?? "";
 		return "";
 	}, [variableType, variablePointer, engine]);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: complex memo with stable callbacks
 	const input = useMemo(() => {
 		if (variableType === "string") {
 			return (
@@ -397,6 +399,7 @@ export const AddVariablePopover = observer((props: AddVariablePopoverProps) => {
 		return null;
 	}, [variableType, variableInputValue, selectOptions, selectValue]);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional dep subset
 	const preview = useMemo(() => {
 		try {
 			if (
@@ -547,6 +550,7 @@ export const AddVariablePopover = observer((props: AddVariablePopoverProps) => {
 		}
 	}, [variableType, variablePointer, engine, variableInputValue]);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional dep subset
 	const addVariableDisabled = useMemo(() => {
 		const hasRequiredFields = Boolean(
 			variableType.length > 0 && variableName.length > 0,
@@ -590,6 +594,7 @@ export const AddVariablePopover = observer((props: AddVariablePopoverProps) => {
 		alreadyAliased,
 	]);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-sync on variable change
 	useEffect(() => {
 		if (variable?.id) {
 			setVariableName(variable.id);
@@ -784,10 +789,9 @@ export const AddVariablePopover = observer((props: AddVariablePopoverProps) => {
 										},
 									});
 
-									notification.add({
-										color: "success",
-										message: `Successfully editted ${variable.id}, remember to save your app.`,
-									});
+									toast.success(
+										`Successfully editted ${variable.id}, remember to save your app.`,
+									);
 									onClose();
 								} else {
 									console.warn(
@@ -827,12 +831,15 @@ export const AddVariablePopover = observer((props: AddVariablePopoverProps) => {
 													},
 									});
 
-									notification.add({
-										color: success ? "success" : "error",
-										message: success
-											? `Successfully added ${variableName}, remember to save your app.`
-											: `Unable to create ${variableName}`,
-									});
+									if (success) {
+										toast.success(
+											`Successfully added ${variableName}, remember to save your app.`,
+										);
+									} else {
+										toast.error(
+											`Unable to create ${variableName}`,
+										);
+									}
 									onClose();
 								}
 							}

--- a/packages/client/src/components/notebook/NotebookCell.tsx
+++ b/packages/client/src/components/notebook/NotebookCell.tsx
@@ -16,8 +16,13 @@ import {
 	useBlocks,
 } from "@semoss/renderer";
 import { runPixel } from "@semoss/sdk";
-import { useNotification } from "@semoss/ui";
-import { Button, ButtonGroup, Separator, Spinner } from "@semoss/ui/next";
+import {
+	Button,
+	ButtonGroup,
+	Separator,
+	Spinner,
+	toast,
+} from "@semoss/ui/next";
 import { useWorkspace } from "@/hooks";
 import { MCP_NOTEBOOK_NAME } from "@/pages/app/app.constants";
 // TODO: MOVE TO SDK or a seperate lib specifically for utilities @semoss/utility
@@ -54,7 +59,6 @@ export const NotebookCell = observer(
 
 		const { state, notebook } = useBlocks();
 		const { workspace } = useWorkspace();
-		const notification = useNotification();
 
 		const [showRaw, setShowRaw] = useState(false);
 		const [showCellActions, setShowCellActions] = useState(false);
@@ -74,6 +78,7 @@ export const NotebookCell = observer(
 
 		const variableName = state.getAlias(queryId, cellId);
 
+		// biome-ignore lint/correctness/useExhaustiveDependencies: dependentBlocksModal is intentional dep
 		const replacementCellOptions = useMemo(() => {
 			if (!state.queries) return [];
 			const allCellsList = [];
@@ -86,6 +91,7 @@ export const NotebookCell = observer(
 			return allCellsList;
 		}, [state.queries, dependentBlocksModal === true]);
 
+		// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only react to isExecuted
 		useEffect(() => {
 			if (cell.isExecuted === false) {
 				setLocalCellPlayNumber(null);
@@ -96,6 +102,7 @@ export const NotebookCell = observer(
 			}
 		}, [cell.isExecuted]);
 
+		// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only react to counter
 		useEffect(() => {
 			if (cellPlayCounter == null) {
 				setLocalCellPlayNumber(null);
@@ -173,10 +180,7 @@ export const NotebookCell = observer(
 					},
 				});
 				await dispatchDeleteCell();
-				notification.add({
-					color: "success",
-					message: "Successfully replaced cells",
-				});
+				toast.success("Successfully replaced cells");
 				workspace.setLoading(false);
 			} catch (e) {
 				console.error(e);
@@ -221,6 +225,7 @@ export const NotebookCell = observer(
 		};
 
 		// render the view
+		// biome-ignore lint/correctness/useExhaustiveDependencies: cell.component is stable once set
 		const rendered = useMemo(() => {
 			if (!cell.component) {
 				return;
@@ -350,10 +355,7 @@ export const NotebookCell = observer(
 
 				// Handle pixel call errors
 				if (errors?.length) {
-					notification.add({
-						message: errors[0],
-						color: "error",
-					});
+					toast.error(errors[0]);
 					return;
 				}
 
@@ -421,10 +423,7 @@ export const NotebookCell = observer(
 				console.error("Error in makeCellMCP:", error);
 				workspace.setLoading(false);
 
-				notification.add({
-					message: error.message || "Failed to create MCP cell",
-					color: "error",
-				});
+				toast.error(error.message || "Failed to create MCP cell");
 			}
 		};
 
@@ -455,9 +454,7 @@ export const NotebookCell = observer(
 							<button
 								type="button"
 								className="rounded px-1.5 py-0.5 text-muted-foreground text-xs hover:text-foreground"
-								onClick={() =>
-									copyTextToClipboard(rawOutput, notification)
-								}
+								onClick={() => copyTextToClipboard(rawOutput)}
 							>
 								<Copy className="inline size-3" /> Copy
 							</button>
@@ -540,10 +537,7 @@ export const NotebookCell = observer(
 						type="button"
 						className="absolute top-[-12px] left-[calc(theme(spacing.10)+theme(spacing.6))] z-10 cursor-pointer overflow-hidden rounded bg-background px-1.5 py-0.5 text-muted-foreground text-xs transition-colors hover:bg-primary/10"
 						onClick={() =>
-							copyTextToClipboard(
-								`{{${variableName}}}`,
-								notification,
-							)
+							copyTextToClipboard(`{{${variableName}}}`)
 						}
 					>
 						{variableName}
@@ -644,7 +638,6 @@ export const NotebookCell = observer(
 												e.stopPropagation();
 												copyTextToClipboard(
 													`{{${variableName}}}`,
-													notification,
 												);
 											}}
 										>

--- a/packages/client/src/components/notebook/NotebookVariable.tsx
+++ b/packages/client/src/components/notebook/NotebookVariable.tsx
@@ -2,7 +2,6 @@ import { Copy, MoreVertical, Pencil, Sparkles, Trash2 } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useMemo, useState } from "react";
 import { ActionMessages, useBlocks, type Variable } from "@semoss/renderer";
-import { useNotification } from "@semoss/ui";
 import {
 	Button,
 	Dialog,
@@ -18,6 +17,7 @@ import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
+	toast,
 } from "@semoss/ui/next";
 import { useWorkspace } from "@/hooks";
 import { suggestVariableRenames } from "../blocks-workspace/utils";
@@ -67,7 +67,6 @@ interface NotebookTokenProps {
 export const NotebookVariable = observer((props: NotebookTokenProps) => {
 	const { id, variable, engines } = props;
 	const { state } = useBlocks();
-	const notification = useNotification();
 
 	const { workspace } = useWorkspace();
 
@@ -104,17 +103,11 @@ export const NotebookVariable = observer((props: NotebookTokenProps) => {
 				setSuggestedNewName(changes[id]);
 				setIsAutoRenameModalOpen(true);
 			} else {
-				notification.add({
-					color: "warning",
-					message: "No suggestion available for this variable",
-				});
+				toast.warning("No suggestion available for this variable");
 			}
 		} catch (error) {
 			console.error("Error getting suggested changes:", error);
-			notification.add({
-				color: "error",
-				message: "Failed to get variable name suggestion",
-			});
+			toast.error("Failed to get variable name suggestion");
 		} finally {
 			setIsProcessing(false);
 		}
@@ -137,10 +130,9 @@ export const NotebookVariable = observer((props: NotebookTokenProps) => {
 		if (!suggestedNewName) return;
 
 		if (!isValidPythonVariableName(suggestedNewName)) {
-			notification.add({
-				color: "error",
-				message: `Invalid variable name: ${suggestedNewName}. Must start with letter/underscore and contain only letters, numbers, and underscores.`,
-			});
+			toast.error(
+				`Invalid variable name: ${suggestedNewName}. Must start with letter/underscore and contain only letters, numbers, and underscores.`,
+			);
 			return;
 		}
 
@@ -226,24 +218,17 @@ export const NotebookVariable = observer((props: NotebookTokenProps) => {
 			});
 
 			if (success) {
-				notification.add({
-					color: "success",
-					message: `Successfully renamed variable ${id} to ${suggestedNewName}`,
-				});
+				toast.success(
+					`Successfully renamed variable ${id} to ${suggestedNewName}`,
+				);
 				setIsAutoRenameModalOpen(false);
 				setSuggestedNewName("");
 			} else {
-				notification.add({
-					color: "error",
-					message: `Failed to rename variable ${id}`,
-				});
+				toast.error(`Failed to rename variable ${id}`);
 			}
 		} catch (error) {
 			console.error("Error applying rename:", error);
-			notification.add({
-				color: "error",
-				message: "Error applying variable rename",
-			});
+			toast.error("Error applying variable rename");
 		} finally {
 			setIsProcessing(false);
 		}
@@ -256,22 +241,16 @@ export const NotebookVariable = observer((props: NotebookTokenProps) => {
 	const copyAlias = (alias: string) => {
 		try {
 			navigator.clipboard.writeText(`{{${alias}}}`);
-
-			notification.add({
-				color: "success",
-				message: "Successfully copied to clipboard",
-			});
+			toast.success("Successfully copied to clipboard");
 		} catch (e) {
-			notification.add({
-				color: "error",
-				message: e.message,
-			});
+			toast.error(e.message);
 		}
 	};
 
 	/**
 	 * Effects/Memos
 	 */
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — engines shape is stable
 	const getVariableTypeDisplay: string = useMemo(() => {
 		if (
 			variable.type !== "query" &&
@@ -344,10 +323,9 @@ export const NotebookVariable = observer((props: NotebookTokenProps) => {
 													);
 
 												if (!isValidSyntax) {
-													notification.add({
-														color: "error",
-														message: `Unable to rename ${id} to ${newTokenAlias}, due to syntax or a duplicated alias`,
-													});
+													toast.error(
+														`Unable to rename ${id} to ${newTokenAlias}, due to syntax or a duplicated alias`,
+													);
 													return;
 												}
 
@@ -361,14 +339,15 @@ export const NotebookVariable = observer((props: NotebookTokenProps) => {
 														},
 													});
 
-												notification.add({
-													color: success
-														? "success"
-														: "error",
-													message: success
-														? `Successfully renamed variable ${id} to ${newTokenAlias}, remember to save your app.`
-														: `Unable to rename ${id} to ${newTokenAlias}, due to syntax or a duplicated alias`,
-												});
+												if (success) {
+													toast.success(
+														`Successfully renamed variable ${id} to ${newTokenAlias}, remember to save your app.`,
+													);
+												} else {
+													toast.error(
+														`Unable to rename ${id} to ${newTokenAlias}, due to syntax or a duplicated alias`,
+													);
+												}
 
 												setNewTokenAlias(
 													success
@@ -495,10 +474,9 @@ export const NotebookVariable = observer((props: NotebookTokenProps) => {
 										id: id,
 									},
 								});
-								notification.add({
-									color: "warning",
-									message: `Successfully deleted ${id}, please be aware this likely will affect your data notebook.`,
-								});
+								toast.warning(
+									`Successfully deleted ${id}, please be aware this likely will affect your data notebook.`,
+								);
 								setIsDeleteModalOpen(false);
 							}}
 							data-testid={"notebook-variable-delete-confirm-btn"}

--- a/packages/client/src/components/workspace/WorkspaceManager.tsx
+++ b/packages/client/src/components/workspace/WorkspaceManager.tsx
@@ -363,35 +363,6 @@ export const WorkspaceManager: React.FC<WorkspaceManagerProps> = observer(
 											workspace.saveToCache();
 										}}
 										onAction={(action) => {
-											// Prevent collapsing a border panel when clicking its already-selected tab
-											if (
-												action.type ===
-												"FlexLayout_SelectTab"
-											) {
-												const tabId =
-													action.data?.tabNode;
-												const isSelectedBorderTab =
-													model
-														?.getBorderSet()
-														?.getBorders()
-														?.some((border) => {
-															const sel =
-																border.getSelected();
-															if (sel < 0)
-																return false;
-															const children =
-																border.getChildren();
-															return (
-																children[
-																	sel
-																]?.getId() ===
-																tabId
-															);
-														});
-												if (isSelectedBorderTab) {
-													return false;
-												}
-											}
 											const handled = updateModel(action);
 											return !handled ? action : false;
 										}}

--- a/packages/client/src/components/workspace/panels/TerminalPanel.tsx
+++ b/packages/client/src/components/workspace/panels/TerminalPanel.tsx
@@ -2,13 +2,8 @@ import { Code, Terminal as TerminalIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useEffect, useRef, useState } from "react";
 import { runPixel } from "@semoss/sdk/react";
-import {
-	buildTable,
-	Terminal,
-	type TerminalProps,
-	useNotification,
-} from "@semoss/ui";
-import { Button, ToggleGroup, ToggleGroupItem } from "@semoss/ui/next";
+import { buildTable, Terminal, type TerminalProps } from "@semoss/ui";
+import { Button, ToggleGroup, ToggleGroupItem, toast } from "@semoss/ui/next";
 import PythonLogo from "@/assets/img/PYTHON.svg";
 import RLogo from "@/assets/img/R-logo.svg";
 import { useRootStore, useWorkspace } from "@/hooks";
@@ -44,8 +39,6 @@ interface TaskData {
 }
 
 export const TerminalPanel: React.FC = observer(() => {
-	const notification = useNotification();
-
 	const [history, setHistory] = useState<TerminalProps["history"]>([]);
 	const [, setIsLoading] = useState<boolean>(false);
 	const { workspace } = useWorkspace();
@@ -224,17 +217,13 @@ export const TerminalPanel: React.FC = observer(() => {
 						.download(insightId, formatted as string)
 						.then(() => {
 							if (output && response.errors.length === 0) {
-								notification.add({
-									color: "success",
-									message: `file downloaded successfully`,
-								});
+								toast.success("file downloaded successfully");
 							}
 						})
 						.catch(() => {
-							notification.add({
-								color: "error",
-								message: `Error occurred while trying to download`,
-							});
+							toast.error(
+								"Error occurred while trying to download",
+							);
 						});
 				}
 
@@ -256,10 +245,7 @@ export const TerminalPanel: React.FC = observer(() => {
 			// update the history
 			setHistory(updatedHistory);
 		} catch (e) {
-			notification.add({
-				color: "error",
-				message: e,
-			});
+			toast.error(e);
 
 			console.error(e);
 		} finally {

--- a/packages/client/src/utility/general.ts
+++ b/packages/client/src/utility/general.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import { Env } from "@semoss/sdk/react";
+import { toast } from "@semoss/ui/next";
 import type { Role } from "@/types";
 
 /**
@@ -90,19 +91,12 @@ export const formatPermission = (permission: Role | ""): string => {
 /**
  * @desc Copies string to clipboard
  */
-export const copyTextToClipboard = (text: string, notificationService) => {
+export const copyTextToClipboard = (text: string) => {
 	try {
 		navigator.clipboard.writeText(text);
-
-		notificationService.add({
-			color: "success",
-			message: "Successfully copied to clipboard",
-		});
+		toast.success("Successfully copied to clipboard");
 	} catch (e) {
-		notificationService.add({
-			color: "error",
-			message: e.message,
-		});
+		toast.error(e.message);
 	}
 };
 


### PR DESCRIPTION
- Replace all useNotification calls with toast from @semoss/ui/next across 13 files to fix crashes after Notification provider was removed in AppWrapper migration
- Fix stale notification dep in useCallback after hook removal (AddBlocksMenuCard)
- Remove onAction guard that prevented border panel toggle-close (WorkspaceManager)
- Fix info icon alignment in block name labels: Icon font wrapper → inline span
- Replace MUI purple StyledTypography with Tailwind text-foreground in block labels
- Fix data-testId → data-testid in 10 files to silence React DOM prop warnings
- Clean up unused variables (registry, configStore) in AddClientBlockModal