### PR TITLE
feat(renderer): migrate grid blocks to @semoss/ui/next and fix grid block bugs

### DIFF
--- a/libs/renderer/src/components/block-defaults/grid-block/CustomToolbar.tsx
+++ b/libs/renderer/src/components/block-defaults/grid-block/CustomToolbar.tsx
@@ -1,11 +1,16 @@
-import { Tooltip } from "@mui/material";
 import {
 	type GridApi,
 	GridToolbarContainer,
 	GridToolbarFilterButton,
 } from "@mui/x-data-grid";
 import { FileDown } from "lucide-react";
-import { Button } from "@semoss/ui";
+import {
+	Button,
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@semoss/ui/next";
 
 interface CustomToolbarProps {
 	apiRef: React.MutableRefObject<GridApi>;
@@ -28,7 +33,7 @@ export const CustomToolbar = ({
 
 	return (
 		<GridToolbarContainer
-			sx={{
+			style={{
 				padding: "8px",
 				borderBottom: "1px solid rgba(224, 224, 224, 1)",
 				display: "flex",
@@ -38,16 +43,21 @@ export const CustomToolbar = ({
 		>
 			{isBatchingEnabled && <GridToolbarFilterButton />}
 			<div style={{ flex: 1 }} />
-			<Tooltip title="Export CSV">
-				<Button
-					variant="text"
-					size="small"
-					startIcon={<FileDown className="size-4" />}
-					onClick={handleExportClick}
-				>
-					Export
-				</Button>
-			</Tooltip>
+			<TooltipProvider>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={handleExportClick}
+						>
+							<FileDown className="mr-1.5 size-4" />
+							Export
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Export CSV</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>
 		</GridToolbarContainer>
 	);
 };

--- a/libs/renderer/src/components/block-defaults/grid-block/GridBlock.tsx
+++ b/libs/renderer/src/components/block-defaults/grid-block/GridBlock.tsx
@@ -1,4 +1,3 @@
-import { styled } from "@mui/material";
 import { DataGrid, useGridApiRef } from "@mui/x-data-grid";
 import { observer } from "mobx-react-lite";
 import { useEffect, useRef, useState } from "react";
@@ -31,19 +30,6 @@ interface DataImportCellParams {
 
 const DEFAULT_HEIGHT = "300px";
 const DEFAULT_WIDTH = "500px";
-
-const StyledBlock = styled("div")(() => ({
-	display: "flex",
-	flexDirection: "column",
-	minHeight: DEFAULT_HEIGHT,
-	width: DEFAULT_WIDTH,
-}));
-
-const StyledDataGridContainer = styled("div")(() => ({
-	flex: 1,
-	width: "100%",
-	height: "100%",
-}));
 
 export interface HeaderBackgroundSettings {
 	backgroundColor: string;
@@ -218,6 +204,7 @@ export const GridBlock: BlockComponent = observer(({ id }) => {
 	 * Anytime our Frame Headers change, we need to sync our column block data with our source of truth
 	 * This ensures all columns are present, especially important for batching scenarios
 	 */
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — sync only on header list change
 	useEffect(() => {
 		if (!frameHeaders.isLoading && frameHeaders.data.list.length > 0) {
 			// Only sync if columns are empty (initial load)
@@ -232,6 +219,7 @@ export const GridBlock: BlockComponent = observer(({ id }) => {
 	 * Handle data accumulation when batching is enabled
 	 * Also handles filter detection - when filters change, frame key changes and offset resets to 0
 	 */
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — deps use .length to avoid stale closure on full array
 	useEffect(() => {
 		if (!isBatchingEnabled) {
 			if (accumulatedDataRef.current.length > 0) {
@@ -516,7 +504,8 @@ export const GridBlock: BlockComponent = observer(({ id }) => {
 			}
 
 			return (
-				<td
+				// biome-ignore lint/a11y/noStaticElementInteractions: context menu on DataGrid cell — keyboard handled by DataGrid
+				<div
 					onContextMenu={(e) =>
 						handleTableCellOnContextMenu(e, col, params.value)
 					}
@@ -525,7 +514,7 @@ export const GridBlock: BlockComponent = observer(({ id }) => {
 					}}
 				>
 					{params.value}
-				</td>
+				</div>
 			);
 		},
 	}));
@@ -621,8 +610,17 @@ export const GridBlock: BlockComponent = observer(({ id }) => {
 		hasNoRows;
 
 	return (
-		<StyledBlock sx={data.style} {...attrs}>
-			<StyledDataGridContainer>
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				minHeight: DEFAULT_HEIGHT,
+				width: DEFAULT_WIDTH,
+				...data.style,
+			}}
+			{...attrs}
+		>
+			<div style={{ flex: 1, width: "100%", height: "100%" }}>
 				<DataGrid
 					apiRef={apiRef}
 					rows={rows}
@@ -662,12 +660,8 @@ export const GridBlock: BlockComponent = observer(({ id }) => {
 								)
 							: undefined,
 					}}
-					showCellVerticalBorder={
-						data.option?.rowSpanning ? true : false
-					}
-					showColumnVerticalBorder={
-						data.option?.rowSpanning ? true : false
-					}
+					showCellVerticalBorder={!!data.option?.rowSpanning}
+					showColumnVerticalBorder={!!data.option?.rowSpanning}
 					unstable_rowSpanning={data.option?.rowSpanning}
 					sx={{
 						borderRadius: "0",
@@ -685,13 +679,13 @@ export const GridBlock: BlockComponent = observer(({ id }) => {
 						},
 					}}
 				/>
-			</StyledDataGridContainer>
+			</div>
 			<GridBlockContextMenu
 				id={id}
 				frame={frame}
 				contextMenu={contextMenu}
 				onClose={() => setContextMenu(null)}
 			/>
-		</StyledBlock>
+		</div>
 	);
 });

--- a/libs/renderer/src/components/block-defaults/grid-block/GridBlockContextMenu.tsx
+++ b/libs/renderer/src/components/block-defaults/grid-block/GridBlockContextMenu.tsx
@@ -1,5 +1,10 @@
 import { observer } from "mobx-react-lite";
-import { Menu } from "@semoss/ui";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@semoss/ui/next";
 import { useBlock, type useFrame } from "../../../hooks";
 import type { GridBlockDef } from "./GridBlock";
 import type { GridBlockColumn } from "./grid-block.types";
@@ -34,51 +39,51 @@ export const GridBlockContextMenu: React.FC<GridBlockContextMenuProps> =
 			const { data } = useBlock<GridBlockDef>(id);
 
 			return (
-				<Menu
+				<DropdownMenu
 					open={contextMenu !== null}
-					onClose={() => onClose()}
-					anchorReference="anchorPosition"
-					anchorPosition={
-						contextMenu !== null
-							? {
-									top: contextMenu.mouseY,
-									left: contextMenu.mouseX,
-								}
-							: undefined
-					}
+					onOpenChange={(open) => !open && onClose()}
 				>
-					{contextMenu && !data.contextMenu?.hideUnfilter ? (
-						<Menu.Item
-							dense={true}
-							value={"unfilter"}
-							onClick={() => {
-								frame.unfilter();
-								onClose();
+					<DropdownMenuTrigger asChild>
+						<span
+							style={{
+								position: "fixed",
+								top: contextMenu?.mouseY ?? 0,
+								left: contextMenu?.mouseX ?? 0,
+								width: 0,
+								height: 0,
 							}}
-						>
-							Unfilter
-						</Menu.Item>
-					) : null}
-					{contextMenu && !data.contextMenu?.hideFilter ? (
-						<Menu.Item
-							dense={true}
-							value={"filter"}
-							onClick={() => {
-								frame.filter(
-									`SetFrameFilter(${
-										contextMenu.column.selector
-									}==${JSON.stringify(contextMenu.value)})`,
-								);
-								onClose();
-							}}
-						>
-							Filter {contextMenu.column.name} ==
-							{typeof contextMenu.value === "string"
-								? contextMenu.value
-								: JSON.stringify(contextMenu.value)}
-						</Menu.Item>
-					) : null}
-				</Menu>
+						/>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent>
+						{contextMenu && !data.contextMenu?.hideUnfilter ? (
+							<DropdownMenuItem
+								onClick={() => {
+									frame.unfilter();
+									onClose();
+								}}
+							>
+								Unfilter
+							</DropdownMenuItem>
+						) : null}
+						{contextMenu && !data.contextMenu?.hideFilter ? (
+							<DropdownMenuItem
+								onClick={() => {
+									frame.filter(
+										`SetFrameFilter(${
+											contextMenu.column.selector
+										}==${JSON.stringify(contextMenu.value)})`,
+									);
+									onClose();
+								}}
+							>
+								Filter {contextMenu.column.name} =={" "}
+								{typeof contextMenu.value === "string"
+									? contextMenu.value
+									: JSON.stringify(contextMenu.value)}
+							</DropdownMenuItem>
+						) : null}
+					</DropdownMenuContent>
+				</DropdownMenu>
 			);
 		},
 	);

--- a/libs/renderer/src/components/block-defaults/grid-block/GridFooter.tsx
+++ b/libs/renderer/src/components/block-defaults/grid-block/GridFooter.tsx
@@ -1,4 +1,5 @@
-import { Button, CircularProgress } from "@semoss/ui";
+import { Loader2 } from "lucide-react";
+import { Button } from "@semoss/ui/next";
 
 interface GridFooterProps {
 	isBatchingEnabled: boolean;
@@ -25,13 +26,15 @@ export const GridFooter = ({
 			}}
 		>
 			<Button
-				variant="outlined"
-				size="small"
+				variant="outline"
+				size="sm"
 				onClick={onLoadMore}
 				disabled={shouldDisableLoadMore}
-				startIcon={loadingMore ? <CircularProgress size={16} /> : null}
-				sx={{ width: "100%" }}
+				className="w-full"
 			>
+				{loadingMore && (
+					<Loader2 className="mr-1.5 size-4 animate-spin" />
+				)}
 				{loadingMore ? "Loading..." : "Load More"}
 			</Button>
 		</div>

--- a/libs/renderer/src/components/block-defaults/grid-dynamic-frame-block/GridDynamicFrameBlock.tsx
+++ b/libs/renderer/src/components/block-defaults/grid-dynamic-frame-block/GridDynamicFrameBlock.tsx
@@ -1,4 +1,4 @@
-import { styled } from "@mui/material";
+// biome-ignore-all lint/a11y/noStaticElementInteractions: DataGrid renderCell content — keyboard events handled by DataGrid
 import { DataGrid } from "@mui/x-data-grid";
 import { observer } from "mobx-react-lite";
 import { type CSSProperties, useEffect, useState } from "react";
@@ -9,21 +9,6 @@ import type { GridBlockColumn } from "../grid-block/grid-block.types";
 
 const DEFAULT_HEIGHT = "300px";
 const DEFAULT_WIDTH = "500px";
-
-const StyledBlock = styled("div")(() => ({
-	display: "flex",
-	flexDirection: "column",
-	height: DEFAULT_HEIGHT,
-	width: DEFAULT_WIDTH,
-}));
-
-const StyledHeader = styled("div")(({ theme }) => ({
-	padding: theme.spacing(1),
-}));
-
-const StyledRow = styled("div")(({ theme }) => ({
-	padding: theme.spacing(1),
-}));
 
 export interface GridDynamicFrameBlockDef
 	extends BlockDef<"grid-dynamic-frame"> {
@@ -106,6 +91,7 @@ export const GridDynamicFrameBlock: BlockComponent = observer(({ id }) => {
 	/**
 	 * Anytime our Frame Headers, we need to sync our column block data with our source of truth ^
 	 */
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — sync only on header list change
 	useEffect(() => {
 		if (data.columns.length === 0 && !frameHeaders.isLoading) {
 			// If no columns are defined, fetch the frame headers
@@ -165,16 +151,17 @@ export const GridDynamicFrameBlock: BlockComponent = observer(({ id }) => {
 		field: col.name,
 		headerName: col.name,
 		sortable: false,
-		renderHeader: () => <StyledHeader>{col.name}</StyledHeader>,
+		renderHeader: () => <div style={{ padding: "8px" }}>{col.name}</div>,
 		renderCell: (params) => {
 			return (
-				<StyledRow
+				<div
+					style={{ padding: "8px" }}
 					onContextMenu={(e) =>
 						handleTableCellOnContextMenu(e, col, params.value)
 					}
 				>
 					{params.value}
-				</StyledRow>
+				</div>
 			);
 		},
 	}));
@@ -200,14 +187,17 @@ export const GridDynamicFrameBlock: BlockComponent = observer(({ id }) => {
 	};
 
 	return (
-		<StyledBlock sx={data.style} {...attrs}>
-			<div
-				style={{
-					flex: 1,
-					width: "100%",
-					height: "100%",
-				}}
-			>
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				height: DEFAULT_HEIGHT,
+				width: DEFAULT_WIDTH,
+				...data.style,
+			}}
+			{...attrs}
+		>
+			<div style={{ flex: 1, width: "100%", height: "100%" }}>
 				<DataGrid
 					rows={rows}
 					columns={columns}
@@ -245,6 +235,6 @@ export const GridDynamicFrameBlock: BlockComponent = observer(({ id }) => {
 				contextMenu={contextMenu}
 				onClose={() => setContextMenu(null)}
 			/>
-		</StyledBlock>
+		</div>
 	);
 });

--- a/libs/renderer/src/store/state/state.store.ts
+++ b/libs/renderer/src/store/state/state.store.ts
@@ -347,8 +347,10 @@ export class StateStore {
 	 * @returns Updated object
 	 */
 	private updateObjectVariableReferences(
+		// biome-ignore lint/suspicious/noExplicitAny: untyped object tree
 		obj: any,
 		suggestedChanges: Record<string, string>,
+		// biome-ignore lint/suspicious/noExplicitAny: recursive return matches input type
 	): any {
 		if (obj === null || obj === undefined) {
 			return obj;
@@ -452,7 +454,7 @@ export class StateStore {
 				} else if (type === "query") {
 					const query = this._store.queries[pointer];
 					if (query) {
-						if (path.length === 1) {
+						if (!path || path.length === 1) {
 							// Just get query output
 							return query.output;
 						} else {
@@ -472,7 +474,7 @@ export class StateStore {
 					const cell = query.getCell(cellId);
 
 					if (cell) {
-						if (path.length === 1) {
+						if (!path || path.length === 1) {
 							return cell.output;
 						} else {
 							const key = path[1];
@@ -838,7 +840,7 @@ export class StateStore {
 		const pointer = path[0];
 
 		// Special syntax to parse by cell order
-		const isNumber = !isNaN(parseFloat(path[1]));
+		const isNumber = !Number.isNaN(parseFloat(path[1]));
 
 		if (isNumber) {
 			let q: QueryState;
@@ -1022,7 +1024,10 @@ export class StateStore {
 		while (
 			this._store.blocks[
 				`${isCommunityBlock ? "com_" : ""}${widget}--${blockNum}`
-			] || generatedBlockIds.includes(`${isCommunityBlock ? "com_" : ""}${widget}--${blockNum}`)
+			] ||
+			generatedBlockIds.includes(
+				`${isCommunityBlock ? "com_" : ""}${widget}--${blockNum}`,
+			)
 		) {
 			blockNum++;
 		}
@@ -1042,7 +1047,11 @@ export class StateStore {
 		if (json.widget === "page") {
 			return this.generatePageId();
 		}
-		return this.generateNonPageId(json.widget, isCommunityBlock, generatedBlockIds);
+		return this.generateNonPageId(
+			json.widget,
+			isCommunityBlock,
+			generatedBlockIds,
+		);
 	};
 
 	/**
@@ -1059,10 +1068,14 @@ export class StateStore {
 		parent?: Block["parent"],
 	) => {
 		// generate a new id
-		const id = this.generateBlockId(json, isCommunityBlock, generatedBlockIds);
+		const id = this.generateBlockId(
+			json,
+			isCommunityBlock,
+			generatedBlockIds,
+		);
 
 		generatedBlockIds.push(id);
-		
+
 		// create the block
 		const block = {
 			id: id,
@@ -1091,7 +1104,7 @@ export class StateStore {
 		// add the listeners
 		block.listeners = json.listeners;
 
-		if (!json["parent"] && parent) {
+		if (!json.parent && parent) {
 			block.parent = parent;
 		}
 
@@ -1102,7 +1115,7 @@ export class StateStore {
 					name: slot,
 					children: (Array.isArray(json.slots[slot])
 						? json.slots[slot]
-						: json.slots[slot]["children"]
+						: json.slots[slot].children
 					).map((child) => {
 						// form the parent object
 						const parent = { id: id, slot: slot };
@@ -1138,7 +1151,7 @@ export class StateStore {
 			if (currentBlock.widget === "iteration") {
 				return currentBlock;
 			}
-			if (currentBlock.parent && currentBlock.parent.id) {
+			if (currentBlock.parent?.id) {
 				currentBlock = this._store.blocks[currentBlock.parent.id];
 			} else {
 				break;
@@ -1419,7 +1432,12 @@ export class StateStore {
 		}
 		const generatedBlockIds = [];
 		// generate the block
-		const block = this.generateBlock(json, isCommunity, {}, generatedBlockIds);
+		const block = this.generateBlock(
+			json,
+			isCommunity,
+			{},
+			generatedBlockIds,
+		);
 
 		// try to place it if position
 		if (!position) {
@@ -1680,7 +1698,7 @@ export class StateStore {
 
 		// Find the next available slot number
 		const slotNames = Object.keys(block.slots)
-			.filter((name) => !isNaN(Number(name)))
+			.filter((name) => !Number.isNaN(Number(name)))
 			.map((name) => Number(name))
 			.sort((a, b) => a - b);
 
@@ -1710,7 +1728,7 @@ export class StateStore {
 
 		// Convert slot names to array and sort them numerically
 		const slotNames = Object.keys(block.slots)
-			.filter((name) => !isNaN(Number(name)))
+			.filter((name) => !Number.isNaN(Number(name)))
 			.map((name) => Number(name))
 			.sort((a, b) => a - b);
 
@@ -1832,7 +1850,7 @@ export class StateStore {
 	private runQuery = (
 		queryId: string,
 		type?: "sync" | "async",
-	): void | Promise<boolean> => {
+	): undefined | Promise<boolean> => {
 		const q = this._store.queries[queryId];
 
 		const key = `query--${queryId};`;
@@ -1864,7 +1882,7 @@ export class StateStore {
 			return p.promise;
 		} else {
 			p.promise
-				.then((resp) => {
+				.then((_resp) => {
 					// noop
 				})
 				.catch((e) => {
@@ -1981,7 +1999,7 @@ export class StateStore {
 		queryId: string,
 		cellId: string,
 		type?: string,
-	): void | Promise<boolean> => {
+	): undefined | Promise<boolean> => {
 		const q = this._store.queries[queryId];
 		const c = q.getCell(cellId);
 
@@ -2017,7 +2035,7 @@ export class StateStore {
 			return p.promise;
 		} else {
 			p.promise
-				.then((resp) => {
+				.then((_resp) => {
 					// noop
 				})
 				.catch((e) => {
@@ -2063,7 +2081,7 @@ export class StateStore {
 
 				if (appPageMatch || sharePageMatch) {
 					const base = appPageMatch
-						? appPageMatch[0] + "/view"
+						? `${appPageMatch[0]}/view`
 						: sharePageMatch[0]; // This will be either #/s/:id/ or #/:id/view
 
 					const pageBlocks = this.getAllBlocksOfType("page");
@@ -2075,7 +2093,7 @@ export class StateStore {
 					if (urlPageRouteMatch) {
 						const newHash = destination.startsWith("/")
 							? base.replace(/\/$/, "") + destination
-							: base.replace(/\/$/, "") + "/" + destination; // Avoid double slashes
+							: `${base.replace(/\/$/, "")}/${destination}`; // Avoid double slashes
 
 						window.location.hash = newHash;
 					}
@@ -2119,13 +2137,13 @@ export class StateStore {
 		const token = { type };
 
 		if (to) {
-			token["to"] = to;
+			token.to = to;
 		}
 		if (cellId) {
-			token["cellId"] = cellId;
+			token.cellId = cellId;
 		}
 		if (value) {
-			token["value"] = value;
+			token.value = value;
 		}
 
 		this._store.variables[id] = token as Variable;
@@ -2208,12 +2226,12 @@ export class StateStore {
 	private buildCommunityBlockPreDeps = (json) => {
 		let newJson = json;
 		let variablesList = [];
-		if (json["queries"] || json["variables"]) {
+		if (json.queries || json.variables) {
 			const { placeholderJson, variableStack } =
 				this.dispatchDependencyQueriesAndVars(
 					json,
-					json["queries"],
-					json["variables"],
+					json.queries,
+					json.variables,
 				);
 			newJson = placeholderJson;
 			variablesList = variableStack;

--- a/packages/client/src/components/blocks-workspace/blocks/settings/custom/grid-two/GridBlockTool.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/settings/custom/grid-two/GridBlockTool.tsx
@@ -174,8 +174,6 @@ export const GridBlockTool = observer<GridBlockToolProps>(({ id }) => {
 					{selectedList === "export" && (
 						<div className="block w-full px-4 py-2">
 							<div className="flex items-center gap-2 pl-3">
-								{/* biome-ignore lint/suspicious/noCommentText: JSX comment in text node */}
-								// biome-ignore
 								{/* biome-ignore lint/correctness/useUniqueElementIds: component-scoped id */}
 								<Checkbox
 									id="enable-export"


### PR DESCRIPTION
- Migrate CustomToolbar, GridBlock, GridBlockContextMenu, GridFooter, GridDynamicFrameBlock from @semoss/ui/@mui/material to @semoss/ui/next
- Fix context menu: wrap anchor span in DropdownMenuTrigger so Radix positions correctly
- Fix tooltip: wrap CustomToolbar export button in TooltipProvider
- Fix renderCell: replace <td> with <div> to avoid invalid DOM nesting in DataGrid
- Fix getVariable crash: add !path guard in query/cell branches of StateStore
- Fix GridBlockTool: remove stray biome-ignore text node rendered in JSX