### PR TITLE
fix: allowing percent symbols in Create Agent

### DIFF
--- a/packages/playground/src/stores/chat/chat.store.ts
+++ b/packages/playground/src/stores/chat/chat.store.ts
@@ -364,7 +364,7 @@ export class ChatStore {
 				({ name, id, type }): MCPConfig => ({ name, id, type }),
 			);
 
-			const pixel = `AddWorkspace(name=${JSON.stringify(data.name)}, description=${JSON.stringify(data.description)}, systemPrompt=${JSON.stringify(data.system_prompt)}, mcp=${JSON.stringify(mcp)}, prompts=${JSON.stringify(data.prompts)})`;
+			const pixel = `AddWorkspace(name=${JSON.stringify(data.name)}, description=${JSON.stringify(data.description)}, systemPrompt="<encode>${data.system_prompt}</encode>", mcp=${JSON.stringify(mcp)}, prompts=${JSON.stringify(data.prompts)})`;
 			const { pixelReturn } = await this._actions.run<[string]>(pixel);
 
 			return pixelReturn[0].output;
@@ -388,7 +388,7 @@ export class ChatStore {
 				({ name, id, type }): MCPConfig => ({ name, id, type }),
 			);
 
-			const pixel = `EditWorkspace(workspaceId=${JSON.stringify(workspaceId)},name=${JSON.stringify(data.name)}, description=${JSON.stringify(data.description)}, systemPrompt=${JSON.stringify(data.system_prompt)}, mcp=${JSON.stringify(mcp)}, prompts=${JSON.stringify(data.prompts)})`;
+			const pixel = `EditWorkspace(workspaceId=${JSON.stringify(workspaceId)},name=${JSON.stringify(data.name)}, description=${JSON.stringify(data.description)}, systemPrompt="<encode>${data.system_prompt}</encode>", mcp=${JSON.stringify(mcp)}, prompts=${JSON.stringify(data.prompts)})`;
 			const { pixelReturn } = await this._actions.run<[string]>(pixel);
 
 			// throw errors


### PR DESCRIPTION
## Description
Fixes error on Create Agent page when user enters percent sign (%) in Instructions text area and then submits form

## Changes Made
1. The systemPrompt params in EditWorkspace and AddWorkspace pixel calls in chat.store.ts were changed from JSON.stringify to <encode>...</encode>

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Navigate to Create Agent page
2. Fill out form and add % in the Instructions
3. Submit the form, and it should create the agent successfully

## Notes
<img width="1920" height="1080" alt="Screenshot 2026-04-20 at 10 43 53 PM" src="https://github.com/user-attachments/assets/94f77f72-36d4-41fb-aaeb-2fcf4eb57390" />
