### PR TITLE
feat(client): migrate designer components to @semoss/ui/next and lucide-react

### DIFF
--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/form-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/form-block/config.tsx
@@ -1,7 +1,17 @@
 import { HighlightAlt } from "@mui/icons-material";
 import { observer } from "mobx-react-lite";
-import { useBlocks } from "@semoss/renderer";
-import { ContainerLayoutSettings, SelectSettings } from "../../settings";
+import { useMemo } from "react";
+import { ActionMessages, useBlocks } from "@semoss/renderer";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@semoss/ui/next";
+import { usePixel } from "@/hooks";
+import { ContainerLayoutSettings } from "../../settings";
+import { BaseSettingSection } from "../../settings/BaseSettingSection";
 import { SelectInputSettings } from "../../settings/shared/SelectInputSettings";
 import { SizeSettings } from "../../settings/shared/SizeSettings";
 import { BLOCK_TYPE_LAYOUT } from "../block-defaults.constants";
@@ -20,11 +30,62 @@ const FormLayoutSettings = observer(({ id }: { id: string }) => {
 	const { state } = useBlocks();
 	const block = state.getBlock(id);
 
-	// Default to empty so "manual" is NOT selected
 	const type = block?.data?.type || "";
-	console.log(type, "type");
-
 	const isManual = type === "manual";
+	const selectedDatabase = (block?.data?.database as string) || "";
+
+	const getEngines =
+		usePixel<
+			{ engine_id: string; engine_name: string; engine_type: string }[]
+		>(`MyEngines();`);
+
+	const selectedTable = (block?.data?.table as string) || "";
+
+	const getTables = usePixel<{
+		nodes: { conceptualName: string; propSet: string[] }[];
+	}>(
+		selectedDatabase
+			? `GetDatabaseMetamodel(database=["${selectedDatabase}"], options=[]);`
+			: "",
+	);
+
+	const databases = useMemo(() => {
+		if (
+			getEngines.status !== "SUCCESS" ||
+			!Array.isArray(getEngines.data)
+		) {
+			return [];
+		}
+		return getEngines.data
+			.filter((e) => e.engine_type === "DATABASE")
+			.map((e) => ({
+				id: e.engine_id,
+				name: e.engine_name.replace(/_/g, " "),
+			}));
+	}, [getEngines.status, getEngines.data]);
+
+	const tableOptions = useMemo(() => {
+		if (getTables.status !== "SUCCESS" || !getTables.data?.nodes) {
+			return [];
+		}
+		return getTables.data.nodes.map((n) => ({
+			value: n.conceptualName,
+			display: n.conceptualName,
+		}));
+	}, [getTables.status, getTables.data]);
+
+	const columnOptions = useMemo(() => {
+		if (getTables.status !== "SUCCESS" || !getTables.data?.nodes) {
+			return [];
+		}
+		const node = getTables.data.nodes.find(
+			(n) => n.conceptualName === selectedTable,
+		);
+		return (node?.propSet ?? []).map((col) => ({
+			value: col,
+			display: col,
+		}));
+	}, [getTables.status, getTables.data, selectedTable]);
 
 	return (
 		<div>
@@ -41,42 +102,71 @@ const FormLayoutSettings = observer(({ id }: { id: string }) => {
 				]}
 			/>
 
-			{/* Hide only when user explicitly picks Manual */}
 			{!isManual && (
 				<>
-					<SelectInputSettings
-						id={id}
-						path="database"
-						label="Select Database"
-						options={[
-							{ value: "manual", display: "Manual" },
-							{ value: "create", display: "Create" },
-							{ value: "read", display: "Read" },
-							{ value: "update", display: "Update" },
-							{ value: "delete", display: "Delete" },
-						]}
-					/>
+					<BaseSettingSection label="Select Database">
+						<Select
+							value={selectedDatabase || "__none__"}
+							onValueChange={(val) => {
+								const next = val === "__none__" ? "" : val;
+								state.dispatch({
+									message: ActionMessages.SET_BLOCK_DATA,
+									payload: {
+										id,
+										path: "database",
+										value: next,
+									},
+								});
+								if (!next) {
+									state.dispatch({
+										message: ActionMessages.SET_BLOCK_DATA,
+										payload: {
+											id,
+											path: "table",
+											value: "",
+										},
+									});
+								}
+							}}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder="Select database..." />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="__none__">None</SelectItem>
+								{databases.map((db) => (
+									<SelectItem key={db.id} value={db.id}>
+										<span className="flex flex-col text-left">
+											<span>{db.name}</span>
+											<span className="text-[11px] text-muted-foreground">
+												id: {db.id}
+											</span>
+										</span>
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</BaseSettingSection>
 
-					<SelectInputSettings
-						id={id}
-						path="table"
-						label="Select Table"
-						options={[
-							{ value: "manual", display: "Manual" },
-							{ value: "create", display: "Create" },
-							{ value: "read", display: "Read" },
-							{ value: "update", display: "Update" },
-							{ value: "delete", display: "Delete" },
-						]}
-					/>
+					{selectedDatabase && (
+						<SelectInputSettings
+							id={id}
+							path="table"
+							label="Select Table"
+							options={tableOptions}
+							allowUnset
+						/>
+					)}
 
-					<SelectSettings
-						id={id}
-						path="column"
-						label="Select Column"
-						options={["GET", "POST", "PUT"]}
-						multiple={true}
-					/>
+					{selectedTable && (
+						<SelectInputSettings
+							id={id}
+							path="column"
+							label="Select Column"
+							options={columnOptions}
+							allowUnset
+						/>
+					)}
 				</>
 			)}
 		</div>

--- a/packages/client/src/components/blocks-workspace/blocks/settings/shared/SelectInputSettings.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/settings/shared/SelectInputSettings.tsx
@@ -161,10 +161,9 @@ export const SelectInputSettings = observer(
 					></input>
 				) : (
 					<Select
-						value={value}
+						value={value || (allowUnset ? "__none__" : value)}
 						onValueChange={(val) => {
-							// sync the data on change
-							onChange(val);
+							onChange(val === "__none__" ? "" : val);
 						}}
 					>
 						<SelectTrigger
@@ -177,9 +176,7 @@ export const SelectInputSettings = observer(
 						</SelectTrigger>
 						<SelectContent>
 							{allowUnset ? (
-								<SelectItem value="">
-									<em>None</em>
-								</SelectItem>
+								<SelectItem value="__none__">None</SelectItem>
 							) : null}
 							{Array.from(options, (option, _i) => {
 								return (

--- a/packages/client/src/components/designer/AddBlocksMenuCard.tsx
+++ b/packages/client/src/components/designer/AddBlocksMenuCard.tsx
@@ -1,21 +1,14 @@
-import {
-	DeleteOutline,
-	InfoOutlined,
-	ReportRounded,
-} from "@mui/icons-material";
+import { AlertTriangle, Info, Trash2 } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useCallback, useEffect, useState } from "react";
 import { ActionMessages, INPUT_BLOCK_TYPES, useBlocks } from "@semoss/renderer";
 import {
-	Box,
-	ButtonGroup,
-	Card,
-	IconButton,
-	Stack,
-	styled,
 	Tooltip,
-} from "@semoss/ui";
-import { toast } from "@semoss/ui/next";
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+	toast,
+} from "@semoss/ui/next";
 import { useDesigner, useRootStore } from "@/hooks";
 import type {
 	BlockLocalStorageData,
@@ -25,53 +18,6 @@ import { BlockCardContent } from "./BlockMenuCardContent";
 
 const addBlocksCardWidth = "120px";
 const addBlocksCardHeight = "94px";
-
-const StyledCard = styled(Card)({
-	cursor: "grab",
-	border: `1px solid rgba(0, 0, 0, 0.12)`,
-	borderRadius: "6px",
-	justifyContent: "center",
-});
-
-const StyledDiv = styled("div")({
-	position: "relative",
-	display: "inline-block",
-	paddingTop: "6px",
-	paddingRight: "6px",
-});
-
-const StyledContainer = styled(Box)({
-	position: "absolute",
-	top: 10,
-	right: -24,
-	zIndex: 1000,
-	display: "flex",
-	flexDirection: "column",
-	gap: 1,
-	backgroundColor: "#fff",
-	borderRadius: "8px",
-	p: 0.5,
-});
-
-const StyleButtonGroup = styled(ButtonGroup)(({ theme }) => ({
-	display: "flex",
-	gap: theme.spacing(1),
-	flexDirection: "column",
-	backgroundColor: "white",
-	padding: theme.spacing(1),
-	borderRadius: "6px",
-	boxShadow:
-		"0px 5px 22px rgba(0, 0, 0, 0.10), 0px 4px 4px 0.5px rgba(0, 0, 0, 0.03)",
-	width: "35px",
-	"& .MuiButtonBase-root.MuiButton-root": {
-		justifyContent: "unset",
-	},
-}));
-
-const StyledButtonGroupIconButton = styled(IconButton)(({ theme }) => ({
-	backgroundColor: "white",
-	borderRadius: theme.shape.borderRadius,
-}));
 
 export interface AddBlocksMenuItemProps {
 	/** Item that can be dragged onto the block */
@@ -87,28 +33,18 @@ export interface AddBlocksMenuItemProps {
 	handleOnEditClick: (blockId: string, item: DesignerMenuItem) => void;
 }
 
-/**
- * Individaul block that can be dragged onto the UI
- */
 export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 	const { item, isCommunity, handleOnTrashClick } = props;
 	const { state } = useBlocks();
 	const { designer } = useDesigner();
 	const { configStore } = useRootStore();
 
-	const [imageSrc, _setImageSrc] = useState(null);
+	const [_imageSrc, _setImageSrc] = useState(null);
 
-	// track if it is this one that is dragging
 	const [local, setLocal] = useState(false);
-
-	// track if this is being hovered
 	const [hovered, setHovered] = useState<boolean>(false);
 
-	/**
-	 * Handle the mousedown on the widget.
-	 */
 	const handleMouseDown = () => {
-		// set the dragged
 		designer.activateDrag(
 			item.json.widget,
 			() => {
@@ -118,28 +54,18 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 			item.hoverImage,
 		);
 
-		// clear the hovered
 		designer.setHovered("");
-
-		// clear the selected
 		designer.setSelected("");
-
-		// set as inactive
 		setLocal(true);
 	};
 
-	/**
-	 * Handle the mouseup event on the document
-	 */
 	const handleDocumentMouseUp = useCallback(async () => {
 		if (!designer.drag.active) {
 			return;
 		}
 
-		// ID of newly added block
 		let id = "";
 
-		// put a placeholder action to check if it is valid
 		const placeholderAction = designer.drag.placeholderAction;
 		if (!placeholderAction || !placeholderAction.id) {
 			designer.deactivateDrag();
@@ -149,7 +75,6 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 			return;
 		}
 
-		// Track block in session storage
 		localStorage.setItem(
 			"blocks--frequently-used",
 			(() => {
@@ -167,10 +92,8 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 			})(),
 		);
 
-		// apply the action
 		const sw = state.getBlock(placeholderAction.id);
 
-		// Safely get the block associated with the placeholder action
 		if (!sw) {
 			designer.deactivateDrag();
 			designer.setHovered("");
@@ -178,8 +101,6 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 			setLocal(false);
 			return;
 		}
-
-		// TODO: Add logic to prevent adding block it iter block if one is already present
 
 		if (sw.widget === "iteration") {
 			if (sw.slots.children.children.length) {
@@ -258,8 +179,6 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 			}
 		}
 
-		// TODO: REFACTOR
-		// Add variables for all blocks that are inputs from user
 		if (INPUT_BLOCK_TYPES.indexOf(item.json.widget) > -1 && !isCommunity) {
 			await state.dispatch({
 				message: ActionMessages.ADD_VARIABLE,
@@ -271,19 +190,10 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 			});
 		}
 
-		// clear the drag
 		designer.deactivateDrag();
-
-		// clear the hovered
 		designer.setHovered("");
-
-		// clear the selected
 		designer.setSelected(id ? id : "");
-
-		// clear the selectedBlocks
 		designer.addBlockToSelected("clear");
-
-		// set as active
 		setLocal(false);
 	}, [
 		item.name,
@@ -295,7 +205,6 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 		state,
 	]);
 
-	// add the mouse up listener when dragged
 	useEffect(() => {
 		if (!designer.drag.active || !local) {
 			return;
@@ -309,102 +218,103 @@ export const AddBlocksMenuCard = observer((props: AddBlocksMenuItemProps) => {
 	}, [designer.drag.active, local, handleDocumentMouseUp]);
 
 	return (
-		<Stack
-			spacing={0.25}
-			alignItems="center"
-			height="100%"
-			justifyContent="flex-end"
-		>
+		<div className="flex h-full flex-col items-center justify-end gap-1">
 			<div
 				className="flex select-none flex-wrap items-center justify-center gap-1 text-center font-medium text-foreground text-xs"
 				style={{ width: addBlocksCardWidth, overflowWrap: "anywhere" }}
 			>
 				{item.name}
 				{item.recentChanges && (
-					<Tooltip title={item.recentChanges}>
-						<span
-							style={{
-								display: "inline-flex",
-								alignItems: "center",
-							}}
-						>
-							<InfoOutlined fontSize="small" color="info" />
-						</span>
-					</Tooltip>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span className="inline-flex items-center">
+									<Info className="size-4 text-blue-500" />
+								</span>
+							</TooltipTrigger>
+							<TooltipContent>
+								{item.recentChanges}
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
 				)}
 				{item.isBeta && (
-					<Tooltip title={"This block is currently in beta"}>
-						<span
-							style={{
-								display: "inline-flex",
-								alignItems: "center",
-							}}
-						>
-							<ReportRounded fontSize="small" color="warning" />
-						</span>
-					</Tooltip>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span className="inline-flex items-center">
+									<AlertTriangle className="size-4 text-amber-500" />
+								</span>
+							</TooltipTrigger>
+							<TooltipContent>
+								This block is currently in beta
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
 				)}
 			</div>
-			<StyledDiv
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: drag container — keyboard drag not applicable */}
+			<div
+				className="relative inline-block pt-1.5 pr-1.5"
 				onMouseEnter={() => setHovered(true)}
 				onMouseLeave={() => setHovered(false)}
 				onMouseDown={handleMouseDown}
 			>
-				{/* TODO: FIX */}
 				{hovered && isCommunity && configStore.store.user.admin && (
-					<StyledContainer>
-						<StyleButtonGroup>
-							{/* <StyledButtonGroupIconButton
-                                size="small"
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    handleOnEditClick(item['id'], item);
-                                }}
-                            >
-                                <EditOutlined sx={{ color: '#757575' }} />
-                            </StyledButtonGroupIconButton> */}
-							<StyledButtonGroupIconButton
-								size="small"
-								onClick={(e) => {
-									e.stopPropagation();
-									handleOnTrashClick(
-										item.id ?? "",
-										item.name,
-									);
-								}}
-							>
-								<DeleteOutline sx={{ color: "#757575" }} />
-							</StyledButtonGroupIconButton>
-						</StyleButtonGroup>
-					</StyledContainer>
+					<div
+						className="-right-6 absolute top-2.5 z-[1000] flex flex-col gap-1 rounded-lg bg-white p-2"
+						style={{
+							boxShadow:
+								"0px 5px 22px rgba(0, 0, 0, 0.10), 0px 4px 4px 0.5px rgba(0, 0, 0, 0.03)",
+						}}
+					>
+						<button
+							type="button"
+							className="flex size-8 items-center justify-center rounded hover:bg-accent"
+							onClick={(e) => {
+								e.stopPropagation();
+								handleOnTrashClick(item.id ?? "", item.name);
+							}}
+						>
+							<Trash2 className="size-4 text-[#757575]" />
+						</button>
+					</div>
 				)}
 
-				{/* Card */}
-				<StyledCard>
-					<Tooltip
-						title={item.helperText ?? item.name}
-						arrow
-						placement="bottom"
-					>
-						<div>
-							<BlockCardContent
-								image={
-									isCommunity
-										? imageSrc
-										: hovered
-											? item.hoverImage
-											: item.activeImage
-								}
-								name={item.name}
-								width={addBlocksCardWidth}
-								height={addBlocksCardHeight}
-								paddingX={0.75}
-								paddingY={1}
-							/>
-						</div>
-					</Tooltip>
-				</StyledCard>
-			</StyledDiv>
-		</Stack>
+				<div
+					className="cursor-grab rounded-md border transition-colors"
+					style={{
+						justifyContent: "center",
+						borderColor: hovered
+							? "var(--primary)"
+							: "var(--border)",
+					}}
+				>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<div>
+									<BlockCardContent
+										image={
+											isCommunity
+												? undefined
+												: item.activeImage
+										}
+										name={item.name}
+										width={addBlocksCardWidth}
+										height={addBlocksCardHeight}
+										paddingX={0.75}
+										paddingY={1}
+									/>
+								</div>
+							</TooltipTrigger>
+							<TooltipContent>
+								{item.helperText ?? item.name}
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				</div>
+			</div>
+		</div>
 	);
 });

--- a/packages/client/src/components/designer/AddClientBlockModal.tsx
+++ b/packages/client/src/components/designer/AddClientBlockModal.tsx
@@ -1,56 +1,32 @@
-import { ArrowBack, Close, PreviewOutlined } from "@mui/icons-material";
 import html2canvas from "html2canvas";
+import { ArrowLeft, Eye, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useBlocks } from "@semoss/renderer";
 import {
-	Autocomplete,
-	Box,
 	Button,
-	IconButton,
-	Modal,
-	styled,
-	TextField,
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Input,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
 	Tooltip,
-	Typography,
-} from "@semoss/ui";
-import { toast } from "@semoss/ui/next";
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+	toast,
+} from "@semoss/ui/next";
 import { useRootStore } from "@/hooks";
 import { getBlockElement } from "@/stores";
 import { SECTION_ORDER } from "../blocks-workspace/menus/default-menu";
 import type { DesignerMenuItem } from "../blocks-workspace/menus/menu-types";
 import { CommunityLayers } from "./CommunityLayers";
-
-const StyledModalHeading = styled(Modal.Title)({
-	display: "flex",
-	justifyContent: "space-between",
-	alignItems: "center",
-});
-
-const StyledTitle = styled(Typography)({
-	fontWeight: 500,
-});
-
-const StyledModalContent = styled(Modal.Content)(({ theme }) => ({
-	display: "flex",
-	flexDirection: "column",
-	gap: theme.spacing(2),
-	paddingTop: `${theme.spacing(1)}!important`,
-	width: "100%",
-}));
-
-const StyledButtonGroupIconButton = styled(IconButton)(({ theme }) => ({
-	backgroundColor: "white",
-	borderRadius: theme.shape.borderRadius,
-	color: theme.palette.primary.dark,
-	alignSelf: "flex-start",
-	fontSize: theme.typography.pxToRem(16),
-	fontWeight: 500,
-	"&:hover": {
-		backgroundColor: "transparent",
-	},
-	padding: "0px",
-}));
 
 interface EditDetailsModalProps {
 	isOpen: boolean;
@@ -135,40 +111,29 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 		}));
 	};
 
-	/**
-	 * Recursively processes the slots of a block to retain only the allowed keys.
-	 *
-	 * @param value - The slots or part of slots to process.
-	 * @param blocks - The entire blocks object for reference.
-	 */
 	// biome-ignore lint/suspicious/noExplicitAny: recursive slot structure is untyped
 	const processSlots = (value: any, blocks: Record<string, any>): any => {
-		// Check if the current value is an array
 		if (Array.isArray(value)) {
-			return value.map(
-				(item) =>
-					// If the item is a string and exists in blocks, process it
-					typeof item === "string" && item in blocks
-						? Object.fromEntries(
-								allowedKeys
-									.filter((key) => key in blocks[item]) // Filter allowed keys
-									.map((key) => [
-										key,
-										processSlots(blocks[item][key], blocks),
-									]), // Process each key recursively
-							)
-						: processSlots(item, blocks), // Recursively process item if not a string or not in blocks
+			return value.map((item) =>
+				typeof item === "string" && item in blocks
+					? Object.fromEntries(
+							allowedKeys
+								.filter((key) => key in blocks[item])
+								.map((key) => [
+									key,
+									processSlots(blocks[item][key], blocks),
+								]),
+						)
+					: processSlots(item, blocks),
 			);
-			// Check if the current value is an object
 		} else if (typeof value === "object" && value !== null) {
 			return Object.fromEntries(
 				Object.entries(value).map(([key, val]) => [
 					key,
-					processSlots(val, blocks), // Recursively process each entry
+					processSlots(val, blocks),
 				]),
 			);
 		} else {
-			// Return value if it's neither an array nor an object
 			return value;
 		}
 	};
@@ -184,7 +149,6 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 
 		const mustacheRE = /{{\s*([^{}\s]+?)\s*}}/g;
 
-		/** push-based walk = no recursion, cycle-safe */
 		// biome-ignore lint/suspicious/noExplicitAny: generic walk over untyped block tree
 		function walk(root: any) {
 			const seen = new WeakSet<object>();
@@ -195,16 +159,13 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 				const node = stack.pop();
 				if (node == null) continue;
 
-				/* ---------- arrays ---------- */
 				if (Array.isArray(node)) {
 					for (let i = node.length - 1; i >= 0; --i)
 						stack.push(node[i]);
 					continue;
 				}
 
-				/* ---------- objects ---------- */
 				if (typeof node === "object") {
-					// avoid revisiting the same object (break cycles)
 					if (seen.has(node)) continue;
 					seen.add(node);
 
@@ -216,10 +177,8 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 						// biome-ignore lint/suspicious/noExplicitAny: untyped node
 						(node as any).id;
 
-					// query found, maybe add
 					if (typeof queryId === "string") qIds.add(queryId);
 
-					// NEW LOGIC — check for { queryId, cellId }
 					if (
 						node.payload &&
 						typeof node.payload.queryId === "string" &&
@@ -234,17 +193,15 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 						}
 					}
 
-					// enqueue own values
 					for (const v of Object.values(node)) stack.push(v);
 					continue;
 				}
 
-				/* ---------- strings ---------- */
 				if (typeof node === "string") {
 					let m: RegExpExecArray | null;
 					// biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop pattern
 					while ((m = mustacheRE.exec(node))) {
-						const rootId = m[1].split(".")[0]; // trim .prop chain
+						const rootId = m[1].split(".")[0];
 						if (rootId in allQueries) qIds.add(rootId);
 						if (rootId in allVariables) vIds.add(rootId);
 					}
@@ -252,10 +209,8 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 			}
 		}
 
-		/* pass #1 – widget tree */
 		walk(blocks);
 
-		/* pass #2 – transitive scan of every used query */
 		const processed = new Set<string>();
 		const queue = Array.from(qIds);
 
@@ -266,17 +221,15 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 			processed.add(qId);
 
 			const qObj = allQueries[qId];
-			if (!qObj) continue; // missing def – ignore
+			if (!qObj) continue;
 
-			walk(qObj); // scan its internals
+			walk(qObj);
 
-			// if walk() encountered further queries, they’re now in qIds
 			for (const id of qIds) {
 				if (!processed.has(id)) queue.push(id);
 			}
 		}
 
-		/* shape the result */
 		const queries: Dict = {};
 		const variables: Dict = {};
 
@@ -290,18 +243,6 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 		return { queries, variables };
 	};
 
-	/**
-	 * This function is a wrapper around the useForm's handleSubmit function.
-	 * It processes the block's slots to remove any unnecessary keys and
-	 * recursively calls itself until all the slots are processed.
-	 *
-	 * Once the slots are processed, it calls the monolith's AddBlock query to
-	 * add the block to the monolith's database.
-	 *
-	 * @param {AddAsClientBlockTypes} data - The data to be sent to the monolith.
-	 *
-	 * @returns {Promise<void>}
-	 */
 	const handleAddAsClientBlock = handleSubmit(
 		async (data: AddAsClientBlockTypes) => {
 			const block = state.blocks[selected];
@@ -326,9 +267,7 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 			const response = await monolithStore.runQuery<[true]>(
 				`AddBlock(name=["${data.name}"], section=["${
 					data.section
-				}"], json=["<encode>${JSON.stringify(
-					newClientBlock,
-				)}</encode>"]);`,
+				}"], json=["<encode>${JSON.stringify(newClientBlock)}</encode>"]);`,
 			);
 			const { output, operationType } = response.pixelReturn[0];
 
@@ -345,50 +284,10 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 	);
 
 	const handleSaveAsClientBlock = async () => {
-		const itemToSave = localBlockItem;
-		if (!itemToSave) return;
-		const _updatedClientBlock = {
-			widget: itemToSave.json?.widget,
-			data: itemToSave.json?.data,
-			listeners: itemToSave.json?.listeners,
-			slots: itemToSave.json?.slots,
-		};
-		// try {
-		//     const response = await monolithStore.runQuery<[true]>(
-		//         `AddBlock(name=["${itemToSave.name}"], section=["${
-		//             itemToSave.section
-		//         }"], helperText=["${
-		//             itemToSave.helperText
-		//         }"], json=["<encode>${JSON.stringify(
-		//             updatedClientBlock,
-		//         )}</encode>"]);`,
-		//     );
-
-		//     console.log('Save response:', response);
-		//     const { output, operationType } = response.pixelReturn[0];
-
-		//     if (operationType.indexOf('ERROR') === -1) {
-		//         notification.add({
-		//             color: 'success',
-		//             message: 'Successfully saved updated block',
-		//         });
-		//     } else {
-		//         notification.add({
-		//             color: 'error',
-		//             message: output,
-		//         });
-		//     }
-		// } catch (error) {
-		//     console.error('Save error:', error);
-		//     notification.add({
-		//         color: 'error',
-		//         message: 'Error occurred while saving block',
-		//     });
-		// }
-		// reset(AddAsClientBlock);
 		onClose();
 		setShowPreviewModal(false);
 	};
+
 	const handleInputValidations = (val: string, _field: string) => {
 		if (!/^[a-zA-Z_-]*$/.test(val)) {
 			return false;
@@ -396,13 +295,11 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 		return true;
 	};
 
-	/** html2canvas to PNG conversion */
 	const handleCanvasPreview = async () => {
 		const block = state.blocks[selected];
 		if (block?.id) {
 			const element = getBlockElement(block.id) as HTMLElement;
 			if (element) {
-				// Capture the element's dimensions
 				const elementWidth = element.offsetWidth;
 				const elementHeight = element.offsetHeight;
 
@@ -413,14 +310,9 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 					const dataUrl = canvas.toDataURL("image/png");
 					console.log("Generated Image:", dataUrl);
 
-					// Scale the dimensions to be 1/2 of the original size
-					const scaledWidth = elementWidth / 2;
-					const scaledHeight = elementHeight / 2;
-
-					// Set the scaled dimensions
 					setImageDimensions({
-						width: scaledWidth,
-						height: scaledHeight,
+						width: elementWidth / 2,
+						height: elementHeight / 2,
 					});
 					setImagePreview(dataUrl);
 					setShowPreviewModal(true);
@@ -442,257 +334,235 @@ export const AddClientBlockModal = (props: EditDetailsModalProps) => {
 	};
 
 	const handleArrowBack = () => {
-		setShowPreviewModal(false); // Close the second modal and show the first modal
+		setShowPreviewModal(false);
 	};
 
 	return (
 		<>
-			<Modal open={isOpen && !showPreviewModal} fullWidth>
-				<StyledModalHeading>
-					<StyledTitle variant="h6">
-						{isEdit ? "Edit Block" : "Add Block"}
-					</StyledTitle>
-					<IconButton size="small" onClick={handleCloseModals}>
-						<Close />
-					</IconButton>
-				</StyledModalHeading>
-
-				<StyledModalContent>
-					{isEdit && (
-						<Box sx={{ gap: "8px" }}>
-							<Typography
-								variant="subtitle1"
-								color="text.secondary"
+			<Dialog
+				open={isOpen && !showPreviewModal}
+				onOpenChange={(open) => !open && handleCloseModals()}
+			>
+				<DialogContent showCloseButton={false}>
+					<DialogHeader>
+						<div className="flex items-center justify-between">
+							<DialogTitle>
+								{isEdit ? "Edit Block" : "Add Block"}
+							</DialogTitle>
+							<button
+								type="button"
+								className="flex size-8 items-center justify-center rounded hover:bg-accent"
+								onClick={handleCloseModals}
 							>
-								Block Template
-							</Typography>
-							<CommunityLayers
-								item={localBlockItem}
-								onJsonUpdate={handleLayersPanelUpdate}
-							/>
-						</Box>
-					)}
-					<Controller
-						name="name"
-						control={control}
-						render={({ field }) => {
-							return (
-								<Box sx={{ gap: "8px" }}>
-									<Typography
-										variant="subtitle1"
-										color="text.secondary"
-									>
-										Block Name
-									</Typography>
-									<TextField
-										value={field.value}
-										onChange={(e) => {
-											field.onChange(e.target.value);
-											handleFieldChange(
-												"name",
-												e.target.value,
-											);
-										}}
-										fullWidth
-										//label="Name"
-										error={
-											!handleInputValidations(
-												field.value,
-												"name",
-											)
-										}
-										helperText={
-											!handleInputValidations(
-												field.value,
-												"name",
-											)
-												? "Name should only contain letters, hyphens, and underscores"
-												: ""
-										}
-									/>
-								</Box>
-							);
-						}}
-					/>
-					<Controller
-						name="section"
-						control={control}
-						render={({ field }) => {
-							return (
-								<Box sx={{ gap: "8px" }}>
-									<Typography
-										variant="subtitle1"
-										color="text.secondary"
-									>
-										Section
-									</Typography>
-									<Autocomplete
-										freeSolo
-										fullWidth
-										value={field.value}
-										options={SECTION_ORDER}
-										onChange={(_, newValue) => {
-											field.onChange(newValue);
-											handleFieldChange(
-												"section",
-												newValue,
-											);
-										}}
-										onInputChange={(_, newValue) => {
-											field.onChange(newValue);
-											handleFieldChange(
-												"section",
-												newValue,
-											);
-										}}
-										renderInput={(params) => (
-											<TextField
-												{...params}
-												error={
-													!handleInputValidations(
-														field.value,
-														"section",
-													)
-												}
-												helperText={
-													!handleInputValidations(
-														field.value,
-														"section",
-													)
-														? "Section should only contain letters, hyphens, and underscores"
+								<X className="size-4" />
+							</button>
+						</div>
+					</DialogHeader>
+
+					<div className="flex flex-col gap-4 pt-2">
+						{isEdit && (
+							<div className="flex flex-col gap-2">
+								<span className="text-muted-foreground text-sm">
+									Block Template
+								</span>
+								<CommunityLayers
+									item={localBlockItem}
+									onJsonUpdate={handleLayersPanelUpdate}
+								/>
+							</div>
+						)}
+						<Controller
+							name="name"
+							control={control}
+							render={({ field }) => {
+								const isValid = handleInputValidations(
+									field.value,
+									"name",
+								);
+								return (
+									<div className="flex flex-col gap-2">
+										<span className="text-muted-foreground text-sm">
+											Block Name
+										</span>
+										<Input
+											value={field.value}
+											onChange={(e) => {
+												field.onChange(e.target.value);
+												handleFieldChange(
+													"name",
+													e.target.value,
+												);
+											}}
+											className={
+												!isValid
+													? "border-destructive"
+													: ""
+											}
+										/>
+										{!isValid && (
+											<span className="text-destructive text-xs">
+												Name should only contain
+												letters, hyphens, and
+												underscores
+											</span>
+										)}
+									</div>
+								);
+							}}
+						/>
+						<Controller
+							name="section"
+							control={control}
+							render={({ field }) => {
+								const isValid = handleInputValidations(
+									field.value,
+									"section",
+								);
+								return (
+									<div className="flex flex-col gap-2">
+										<span className="text-muted-foreground text-sm">
+											Section
+										</span>
+										<Select
+											value={field.value || undefined}
+											onValueChange={(newValue) => {
+												field.onChange(newValue);
+												handleFieldChange(
+													"section",
+													newValue,
+												);
+											}}
+										>
+											<SelectTrigger
+												className={
+													!isValid
+														? "border-destructive"
 														: ""
 												}
-											/>
+											>
+												<SelectValue placeholder="Select section" />
+											</SelectTrigger>
+											<SelectContent>
+												{SECTION_ORDER.map(
+													(section) => (
+														<SelectItem
+															key={section}
+															value={section}
+														>
+															{section}
+														</SelectItem>
+													),
+												)}
+											</SelectContent>
+										</Select>
+										{!isValid && (
+											<span className="text-destructive text-xs">
+												Section should only contain
+												letters, hyphens, and
+												underscores
+											</span>
 										)}
-										multiple={false}
-									/>
-								</Box>
-							);
-						}}
-					/>
-					{/* This section is commented out since the backend functionality is not implemented yet. */}
-					{/* <Controller
-                        name="helperText"
-                        control={control}
-                        render={({ field }) => {
-                            return (
-                                <Box sx={{ gap: '8px' }}>
-                                    <Typography
-                                        variant="subtitle1"
-                                        color="text.secondary"
-                                    >
-                                        Tooltip Description
-                                    </Typography>
-                                    <TextField
-                                        value={field.value}
-                                        onChange={(e) => {
-                                            field.onChange(e.target.value);
-                                            handleFieldChange(
-                                                'helperText',
-                                                e.target.value,
-                                            );
-                                        }}
-                                        fullWidth
-                                    />
-                                </Box>
-                            );
-                        }}
-                    />
-                    <Controller
-                        name="visibility"
-                        control={control}
-                        render={({ field }) => (
-                            <Box sx={{ gap: 0 }}>
-                                <Typography variant="subtitle1">
-                                    Visibility
-                                </Typography>
-                                <RadioGroup {...field} row>
-                                    <RadioGroup.Item
-                                        value="Private"
-                                        label="Private"
-                                    />
-                                    <RadioGroup.Item
-                                        value="Public"
-                                        label="Public"
-                                    />
-                                </RadioGroup>
-                            </Box>
-                        )}
-                    /> */}
-					{!isEdit && (
-						<StyledButtonGroupIconButton
-							onClick={handleCanvasPreview}
-						>
-							<PreviewOutlined sx={{ mr: 1 }} /> Preview Block
-						</StyledButtonGroupIconButton>
-					)}
-				</StyledModalContent>
+									</div>
+								);
+							}}
+						/>
+						{!isEdit && (
+							<TooltipProvider>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<button
+											type="button"
+											className="inline-flex items-center gap-2 self-start font-medium text-primary text-sm hover:underline"
+											onClick={handleCanvasPreview}
+										>
+											<Eye className="size-4" />
+											Preview Block
+										</button>
+									</TooltipTrigger>
+									<TooltipContent>
+										Preview your block
+									</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+						)}
+					</div>
 
-				<Modal.Actions>
-					<Button onClick={handleCloseModals} variant="text">
-						Cancel
-					</Button>
-
-					{isEdit ? (
-						<Button
-							onClick={handleSaveAsClientBlock}
-							variant="contained"
-						>
-							Save
+					<DialogFooter>
+						<Button variant="outline" onClick={handleCloseModals}>
+							Cancel
 						</Button>
-					) : (
-						<Button
-							onClick={handleAddAsClientBlock}
-							variant="contained"
-						>
-							Add
+						{isEdit ? (
+							<Button onClick={handleSaveAsClientBlock}>
+								Save
+							</Button>
+						) : (
+							<Button onClick={handleAddAsClientBlock}>
+								Add
+							</Button>
+						)}
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog
+				open={showPreviewModal}
+				onOpenChange={(open) => !open && handleArrowBack()}
+			>
+				<DialogContent showCloseButton={false}>
+					<DialogHeader>
+						<div className="flex items-center justify-between">
+							<button
+								type="button"
+								className="flex size-8 items-center justify-center rounded hover:bg-accent"
+								onClick={handleArrowBack}
+							>
+								<ArrowLeft className="size-4" />
+							</button>
+							<DialogTitle>Add Block</DialogTitle>
+							<button
+								type="button"
+								className="flex size-8 items-center justify-center rounded hover:bg-accent"
+								onClick={handleCloseModals}
+							>
+								<X className="size-4" />
+							</button>
+						</div>
+					</DialogHeader>
+
+					<div className="flex flex-col gap-4 pt-2">
+						{imagePreview && (
+							<TooltipProvider>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<img
+											src={imagePreview}
+											alt="Canvas Preview"
+											style={{
+												width: imageDimensions.width,
+												height: imageDimensions.height,
+												border: "1px solid #ccc",
+												borderRadius: 8,
+												overflow: "auto",
+												cursor: "pointer",
+											}}
+										/>
+									</TooltipTrigger>
+									<TooltipContent>
+										{localBlockItem?.helperText || ""}
+									</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+						)}
+					</div>
+
+					<DialogFooter>
+						<Button variant="outline" onClick={handleCloseModals}>
+							Cancel
 						</Button>
-					)}
-				</Modal.Actions>
-			</Modal>
-
-			<Modal open={showPreviewModal} maxWidth={false}>
-				<StyledModalHeading>
-					<IconButton size="small" onClick={handleArrowBack}>
-						<ArrowBack />
-					</IconButton>
-					<StyledTitle variant="h6">Add Block</StyledTitle>
-					<IconButton size="small" onClick={handleCloseModals}>
-						<Close />
-					</IconButton>
-				</StyledModalHeading>
-
-				<StyledModalContent>
-					{imagePreview && (
-						<Tooltip title={localBlockItem?.helperText || ""} arrow>
-							<img
-								src={imagePreview}
-								alt="Canvas Preview"
-								style={{
-									width: imageDimensions.width,
-									height: imageDimensions.height,
-									border: "1px solid #ccc",
-									borderRadius: 8,
-									overflow: "auto",
-									cursor: "pointer", // Optional: show pointer on hover
-								}}
-							/>
-						</Tooltip>
-					)}
-				</StyledModalContent>
-
-				<Modal.Actions>
-					<Button onClick={handleCloseModals} variant="text">
-						Cancel
-					</Button>
-					<Button
-						onClick={handleAddAsClientBlock}
-						variant="contained"
-					>
-						Add
-					</Button>
-				</Modal.Actions>
-			</Modal>
+						<Button onClick={handleAddAsClientBlock}>Add</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</>
 	);
 };

--- a/packages/client/src/components/designer/BlockAvatar.tsx
+++ b/packages/client/src/components/designer/BlockAvatar.tsx
@@ -1,17 +1,13 @@
-import { Avatar, styled } from "@semoss/ui";
+import type React from "react";
 
-const StyledAvatar = styled(Avatar)(({ theme }) => ({
-	width: theme.spacing(4),
-	height: theme.spacing(4),
-	backgroundColor: `${theme.palette.primary.light}33`,
-	border: `1px solid ${theme.palette.primary.main}`,
-	color: theme.palette.primary.main,
-}));
-
-export const BlockAvatar = (props: { icon: any; xs?: boolean }) => {
+export const BlockAvatar = (props: {
+	icon: React.ElementType;
+	xs?: boolean;
+}) => {
+	const { icon: Icon } = props;
 	return (
-		<StyledAvatar variant="rounded">
-			<props.icon />
-		</StyledAvatar>
+		<div className="flex size-8 shrink-0 items-center justify-center rounded border border-primary bg-primary/20 text-primary">
+			<Icon className="size-4" />
+		</div>
 	);
 };

--- a/packages/client/src/components/designer/BlockMenuCardContent.tsx
+++ b/packages/client/src/components/designer/BlockMenuCardContent.tsx
@@ -1,4 +1,3 @@
-import { Stack, styled, Typography } from "@semoss/ui";
 import { formatToDataTestId } from "@/utility";
 
 export interface BlockCardContentProps {
@@ -13,11 +12,6 @@ export interface BlockCardContentProps {
 export const blockCardWidth = "133px";
 export const blockCardHeight = "106px";
 
-const StyledTypography = styled(Typography)(({ theme }) => ({
-	color: theme.palette.secondary.dark,
-	userSelect: "none",
-}));
-
 export const BlockCardContent = (props: BlockCardContentProps) => {
 	const {
 		name = "",
@@ -29,13 +23,16 @@ export const BlockCardContent = (props: BlockCardContentProps) => {
 	} = props;
 
 	return (
-		<Stack
-			paddingX={paddingX}
-			paddingY={paddingY}
-			width={width}
-			height={height}
-			alignItems="center"
-			justifyContent="center"
+		<div
+			className="flex flex-col items-center justify-center"
+			style={{
+				width,
+				height,
+				paddingLeft: `${paddingX * 8}px`,
+				paddingRight: `${paddingX * 8}px`,
+				paddingTop: `${paddingY * 8}px`,
+				paddingBottom: `${paddingY * 8}px`,
+			}}
 			data-testid={formatToDataTestId(
 				`blockMenuCardContent-card-${name}`,
 			)}
@@ -50,14 +47,10 @@ export const BlockCardContent = (props: BlockCardContentProps) => {
 					aria-hidden="true"
 				/>
 			) : (
-				<StyledTypography
-					variant="body2"
-					fontWeight="medium"
-					align="center"
-				>
+				<span className="select-none text-center font-medium text-muted-foreground text-sm">
 					{name}
-				</StyledTypography>
+				</span>
 			)}
-		</Stack>
+		</div>
 	);
 };

--- a/packages/client/src/components/designer/BlockSettingsMask.tsx
+++ b/packages/client/src/components/designer/BlockSettingsMask.tsx
@@ -1,28 +1,12 @@
 import { observer } from "mobx-react-lite";
 import { useLayoutEffect, useState } from "react";
 import { useBlocks } from "@semoss/renderer";
-import { styled } from "@semoss/ui";
 import { useDesigner } from "@/hooks";
 import { getBlockElement, getRelativeSize } from "@/stores";
 import { TextSettingsMask } from "./settings-mask/TextSettingsMask";
 
 const STYLED_FONT_STYLE_INPUT_WIDTH = 232;
 const STYLED_FONT_SIZE_INPUT_WIDTH = 168;
-
-const StyledContainer = styled("div")(({ theme }) => ({
-	position: "absolute",
-	padding: theme.spacing(1, 0, 0, 2),
-	top: "0",
-	right: "0",
-	bottom: "0",
-	left: "0",
-	zIndex: "30",
-	height: "fit-content",
-	maxWidth: `${
-		STYLED_FONT_STYLE_INPUT_WIDTH + STYLED_FONT_SIZE_INPUT_WIDTH
-	}px`,
-	minWidth: "fit-content",
-}));
 
 interface FontStyleSizeMaskProps {
 	/** Element to bind the mask to */
@@ -32,7 +16,6 @@ interface FontStyleSizeMaskProps {
 export const BlockSettingsMask = observer((props: FontStyleSizeMaskProps) => {
 	const { screenEle } = props;
 
-	// create the state
 	const [size, setSize] = useState<{
 		top: number;
 		left: number;
@@ -40,33 +23,25 @@ export const BlockSettingsMask = observer((props: FontStyleSizeMaskProps) => {
 		width: number;
 	} | null>(null);
 
-	// get the store
 	const { registry, state } = useBlocks();
 	const { designer } = useDesigner();
 
-	// get the block
 	const block = state.getBlock(designer.selected);
 
-	// check if it is visible
 	const isVisible =
 		block && registry[block.widget] && block.widget !== "page";
 
-	// get the root, watch changes, and reposition the mask
+	// biome-ignore lint/correctness/useExhaustiveDependencies: repositionMask depends on screenEle and designer.selected
 	useLayoutEffect(() => {
 		if (!isVisible || block.widget !== "text") {
 			return;
 		}
 
-		// reposition the mask
 		const repositionMask = () => {
-			// get the block element
 			const blockEle = getBlockElement(designer.selected);
-
 			if (!blockEle) {
 				return;
 			}
-
-			// calculate and set the side
 			const updated = getRelativeSize(blockEle, screenEle);
 			setSize(updated);
 		};
@@ -80,32 +55,21 @@ export const BlockSettingsMask = observer((props: FontStyleSizeMaskProps) => {
 			childList: true,
 		});
 
-		// reposition it
 		repositionMask();
 
 		return () => observer.disconnect();
 	}, [designer.selected, isVisible]);
 
 	if (!size || !isVisible) {
-		return <></>;
+		return null;
 	}
 
-	/**
-	 * Calculates the style properties for positioning an element relative to the screen and
-	 * the selected block element. It determines the top and left positions, taking into account
-	 * potential overflow on the left or right side of the screen.
-	 *
-	 * @returns {Object} - An object containing `top` and `left` style properties in pixels.
-	 */
 	const getStyle = () => {
-		// get position of page root block element
 		const screenElementSize = screenEle.getBoundingClientRect();
-		// get position of selected block element
 		const selectedElement = getBlockElement(designer.selected);
 		if (!selectedElement) return;
 		const selectedElementSize = selectedElement.getBoundingClientRect();
 
-		// check for overflow
 		const hasLeftOverflow =
 			screenElementSize.left === selectedElementSize.left &&
 			selectedElementSize.width <
@@ -138,13 +102,29 @@ export const BlockSettingsMask = observer((props: FontStyleSizeMaskProps) => {
 		return { top, left };
 	};
 
+	if (block.widget !== "text") {
+		return null;
+	}
+
 	return (
-		<>
-			{block.widget === "text" && (
-				<StyledContainer id="delete-duplicate-mask" style={getStyle()}>
-					<TextSettingsMask />
-				</StyledContainer>
-			)}
-		</>
+		// biome-ignore lint/correctness/useUniqueElementIds: component-scoped anchor id
+		<div
+			id="delete-duplicate-mask"
+			style={{
+				position: "absolute",
+				padding: "8px 0 0 16px",
+				top: "0",
+				right: "0",
+				bottom: "0",
+				left: "0",
+				zIndex: 30,
+				height: "fit-content",
+				maxWidth: `${STYLED_FONT_STYLE_INPUT_WIDTH + STYLED_FONT_SIZE_INPUT_WIDTH}px`,
+				minWidth: "fit-content",
+				...getStyle(),
+			}}
+		>
+			<TextSettingsMask />
+		</div>
 	);
 });

--- a/packages/client/src/components/designer/CommunityLayers.tsx
+++ b/packages/client/src/components/designer/CommunityLayers.tsx
@@ -14,23 +14,15 @@ import {
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import ChevronRightIcon from "@mui/icons-material/ChevronRight";
-import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { ChevronDown, ChevronRight, GripVertical } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
-import {
-	Box,
-	Collapse,
-	IconButton,
-	Paper,
-	styled,
-	Typography,
-} from "@semoss/ui";
+import { Collapsible, CollapsibleContent } from "@semoss/ui/next";
 import { BlockSettingsRegistry } from "../blocks-workspace/blocks";
 
 type WidgetItem = {
 	widget: string;
+	// biome-ignore lint/suspicious/noExplicitAny: block data is untyped
 	data: any;
 	slots?: {
 		[slotName: string]: {
@@ -41,51 +33,11 @@ type WidgetItem = {
 };
 
 type Props = {
+	// biome-ignore lint/suspicious/noExplicitAny: item shape varies
 	item: any;
-	onJsonUpdate?: (updated: WidgetItem) => void; // optional callback for parent
+	onJsonUpdate?: (updated: WidgetItem) => void;
 };
-const StyledLabelTitle = styled("div")(({ theme }) => ({
-	display: "flex",
-	alignItems: "center",
-	justifyContent: "space-between",
-	gap: 8,
-	padding: 8,
-	margin: "4px 0",
-	marginLeft: 40,
-	cursor: "grab",
-	borderRadius: 8,
-	height: "70px",
-}));
 
-const StyledContent = styled(Box)(({ theme }) => ({
-	display: "flex",
-	alignItems: "center",
-	gap: "8px",
-}));
-
-const StyledChildContent = styled(Box)(({ theme }) => ({
-	display: "flex",
-	flexDirection: "column",
-	justifyContent: "center",
-}));
-
-const StyledPaper = styled(Paper)(({ theme }) => ({
-	display: "flex",
-	alignItems: "center",
-	gap: "7px",
-	my: 0.5,
-	height: "70px",
-	boxShadow: "none",
-	padding: theme.spacing(1),
-}));
-
-const StyledBox = styled(Box)(({ theme }) => ({
-	border: "1px solid #e0e0e0",
-	borderRadius: "8px",
-	mb: 1,
-	width: "100%",
-}));
-// === DRAGGABLE SORTABLE BLOCK (for leaf nodes only) ===
 const SortableLeaf: React.FC<{
 	id: string;
 	block: WidgetItem;
@@ -108,45 +60,34 @@ const SortableLeaf: React.FC<{
 	const WidgetIcon = BlockSettingsRegistry[block?.widget]?.icon;
 
 	return (
-		<StyledLabelTitle
+		<div
 			ref={setNodeRef}
 			style={style}
+			className="my-1 ml-10 flex h-[70px] cursor-grab items-center justify-between gap-2 rounded-lg p-2"
 			{...attributes}
 			{...listeners}
 		>
-			<StyledContent>
+			<div className="flex items-center gap-2">
 				{WidgetIcon && (
-					<WidgetIcon
-						fontSize="small"
-						sx={{ color: "text.secondary" }}
-					/>
+					<WidgetIcon className="size-4 text-muted-foreground" />
 				)}
-				<StyledChildContent>
-					<Typography
-						variant="body1"
-						fontWeight={400}
-						sx={{ fontSize: "14px" }}
-					>
-						{block?.widget}
-					</Typography>
-					<Typography
-						variant="body1"
-						fontWeight={400}
-						sx={{ fontSize: "14px" }}
-						color="text.secondary"
-					>
-						{block?.widget + "11"}
-					</Typography>
-				</StyledChildContent>
-			</StyledContent>
-			<IconButton size="small">
-				<DragIndicatorIcon />
-			</IconButton>
-		</StyledLabelTitle>
+				<div className="flex flex-col justify-center">
+					<span className="text-sm">{block?.widget}</span>
+					<span className="text-muted-foreground text-sm">
+						{`${block?.widget}11`}
+					</span>
+				</div>
+			</div>
+			<button
+				type="button"
+				className="flex size-8 items-center justify-center rounded hover:bg-accent"
+			>
+				<GripVertical className="size-4" />
+			</button>
+		</div>
 	);
 };
 
-// === RECURSIVE RENDERING ===
 const RecursiveRenderer: React.FC<{
 	block: WidgetItem;
 	path: string;
@@ -157,12 +98,11 @@ const RecursiveRenderer: React.FC<{
 		block?.slots &&
 		Object.values(block?.slots).some((slot) => slot.children?.length);
 
-	const [expanded, setExpanded] = useState(false); // collapsed by default
+	const [expanded, setExpanded] = useState(false);
 	const toggleExpand = () => setExpanded((prev) => !prev);
 
 	const WidgetIcon = BlockSettingsRegistry[block?.widget]?.icon;
 
-	// handle reorder inside each slot
 	const handleReorder = (
 		slotKey: string,
 		oldIndex: number,
@@ -175,101 +115,108 @@ const RecursiveRenderer: React.FC<{
 		onUpdate(updated);
 	};
 
+	// suppress unused variable warning — handleReorder used by DnD context
+	void handleReorder;
+
 	return (
-		<StyledBox sx={{ ml: hasParent ? 5 : 0 }}>
-			<StyledPaper elevation={1}>
+		<div
+			className="w-full rounded-lg border border-border"
+			style={{ marginLeft: hasParent ? "20px" : 0, marginBottom: "4px" }}
+		>
+			<div className="flex h-[70px] items-center gap-2 rounded-lg p-2 shadow-none">
 				{isParent && (
-					<IconButton size="small" onClick={toggleExpand}>
-						{expanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
-					</IconButton>
+					<button
+						type="button"
+						className="flex size-8 items-center justify-center rounded hover:bg-accent"
+						onClick={toggleExpand}
+					>
+						{expanded ? (
+							<ChevronDown className="size-4" />
+						) : (
+							<ChevronRight className="size-4" />
+						)}
+					</button>
 				)}
-				<StyledContent>
+				<div className="flex items-center gap-2">
 					{WidgetIcon && (
-						<WidgetIcon
-							fontSize="small"
-							sx={{ color: "text.secondary" }}
-						/>
+						<WidgetIcon className="size-4 text-muted-foreground" />
 					)}
-					<StyledChildContent>
-						<Typography
-							variant="body1"
-							fontWeight={400}
-							sx={{ fontSize: "14px" }}
-						>
-							{block?.widget}
-						</Typography>
-						<Typography
-							variant="body1"
-							fontWeight={400}
-							sx={{ fontSize: "14px" }}
-							color="text.secondary"
-						>
-							{block?.widget + "11"}
-						</Typography>
-					</StyledChildContent>
-				</StyledContent>
-			</StyledPaper>
+					<div className="flex flex-col justify-center">
+						<span className="text-sm">{block?.widget}</span>
+						<span className="text-muted-foreground text-sm">
+							{`${block?.widget}11`}
+						</span>
+					</div>
+				</div>
+			</div>
 
 			{isParent && (
-				<Collapse in={expanded}>
-					{Object.entries(block?.slots || {}).map(
-						([slotKey, slotValue]) => {
-							const children = slotValue.children ?? [];
-							const ids = children.map(
-								(_, i) => `${path}-${slotKey}-${i}`,
-							);
+				<Collapsible open={expanded}>
+					<CollapsibleContent>
+						{Object.entries(block?.slots || {}).map(
+							([slotKey, slotValue]) => {
+								const children = slotValue.children ?? [];
+								const ids = children.map(
+									(_, i) => `${path}-${slotKey}-${i}`,
+								);
 
-							return (
-								<SortableContext
-									key={slotKey}
-									items={ids}
-									strategy={verticalListSortingStrategy}
-								>
-									{children.map((child, index) => {
-										const isLeaf =
-											!child.slots ||
-											!Object.values(child.slots).some(
-												(s) => s.children?.length,
+								return (
+									<SortableContext
+										key={slotKey}
+										items={ids}
+										strategy={verticalListSortingStrategy}
+									>
+										{children.map((child, index) => {
+											const isLeaf =
+												!child.slots ||
+												!Object.values(
+													child.slots,
+												).some(
+													(s) => s.children?.length,
+												);
+											const childPath = `${path}-${slotKey}-${index}`;
+
+											return isLeaf ? (
+												<SortableLeaf
+													key={childPath}
+													id={childPath}
+													block={child}
+												/>
+											) : (
+												<RecursiveRenderer
+													key={childPath}
+													block={child}
+													path={childPath}
+													onUpdate={(
+														updatedChild,
+													) => {
+														const updated = {
+															...block,
+														};
+														// biome-ignore lint/style/noNonNullAssertion: slot exists since we're iterating
+														updated.slots![slotKey]
+															.children![index] =
+															updatedChild;
+														onUpdate(updated);
+													}}
+													hasParent={true}
+												/>
 											);
-										const childPath = `${path}-${slotKey}-${index}`;
-
-										return isLeaf ? (
-											<SortableLeaf
-												key={childPath}
-												id={childPath}
-												block={child}
-											/>
-										) : (
-											<RecursiveRenderer
-												key={childPath}
-												block={child}
-												path={childPath}
-												onUpdate={(updatedChild) => {
-													const updated = {
-														...block,
-													};
-													updated.slots![slotKey]
-														.children![index] =
-														updatedChild;
-													onUpdate(updated);
-												}}
-												hasParent={true}
-											/>
-										);
-									})}
-								</SortableContext>
-							);
-						},
-					)}
-				</Collapse>
+										})}
+									</SortableContext>
+								);
+							},
+						)}
+					</CollapsibleContent>
+				</Collapsible>
 			)}
-		</StyledBox>
+		</div>
 	);
 };
 
-// === ROOT COMPONENT ===
 export const CommunityLayers: React.FC<Props> = ({ item, onJsonUpdate }) => {
 	const [json, setJson] = useState<WidgetItem>(item.json);
+	// biome-ignore lint/suspicious/noExplicitAny: item shape varies
 	const [localItem, setLocalItem] = useState<any>(item);
 	const sensors = useSensors(useSensor(MouseSensor), useSensor(TouchSensor));
 
@@ -280,6 +227,9 @@ export const CommunityLayers: React.FC<Props> = ({ item, onJsonUpdate }) => {
 		if (onJsonUpdate) onJsonUpdate(updatedItem);
 	};
 
+	// suppress unused variable warning
+	void json;
+
 	const handleDragEnd = (event: DragEndEvent) => {
 		const activeId = String(event.active.id);
 		const overId = String(event.over?.id);
@@ -287,24 +237,26 @@ export const CommunityLayers: React.FC<Props> = ({ item, onJsonUpdate }) => {
 
 		const pathParts = activeId.split("-");
 		const slotKey = pathParts[pathParts.length - 2];
-		const fromIndex = parseInt(pathParts[pathParts.length - 1]);
-		const toIndex = parseInt(overId.split("-").pop() || "0");
+		const fromIndex = Number.parseInt(pathParts[pathParts.length - 1], 10);
+		const toIndex = Number.parseInt(overId.split("-").pop() || "0", 10);
 
 		const updated = { ...localItem.json };
 
 		const parentPath = pathParts.slice(0, -2);
+		// biome-ignore lint/suspicious/noExplicitAny: recursive traversal of untyped structure
 		let parent: any = updated;
 
 		for (const p of parentPath) {
 			const slot = Object.values(parent.slots || {}).find(
+				// biome-ignore lint/suspicious/noExplicitAny: untyped slot traversal
 				(s: any) =>
 					Array.isArray(s.children) &&
-					s.children.length > parseInt(p),
+					s.children.length > Number.parseInt(p, 10),
 			) as { children?: WidgetItem[] } | undefined;
 
 			if (!slot || !slot.children) break;
 
-			parent = slot.children[parseInt(p)];
+			parent = slot.children[Number.parseInt(p, 10)];
 		}
 
 		const slot = parent.slots?.[slotKey];
@@ -320,14 +272,14 @@ export const CommunityLayers: React.FC<Props> = ({ item, onJsonUpdate }) => {
 			collisionDetection={closestCenter}
 			onDragEnd={handleDragEnd}
 		>
-			<Box>
+			<div>
 				<RecursiveRenderer
-					block={json}
+					block={localItem.json}
 					path="root"
 					onUpdate={handleUpdate}
 					hasParent={false}
 				/>
-			</Box>
+			</div>
 		</DndContext>
 	);
 };

--- a/packages/client/src/components/designer/DeleteDuplicateMask.tsx
+++ b/packages/client/src/components/designer/DeleteDuplicateMask.tsx
@@ -1,14 +1,14 @@
 import {
-	Add,
-	AddBox,
-	AddCard,
-	DeleteOutline,
+	ArrowLeftRight,
+	FilePlus,
 	Image,
 	List,
-	SmartButton,
-	SwapHoriz,
-	TextFields,
-} from "@mui/icons-material";
+	MousePointerClick,
+	Plus,
+	SquarePlus,
+	Trash2,
+	Type,
+} from "lucide-react";
 import { toJS } from "mobx";
 import { observer } from "mobx-react-lite";
 import { useLayoutEffect, useState } from "react";
@@ -18,8 +18,13 @@ import {
 	INPUT_BLOCK_TYPES,
 	useBlocks,
 } from "@semoss/renderer";
-import { ButtonGroup, IconButton, styled, Tooltip } from "@semoss/ui";
-import { toast } from "@semoss/ui/next";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+	toast,
+} from "@semoss/ui/next";
 import { useDesigner, useRootStore } from "@/hooks";
 import { getBlockElement, getRelativeSize } from "@/stores";
 import { getDependencyCells } from "@/utility/dependencyScanner";
@@ -31,48 +36,34 @@ import { QuickMenu } from "./QuickMenu";
 const STYLED_BUTTON_GROUP_ICON_BUTTON_WIDTH = 48;
 const STYLED_BUTTON_GROUP_ICON_BUTTON_HEIGHT = 32;
 
-const StyledContainer = styled("div")(({ theme }) => ({
-	position: "absolute",
-	padding: theme.spacing(2),
-	top: "0",
-	right: "0",
-	bottom: "0",
-	left: "0",
-	zIndex: "30",
-	width: `${STYLED_BUTTON_GROUP_ICON_BUTTON_WIDTH}px`,
-	height: `${STYLED_BUTTON_GROUP_ICON_BUTTON_HEIGHT}px`,
-}));
+const quickMenu = [
+	{
+		name: "Container",
+		value: "container",
+		icon: <List className="size-4" />,
+	},
+	{ name: "Text", value: "text", icon: <Type className="size-4" /> },
+	{ name: "Image", value: "image", icon: <Image className="size-4" /> },
+	{ name: "Card", value: "flip-card", icon: <FilePlus className="size-4" /> },
+	{
+		name: "Button",
+		value: "button",
+		icon: <MousePointerClick className="size-4" />,
+	},
+];
 
-const StyledButtonGroup = styled(ButtonGroup)(() => ({
-	boxShadow:
-		"0px 5px 22px 0px rgba(0, 0, 0, 0.10), 0px 4px 4px 0.5px rgba(0, 0, 0, 0.03)", // custom from design
-	backgroundColor: "white",
-}));
-
-const StyledButtonGroupIconButton = styled(IconButton)(({ theme }) => ({
-	width: `${STYLED_BUTTON_GROUP_ICON_BUTTON_WIDTH}px`,
-	backgroundColor: "white",
-	borderRadius: theme.shape.borderRadius,
-}));
+const iconButtonClass =
+	"flex size-8 cursor-pointer items-center justify-center rounded bg-white text-[#757575] hover:bg-gray-50 focus:outline-none";
 
 interface DeleteDuplicateMaskProps {
 	/** Element to bind the mask to */
 	screenEle: HTMLDivElement;
 }
 
-const quickMenu = [
-	{ name: "Container", value: "container", icon: <List /> },
-	{ name: "Text", value: "text", icon: <TextFields /> },
-	{ name: "Image", value: "image", icon: <Image /> },
-	{ name: "Card", value: "flip-card", icon: <AddCard /> },
-	{ name: "Button", value: "button", icon: <SmartButton /> },
-];
-
 export const DeleteDuplicateMask = observer(
 	(props: DeleteDuplicateMaskProps) => {
 		const { screenEle } = props;
 
-		// create the state
 		const [size, setSize] = useState<{
 			top: number;
 			left: number;
@@ -86,12 +77,10 @@ export const DeleteDuplicateMask = observer(
 			useState<boolean>(false);
 		const [dependentCells, setDependentCells] = useState<string[]>([]);
 
-		// get the store
 		const { registry, state } = useBlocks();
 		const { designer } = useDesigner();
 		const { configStore } = useRootStore();
 
-		// get the block
 		const block = state.getBlock(designer.selected);
 
 		const hasChildren = block?.slots?.children?.children?.length > 0;
@@ -105,28 +94,21 @@ export const DeleteDuplicateMask = observer(
 		const isChangeable =
 			hasChildren && block?.widget !== "container" && !isForm;
 		const showQuickMenu = isIterationOrContainer && !isForm;
-		// check if it is visible
 		const isVisible =
 			block && registry[block.widget] && block.widget !== "page";
 
 		const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
-		// get the root, watch changes, and reposition the mask
 		useLayoutEffect(() => {
 			if (!isVisible) {
 				return;
 			}
 
-			// reposition the mask
 			const repositionMask = () => {
-				// get the block element
 				const blockEle = getBlockElement(designer.selected);
-
 				if (!blockEle) {
 					return;
 				}
-
-				// calculate and set the side
 				const updated = getRelativeSize(blockEle, screenEle);
 				setSize(updated);
 			};
@@ -140,7 +122,6 @@ export const DeleteDuplicateMask = observer(
 				childList: true,
 			});
 
-			// reposition it
 			repositionMask();
 
 			return () => observer.disconnect();
@@ -151,14 +132,11 @@ export const DeleteDuplicateMask = observer(
 		}
 
 		const getStyle = () => {
-			// get position of page root block element
 			const screenElementSize = screenEle.getBoundingClientRect();
-			// get position of selected block element
 			const selectedElement = getBlockElement(designer.selected);
 			if (!selectedElement) return;
 			const selectedElementSize = selectedElement.getBoundingClientRect();
 
-			// check for overflow
 			const hasLeftOverflow =
 				screenElementSize.left === selectedElementSize.left &&
 				selectedElementSize.width <
@@ -196,7 +174,6 @@ export const DeleteDuplicateMask = observer(
 		};
 
 		const onClear = () => {
-			// dispatch the event
 			state.dispatch({
 				message: ActionMessages.REMOVE_BLOCK,
 				payload: {
@@ -204,8 +181,6 @@ export const DeleteDuplicateMask = observer(
 					keep: true,
 				},
 			});
-
-			// clear the selected value
 			designer.setSelected("");
 		};
 
@@ -236,7 +211,6 @@ export const DeleteDuplicateMask = observer(
 		const dispatchDeleteBlock = () => {
 			const parentBlock = state.getBlock(block.parent.id);
 
-			// dispatch the event
 			state.dispatch({
 				message: ActionMessages.REMOVE_BLOCK,
 				payload: {
@@ -245,7 +219,6 @@ export const DeleteDuplicateMask = observer(
 				},
 			});
 
-			// If its within an iteration block, clean up the data.child
 			if (parentBlock.widget === "iteration") {
 				state.dispatch({
 					message: ActionMessages.SET_BLOCK_DATA,
@@ -257,13 +230,9 @@ export const DeleteDuplicateMask = observer(
 				});
 			}
 
-			// clear the selected value
 			designer.setSelected("");
 		};
 
-		/**
-		 * Delete the block
-		 */
 		const onDelete = async () => {
 			const dependentCellsList = await getDependencyCells(
 				state,
@@ -285,7 +254,6 @@ export const DeleteDuplicateMask = observer(
 		};
 
 		const onDuplicate = async () => {
-			// get the json for the block to add
 			const getJsonForBlock = (id: string) => {
 				const block = state.blocks[id];
 
@@ -296,7 +264,6 @@ export const DeleteDuplicateMask = observer(
 					slots: {},
 				};
 
-				// generate the slots
 				for (const slot in block.slots) {
 					if (block.slots[slot]) {
 						blockJson.slots[slot] = block.slots[slot].children.map(
@@ -307,7 +274,6 @@ export const DeleteDuplicateMask = observer(
 					}
 				}
 
-				// return it
 				return blockJson;
 			};
 
@@ -336,7 +302,6 @@ export const DeleteDuplicateMask = observer(
 				},
 			});
 
-			// TODO: REFACTOR
 			if (INPUT_BLOCK_TYPES.indexOf(block.widget) > -1) {
 				state.dispatch({
 					message: ActionMessages.ADD_VARIABLE,
@@ -353,15 +318,12 @@ export const DeleteDuplicateMask = observer(
 			designer.setSelected(id ? (id as string) : "");
 		};
 
-		// Conditionally define addBlock to avoid unnecessary creation when not needed.
-		// This ensures the function is only created if the block is an iteration or container.
 		const addBlock = isIterationOrContainer
 			? (item: {
 					name: string;
 					value: string;
 					icon: React.ReactElement;
 				}) => {
-					// Create the new block JSON
 					const blockJson = {
 						widget: item.value,
 						data: registry[item.value].data,
@@ -369,7 +331,6 @@ export const DeleteDuplicateMask = observer(
 						slots: registry[item.value].slots,
 					} as BlockJSON;
 
-					// If the block is an iteration and has children, remove them first
 					if (block.widget === "iteration") {
 						if (block.slots.children.children?.length > 0) {
 							[...block.slots.children.children].forEach(
@@ -386,7 +347,6 @@ export const DeleteDuplicateMask = observer(
 						}
 					}
 
-					// Make this function async and await the dispatch
 					(async () => {
 						const id = await state.dispatch({
 							message: ActionMessages.ADD_BLOCK,
@@ -416,86 +376,126 @@ export const DeleteDuplicateMask = observer(
 			: null;
 
 		return (
-			<StyledContainer style={getStyle()}>
-				<StyledButtonGroup>
-					{isIterationOrContainer && (
-						<>
-							<Tooltip
-								title={
-									isChangeable
-										? "Swap Child Block"
-										: "Add Block to Content"
-								}
-							>
-								<StyledButtonGroupIconButton
-									sx={{ color: "#757575" }}
-									onClick={(e) => {
-										if (isForm) {
-											window.dispatchEvent(
-												new CustomEvent(
-													"FORM_MENU_OPEN",
-													{
-														detail: {
-															formId: block.id,
-														},
-													},
-												),
-											);
-										} else {
-											setAnchorEl(
-												e.currentTarget as HTMLElement,
-											);
-										}
-									}}
-								>
-									{isChangeable ? <SwapHoriz /> : <Add />}
-								</StyledButtonGroupIconButton>
-							</Tooltip>
+			<div
+				style={{
+					position: "absolute",
+					padding: "16px",
+					top: "0",
+					right: "0",
+					bottom: "0",
+					left: "0",
+					zIndex: 30,
+					width: `${STYLED_BUTTON_GROUP_ICON_BUTTON_WIDTH}px`,
+					height: `${STYLED_BUTTON_GROUP_ICON_BUTTON_HEIGHT}px`,
+					...getStyle(),
+				}}
+			>
+				<TooltipProvider>
+					<div
+						className="flex rounded bg-white"
+						style={{
+							boxShadow:
+								"0px 5px 22px 0px rgba(0, 0, 0, 0.10), 0px 4px 4px 0.5px rgba(0, 0, 0, 0.03)",
+						}}
+					>
+						{isIterationOrContainer && (
+							<>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<button
+											type="button"
+											className={iconButtonClass}
+											onClick={(e) => {
+												if (isForm) {
+													window.dispatchEvent(
+														new CustomEvent(
+															"FORM_MENU_OPEN",
+															{
+																detail: {
+																	formId: block.id,
+																},
+															},
+														),
+													);
+												} else {
+													setAnchorEl(
+														e.currentTarget as HTMLElement,
+													);
+												}
+											}}
+										>
+											{isChangeable ? (
+												<ArrowLeftRight className="size-4" />
+											) : (
+												<Plus className="size-4" />
+											)}
+										</button>
+									</TooltipTrigger>
+									<TooltipContent>
+										{isChangeable
+											? "Swap Child Block"
+											: "Add Block to Content"}
+									</TooltipContent>
+								</Tooltip>
 
-							{anchorEl && showQuickMenu && (
-								<QuickMenu
-									parentId={block.id}
-									anchorEl={anchorEl}
-									quickMenu={quickMenu}
-									onClose={() => setAnchorEl(null)}
-									onSelect={addBlock}
-								/>
-							)}
-						</>
-					)}
-					{configStore.store.user.admin && (
-						<Tooltip title="Add to client">
-							<StyledButtonGroupIconButton
-								sx={{ color: "#757575" }}
-								size="small"
-								onClick={() => setOpenModal(true)}
-							>
-								<AddBox />
-							</StyledButtonGroupIconButton>
+								{anchorEl && showQuickMenu && (
+									<QuickMenu
+										parentId={block.id}
+										anchorEl={anchorEl}
+										quickMenu={quickMenu}
+										onClose={() => setAnchorEl(null)}
+										onSelect={addBlock}
+									/>
+								)}
+							</>
+						)}
+						{configStore.store.user.admin && (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<button
+										type="button"
+										className={iconButtonClass}
+										onClick={() => setOpenModal(true)}
+									>
+										<SquarePlus className="size-4" />
+									</button>
+								</TooltipTrigger>
+								<TooltipContent>Add to client</TooltipContent>
+							</Tooltip>
+						)}
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									className={iconButtonClass}
+									onClick={onDuplicate}
+								>
+									<img
+										src={DuplicateIcon}
+										alt="Duplicate Icon"
+									/>
+								</button>
+							</TooltipTrigger>
+							<TooltipContent>Duplicate</TooltipContent>
 						</Tooltip>
-					)}
-					<Tooltip title="Duplicate">
-						<StyledButtonGroupIconButton
-							sx={{ color: "#757575" }}
-							size="small"
-							onClick={onDuplicate}
-						>
-							<img src={DuplicateIcon} alt="Duplicate Icon" />
-						</StyledButtonGroupIconButton>
-					</Tooltip>
-					<Tooltip title="Delete">
-						<StyledButtonGroupIconButton
-							sx={{ color: "#757575" }}
-							onClick={
-								designer.rendered === designer.selected
-									? onClear
-									: onDelete
-							}
-						>
-							<DeleteOutline />
-						</StyledButtonGroupIconButton>
-					</Tooltip>
-				</StyledButtonGroup>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									className={iconButtonClass}
+									onClick={
+										designer.rendered === designer.selected
+											? onClear
+											: onDelete
+									}
+								>
+									<Trash2 className="size-4" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent>Delete</TooltipContent>
+						</Tooltip>
+					</div>
+				</TooltipProvider>
 				<AddClientBlockModal
 					isOpen={openModal}
 					onClose={() => setOpenModal(false)}
@@ -514,7 +514,7 @@ export const DeleteDuplicateMask = observer(
 						desc: "This block is linked to multiple cells in your app. Deleting it may cause errors or broken connections.",
 					}}
 				/>
-			</StyledContainer>
+			</div>
 		);
 	},
 );

--- a/packages/client/src/components/designer/FormMenu.tsx
+++ b/packages/client/src/components/designer/FormMenu.tsx
@@ -1,22 +1,22 @@
-import { InfoOutlined, ReportRounded, Search } from "@mui/icons-material";
+import { AlertTriangle, Info, Search } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { BlockJSON } from "@semoss/renderer";
 import { runPixel } from "@semoss/sdk/react";
 import {
-	Card,
-	Divider,
-	Grid,
-	InputAdornment,
-	Menu,
-	Stack,
-	styled,
-	TextField,
-	ToggleTabsGroup,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuTrigger,
+	Separator,
+	Tabs,
+	TabsList,
+	TabsTrigger,
 	Tooltip,
-	Typography,
-} from "@semoss/ui";
-import { toast } from "@semoss/ui/next";
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+	toast,
+} from "@semoss/ui/next";
 import type { DesignerMenuItem } from "../blocks-workspace/menus/menu-types";
 import { BlockCardContent, blockCardWidth } from "./BlockMenuCardContent";
 
@@ -25,116 +25,11 @@ type MODE = "SYSTEM" | "COMMUNITY";
 interface FormMenuProps {
 	parentId: string;
 	anchorEl: HTMLElement | null;
-
-	// System blocks, same type as BlocksMenuPanel `items`
 	systemItems: DesignerMenuItem[];
-
-	// Host wants a BlockJSON when user picks something
 	onSelect: (blockJson: BlockJSON) => void;
-
 	onClose: () => void;
-
 	title?: string;
 }
-
-const StyledQuickMenu = styled(Menu)(() => ({
-	"& .MuiMenu-paper": {
-		borderRadius: "12px",
-		background: "#FFF",
-		boxShadow: "0px 5px 24px 0px rgba(0, 0, 0, 0.32)",
-		minWidth: 360,
-		maxWidth: 420,
-		padding: "8px 0 8px 0",
-	},
-}));
-
-const StyledTitle = styled("div")(({ theme }) => ({
-	borderRadius: "16px",
-	backgroundColor: theme.palette.primary.selected,
-	color: theme.palette.info.dark,
-	width: "fit-content",
-	marginTop: theme.spacing(0.5),
-	marginBottom: theme.spacing(1),
-	paddingRight: theme.spacing(2),
-	paddingLeft: theme.spacing(2),
-}));
-
-const StyledTitleSpan = styled("span")({
-	color: "var(--Primary-Dark, #1260DD)",
-	fontFamily: "Inter",
-	fontSize: "13px",
-	fontWeight: 400,
-	lineHeight: "18px",
-	letterSpacing: "0.16px",
-});
-
-const StyledTextField = styled(TextField)(() => ({
-	marginTop: 4,
-	marginBottom: 4,
-	width: "100%",
-	borderRadius: 8,
-}));
-
-const StyledToggleTabsGroup = styled(ToggleTabsGroup)(({ theme }) => ({
-	border: 0,
-	minHeight: "36px",
-	color: theme.palette.secondary.light,
-	borderRadius: theme.shape.borderRadius,
-	alignItems: "center",
-	padding: "0px 3px",
-	width: "100%",
-}));
-
-const StyledToggleTabsGroupItem = styled(ToggleTabsGroup.Item)(({ theme }) => ({
-	height: "32px",
-	padding: "4px 10px",
-	fontSize: "12px",
-	"&.MuiTab-root": {
-		borderRadius: theme.shape.borderRadius,
-	},
-	"&.Mui-selected": {
-		boxShadow: "0px 4px 4px 0px rgba(0, 0, 0, 0.05)",
-	},
-}));
-
-const StyledGridWrapper = styled("div")({
-	width: "100%",
-	maxHeight: 280,
-	overflowY: "auto",
-});
-
-const InlineStyledCard = styled(Card)({
-	cursor: "pointer",
-	border: `1px solid rgba(0, 0, 0, 0.12)`,
-	borderRadius: "6px",
-	justifyContent: "center",
-});
-
-const InlineStyledTypography = styled(Typography)(({ theme }) => ({
-	color: theme.palette.secondary.dark,
-	width: blockCardWidth,
-	userSelect: "none",
-	textAlign: "center",
-	overflowWrap: "anywhere",
-	alignItems: "center",
-}));
-
-const InlineStyledDiv = styled("div")({
-	position: "relative",
-	display: "inline-block",
-	paddingTop: "16px",
-	paddingRight: "16px",
-});
-
-const Styledstack = styled(Stack)({
-	padding: "0px 16px 0px 16px",
-	paddingY: "8px 0px 8px 0px",
-	maxWidth: "420px",
-});
-
-const StyledTypography = styled(Typography)({
-	paddingY: "8px",
-});
 
 interface FormMenuCardProps {
 	item: DesignerMenuItem;
@@ -147,70 +42,79 @@ const FormMenuBlockCard: React.FC<FormMenuCardProps> = ({
 }) => {
 	const [hovered, setHovered] = useState(false);
 
-	const image = isCommunity
-		? undefined
-		: hovered
-			? item.hoverImage
-			: item.activeImage;
+	const image = isCommunity ? undefined : item.activeImage;
 
 	return (
-		<Stack
-			spacing={1}
-			alignItems="center"
-			height="100%"
-			justifyContent="flex-end"
-		>
-			<InlineStyledTypography
-				component="div"
-				variant="body2"
-				fontWeight="medium"
-				align="center"
+		<div className="flex h-full flex-col items-center justify-end gap-1">
+			<div
+				className="select-none text-center font-medium text-muted-foreground text-sm"
+				style={{ width: blockCardWidth, overflowWrap: "anywhere" }}
 			>
-				<Stack
-					direction={"row"}
-					gap={1}
-					alignItems={"center"}
-					justifyContent={"center"}
-					flexWrap={"wrap"}
-				>
+				<div className="flex flex-wrap items-center justify-center gap-1">
 					{item.name}
 					{item.recentChanges && (
-						<Tooltip title={item.recentChanges}>
-							<span>
-								<InfoOutlined fontSize="small" color="info" />
-							</span>
-						</Tooltip>
+						<TooltipProvider>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span>
+										<Info className="size-4 text-blue-500" />
+									</span>
+								</TooltipTrigger>
+								<TooltipContent>
+									{item.recentChanges}
+								</TooltipContent>
+							</Tooltip>
+						</TooltipProvider>
 					)}
 					{item.isBeta && (
-						<Tooltip title={"This block is currently in beta"}>
-							<span>
-								<ReportRounded
-									fontSize="small"
-									color="warning"
-								/>
-							</span>
-						</Tooltip>
+						<TooltipProvider>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span>
+										<AlertTriangle className="size-4 text-amber-500" />
+									</span>
+								</TooltipTrigger>
+								<TooltipContent>
+									This block is currently in beta
+								</TooltipContent>
+							</Tooltip>
+						</TooltipProvider>
 					)}
-				</Stack>
-			</InlineStyledTypography>
+				</div>
+			</div>
 
-			<InlineStyledDiv
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: hover-only container */}
+			<div
+				className="relative inline-block pt-4 pr-4"
 				onMouseEnter={() => setHovered(true)}
 				onMouseLeave={() => setHovered(false)}
 			>
-				<InlineStyledCard>
-					<Tooltip
-						title={item.helperText ?? item.name}
-						arrow
-						placement="bottom"
-					>
-						<div>
-							<BlockCardContent image={image} name={item.name} />
-						</div>
-					</Tooltip>
-				</InlineStyledCard>
-			</InlineStyledDiv>
-		</Stack>
+				<div
+					className="cursor-pointer rounded-md border transition-colors"
+					style={{
+						borderColor: hovered
+							? "var(--primary)"
+							: "var(--border)",
+					}}
+				>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<div>
+									<BlockCardContent
+										image={image}
+										name={item.name}
+									/>
+								</div>
+							</TooltipTrigger>
+							<TooltipContent>
+								{item.helperText ?? item.name}
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				</div>
+			</div>
+		</div>
 	);
 };
 
@@ -277,9 +181,7 @@ export const FormMenu: React.FC<FormMenuProps> = ({
 	const activeItems: DesignerMenuItem[] = useMemo(() => {
 		const source = isCommunity ? communityBlocks : systemItems;
 		const s = search.trim().toLowerCase();
-
 		if (!s) return source;
-
 		return source.filter((item) => item.name.toLowerCase().includes(s));
 	}, [isCommunity, communityBlocks, systemItems, search]);
 
@@ -291,87 +193,110 @@ export const FormMenu: React.FC<FormMenuProps> = ({
 		onClose();
 	};
 
+	const rect = anchorEl?.getBoundingClientRect();
+
 	return (
-		<StyledQuickMenu
-			anchorEl={anchorEl}
+		<DropdownMenu
 			open={Boolean(anchorEl)}
-			onClose={onClose}
+			onOpenChange={(open) => !open && onClose()}
 		>
-			<Styledstack spacing={1}>
-				<StyledTitle>
-					<StyledTitleSpan>{title}</StyledTitleSpan>
-				</StyledTitle>
-				<Divider />
-				<Stack direction="row" alignItems="center">
-					<StyledTextField
-						placeholder={
-							isCommunity
-								? "Search community blocks"
-								: "Search system blocks"
-						}
-						size="small"
-						value={search}
-						onChange={(e) => setSearch(e.target.value)}
-						InputProps={{
-							startAdornment: (
-								<InputAdornment position="start">
-									<Search fontSize="small" />
-								</InputAdornment>
-							),
-						}}
-					/>
-				</Stack>
-
-				<StyledToggleTabsGroup
-					value={mode}
-					onChange={(_e: React.SyntheticEvent, val) => {
-						setMode(val as MODE);
+			<DropdownMenuTrigger asChild>
+				<span
+					style={{
+						position: "fixed",
+						top: rect?.bottom ?? 0,
+						left: rect?.left ?? 0,
+						width: 0,
+						height: 0,
 					}}
-				>
-					<StyledToggleTabsGroupItem
-						label="System Blocks"
-						value="SYSTEM"
-					/>
-					<StyledToggleTabsGroupItem
-						label="Community Blocks"
-						value="COMMUNITY"
-					/>
-				</StyledToggleTabsGroup>
+				/>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				className="w-[360px] max-w-[420px] rounded-xl p-0"
+				style={{
+					boxShadow: "0px 5px 24px 0px rgba(0, 0, 0, 0.32)",
+				}}
+				onClick={(e) => e.stopPropagation()}
+			>
+				<div className="flex flex-col gap-2 px-4 py-2">
+					<div
+						className="mt-1 mb-2 w-fit rounded-full px-4 py-0.5"
+						style={{
+							backgroundColor: "hsl(var(--primary) / 0.1)",
+						}}
+					>
+						<span
+							className="text-[13px] leading-[18px] tracking-[0.16px]"
+							style={{ color: "var(--Primary-Dark, #1260DD)" }}
+						>
+							{title}
+						</span>
+					</div>
 
-				<StyledGridWrapper>
-					{isCommunity && loadingCommunity ? (
-						<StyledTypography variant="body2">
-							Loading community blocks...
-						</StyledTypography>
-					) : activeItems.length ? (
-						<Grid container spacing={1.5} paddingLeft={0.5}>
-							{activeItems.map((block) => (
-								<Grid
-									item
-									xs={6} // 👉 two cards per row
-									key={`${parentId}-${block.name}`}
-									onClick={(e) => {
-										e.stopPropagation();
-										handleCardClick(block);
-									}}
-									style={{ cursor: "pointer" }}
-								>
-									<FormMenuBlockCard
-										item={block}
-										isCommunity={isCommunity}
-									/>
-								</Grid>
-							))}
-						</Grid>
-					) : (
-						<StyledTypography variant="body2">
-							{isCommunity && !anyCommunity
-								? "No community blocks found"
-								: "No blocks found"}
-						</StyledTypography>
-					)}
-				</StyledGridWrapper>
-			</Styledstack>
-		</StyledQuickMenu>
+					<Separator />
+
+					<div className="relative flex w-full items-center">
+						<Search className="absolute left-3 size-4 text-muted-foreground" />
+						<input
+							className="h-9 w-full rounded-md border border-input bg-transparent pr-3 pl-9 text-sm outline-none placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring"
+							placeholder={
+								isCommunity
+									? "Search community blocks"
+									: "Search system blocks"
+							}
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+						/>
+					</div>
+
+					<Tabs
+						value={mode}
+						onValueChange={(val) => setMode(val as MODE)}
+					>
+						<TabsList className="w-full">
+							<TabsTrigger value="SYSTEM" className="flex-1">
+								System Blocks
+							</TabsTrigger>
+							<TabsTrigger value="COMMUNITY" className="flex-1">
+								Community Blocks
+							</TabsTrigger>
+						</TabsList>
+					</Tabs>
+
+					<div className="max-h-[280px] w-full overflow-y-auto">
+						{isCommunity && loadingCommunity ? (
+							<p className="text-sm">
+								Loading community blocks...
+							</p>
+						) : activeItems.length ? (
+							<div className="grid grid-cols-2 gap-3 pl-0.5">
+								{activeItems.map((block) => (
+									<button
+										key={`${parentId}-${block.name}`}
+										type="button"
+										className="cursor-pointer text-left"
+										onClick={(e) => {
+											e.stopPropagation();
+											handleCardClick(block);
+										}}
+									>
+										<FormMenuBlockCard
+											item={block}
+											isCommunity={isCommunity}
+										/>
+									</button>
+								))}
+							</div>
+						) : (
+							<p className="text-sm">
+								{isCommunity && !anyCommunity
+									? "No community blocks found"
+									: "No blocks found"}
+							</p>
+						)}
+					</div>
+				</div>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 };

--- a/packages/client/src/components/designer/FormMenuHost.tsx
+++ b/packages/client/src/components/designer/FormMenuHost.tsx
@@ -24,6 +24,7 @@ export const FormMenuHost = observer(() => {
 		setAnchorEl(null);
 	};
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: handleClose is stable — only state depends on state
 	useEffect(() => {
 		const handleOpen = (e: Event) => {
 			const { detail } = e as CustomEvent<{ formId: string }>;

--- a/packages/client/src/components/designer/HoveredMask.tsx
+++ b/packages/client/src/components/designer/HoveredMask.tsx
@@ -1,73 +1,17 @@
 import { observer } from "mobx-react-lite";
 import { useLayoutEffect, useState } from "react";
 import { useBlocks } from "@semoss/renderer";
-import { styled, Typography } from "@semoss/ui";
 import { useDesigner } from "@/hooks";
 import { getBlockElement, getRelativeSize } from "@/stores";
-
-interface StyledContainerProps {
-	top: number;
-	left: number;
-	height: number;
-	width: number;
-	hideHoveredMask: boolean;
-}
-
-const StyledContainer = styled("div", {
-	shouldForwardProp: (prop) =>
-		!["top", "left", "height", "width", "hideHoveredMask"].includes(
-			prop as string,
-		),
-})<StyledContainerProps>(
-	({ theme, top, left, height, width, hideHoveredMask }) => ({
-		position: "absolute",
-		top: `${top}px`,
-		left: `${left}px`,
-		height: `${height}px`,
-		width: `${width}px`,
-		zIndex: "20",
-		opacity: hideHoveredMask ? 0 : 1,
-		pointerEvents: "none",
-		// outlineWidth: '2px',
-		// outlineStyle: 'solid',
-		// outlineColor: theme.palette.primary.light,
-		// outlineWidth: '2px',
-		// outlineStyle: 'solid',
-		outlineWidth: "3px",
-		outlineStyle: "dotted",
-		outlineColor: theme.palette.primary.dark,
-	}),
-);
-
-const StyledTitle = styled("div")(({ theme }) => ({
-	display: "inline-flex",
-	alignItems: "center",
-	position: "absolute",
-	top: theme.spacing(-3),
-	left: `-1px`,
-	height: theme.spacing(3),
-	paddingLeft: theme.spacing(1),
-	paddingRight: theme.spacing(1),
-	//added to match figma
-	borderRadius: "4px",
-	// backgroundColor: theme.palette.primary.light,
-	backgroundColor: theme.palette.primary.dark,
-	color: theme.palette.common.white,
-	whiteSpace: "nowrap",
-}));
 
 interface HoveredMaskProps {
 	/** Element to bind the mask to */
 	screenEle: HTMLDivElement;
 }
 
-/**
- * Show the information of a hovered block
- */
 export const HoveredMask = observer((props: HoveredMaskProps) => {
 	const { screenEle } = props;
 
-	// create the state
 	const [size, setSize] = useState<{
 		top: number;
 		left: number;
@@ -75,23 +19,17 @@ export const HoveredMask = observer((props: HoveredMaskProps) => {
 		width: number;
 	} | null>(null);
 
-	// get the store
 	const { designer } = useDesigner();
 	const { state } = useBlocks();
 	const variableName = state.getAlias(designer.hovered);
 
-	// get the root, watch changes, and reposition the mask
+	// biome-ignore lint/correctness/useExhaustiveDependencies: repositionMask depends on screenEle and designer.hovered
 	useLayoutEffect(() => {
-		// reposition the mask
 		const repositionMask = () => {
-			// get the block element
 			const blockEle = getBlockElement(designer.hovered);
-
 			if (!blockEle) {
 				return;
 			}
-
-			// calculate and set the side
 			const updated = getRelativeSize(blockEle, screenEle);
 			setSize(updated);
 		};
@@ -105,7 +43,6 @@ export const HoveredMask = observer((props: HoveredMaskProps) => {
 			childList: true,
 		});
 
-		// reposition it
 		repositionMask();
 
 		return () => observer.disconnect();
@@ -117,29 +54,53 @@ export const HoveredMask = observer((props: HoveredMaskProps) => {
 
 	const handleRename = (id: string): string => {
 		const block = state.getBlock(id);
-		if (block && block?.data?.id) {
+		if (block?.data?.id) {
 			return block.data.id as string;
 		}
 		return id;
 	};
 
+	const hideHoveredMask =
+		designer.hovered === designer.selected || designer.drag.active;
+
 	return (
-		<StyledContainer
-			top={size.top}
-			left={size.left}
-			height={size.height}
-			width={size.width}
-			hideHoveredMask={
-				designer.hovered === designer.selected || designer.drag.active
-			}
+		<div
+			style={{
+				position: "absolute",
+				top: `${size.top}px`,
+				left: `${size.left}px`,
+				height: `${size.height}px`,
+				width: `${size.width}px`,
+				zIndex: 20,
+				opacity: hideHoveredMask ? 0 : 1,
+				pointerEvents: "none",
+				outlineWidth: "3px",
+				outlineStyle: "dotted",
+				outlineColor: "var(--primary)",
+			}}
 		>
-			<StyledTitle>
-				<Typography variant={"body2"}>
+			<div
+				style={{
+					display: "inline-flex",
+					alignItems: "center",
+					position: "absolute",
+					top: "-24px",
+					left: "-1px",
+					height: "24px",
+					paddingLeft: "8px",
+					paddingRight: "8px",
+					borderRadius: "4px",
+					backgroundColor: "var(--primary)",
+					color: "white",
+					whiteSpace: "nowrap",
+				}}
+			>
+				<span className="text-sm">
 					{variableName
 						? variableName
 						: handleRename(designer.hovered)}
-				</Typography>
-			</StyledTitle>
-		</StyledContainer>
+				</span>
+			</div>
+		</div>
 	);
 });

--- a/packages/client/src/components/designer/Placeholder.tsx
+++ b/packages/client/src/components/designer/Placeholder.tsx
@@ -1,22 +1,7 @@
 import { observer } from "mobx-react-lite";
-import { styled } from "@semoss/ui";
 import { useDesigner } from "@/hooks";
 import type { DesignerStoreInterface } from "@/stores";
 
-const StyledPlaceholder = styled("div")(({ theme }) => ({
-	position: "absolute",
-	zIndex: "20",
-	pointerEvents: "none",
-	userSelect: "none",
-	backgroundColor: theme.palette.primary.main,
-}));
-
-/**
- * Calculate the size of the place holder
- * @param placeholderAction - action to track
- * @param placeholderSize - size of the tracked widget
- * @returns bounding box of the placeholder
- */
 function getPlaceholderStyle(
 	placeholderAction: DesignerStoreInterface["drag"]["placeholderAction"],
 	placeholderSize: DesignerStoreInterface["drag"]["placeholderSize"],
@@ -31,7 +16,6 @@ function getPlaceholderStyle(
 
 	const { type } = placeholderAction;
 
-	// calculate the relative size
 	if (type === "before") {
 		return {
 			top: `${placeholderSize.top - spacer / 2}px`,
@@ -42,9 +26,7 @@ function getPlaceholderStyle(
 		};
 	} else if (type === "after") {
 		return {
-			top: `${
-				placeholderSize.top + placeholderSize.height - spacer / 2
-			}px`,
+			top: `${placeholderSize.top + placeholderSize.height - spacer / 2}px`,
 			left: `${placeholderSize.left}px`,
 			height: `${spacer}px`,
 			width: `${placeholderSize.width}px`,
@@ -63,26 +45,22 @@ function getPlaceholderStyle(
 	return {};
 }
 
-/**
- * Rendered Placeholder for the view
- */
 export const Placeholder = observer(() => {
-	// get the store
 	const { designer } = useDesigner();
 
-	// get the placeholder information
 	if (!designer.drag.placeholderAction || !designer.drag.placeholderSize) {
-		return <></>;
+		return null;
 	}
 
 	return (
-		<StyledPlaceholder
+		<div
+			className="pointer-events-none absolute z-20 select-none bg-primary"
 			style={{
 				...getPlaceholderStyle(
 					designer.drag.placeholderAction,
 					designer.drag.placeholderSize,
 				),
 			}}
-		></StyledPlaceholder>
+		/>
 	);
 });

--- a/packages/client/src/components/designer/QuickMenu.tsx
+++ b/packages/client/src/components/designer/QuickMenu.tsx
@@ -1,5 +1,10 @@
 import type React from "react";
-import { Icon, Menu, Stack, styled, Typography } from "@semoss/ui";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@semoss/ui/next";
 
 interface QuickMenuProps {
 	parentId: string;
@@ -19,50 +24,47 @@ interface QuickMenuProps {
 	iconSize?: "small" | "medium" | "large";
 }
 
-const StyledQuickMenu = styled(Menu)(() => ({
-	"& .MuiMenu-paper": {
-		borderRadius: "4px",
-		background: "#FFF",
-		boxShadow: "0px 5px 24px 0px rgba(0, 0, 0, 0.32)",
-	},
-}));
-
-const StyledIcon = styled(Icon)(() => ({
-	color: "#757575",
-}));
-
 export const QuickMenu: React.FC<QuickMenuProps> = ({
 	parentId,
 	anchorEl,
 	quickMenu,
 	onClose,
 	onSelect,
-	color = "#757575",
-	iconSize = "small",
 }) => {
-	const handleOnSelect = (item) => {
-		onSelect(item);
-	};
+	const rect = anchorEl?.getBoundingClientRect();
+
 	return (
-		<StyledQuickMenu
-			anchorEl={anchorEl}
+		<DropdownMenu
 			open={Boolean(anchorEl)}
-			onClose={onClose}
+			onOpenChange={(open) => !open && onClose()}
 		>
-			{quickMenu.map((item) => (
-				<Menu.Item
-					key={`${parentId}-${item.value}`}
-					value={item.value}
-					onClick={() => handleOnSelect(item)}
-				>
-					<Stack direction="row" alignItems="center">
-						<StyledIcon sx={{ color }} fontSize={iconSize}>
+			<DropdownMenuTrigger asChild>
+				<span
+					style={{
+						position: "fixed",
+						top: rect?.bottom ?? 0,
+						left: rect?.left ?? 0,
+						width: 0,
+						height: 0,
+					}}
+				/>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent>
+				{quickMenu.map((item) => (
+					<DropdownMenuItem
+						key={`${parentId}-${item.value}`}
+						onClick={() => {
+							onSelect(item);
+							onClose();
+						}}
+					>
+						<div className="flex items-center gap-2">
 							{item.icon}
-						</StyledIcon>
-						<Typography variant="body2">{item.name}</Typography>
-					</Stack>
-				</Menu.Item>
-			))}
-		</StyledQuickMenu>
+							<span className="text-sm">{item.name}</span>
+						</div>
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 };

--- a/packages/client/src/components/designer/SelectedMask.tsx
+++ b/packages/client/src/components/designer/SelectedMask.tsx
@@ -1,55 +1,49 @@
-import { DragIndicator } from "@mui/icons-material";
+import { GripVertical } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 import { ActionMessages, useBlocks } from "@semoss/renderer";
-import { Stack, styled, Typography } from "@semoss/ui";
 import { toast } from "@semoss/ui/next";
 import { useDesigner } from "@/hooks";
 import { getBlockElement, getRelativeSize } from "@/stores";
 import { BlockSettingsRegistry } from "../blocks-workspace/blocks";
 
-const StyledContainer = styled("div")(({ theme }) => ({
+const containerStyle: React.CSSProperties = {
 	position: "absolute",
 	top: "0",
 	right: "0",
 	bottom: "0",
 	left: "0",
-	zIndex: "20",
+	zIndex: 20,
 	pointerEvents: "none",
 	userSelect: "none",
 	outlineWidth: "2px",
 	outlineStyle: "solid",
-	outlineColor: theme.palette.primary.main,
-}));
+	outlineColor: "var(--primary)",
+};
 
-const StyledTitle = styled("div")(({ theme }) => ({
+const titleStyle: React.CSSProperties = {
 	display: "inline-flex",
 	alignItems: "center",
 	position: "absolute",
-	top: theme.spacing(-3),
-	left: `-1px`,
-	height: theme.spacing(3),
-	paddingLeft: theme.spacing(1),
-	paddingRight: theme.spacing(1),
+	top: "-24px",
+	left: "-1px",
+	height: "24px",
+	paddingLeft: "8px",
+	paddingRight: "8px",
 	pointerEvents: "auto",
 	cursor: "grab",
-	backgroundColor: theme.palette.primary.main,
-	color: theme.palette.common.white,
+	backgroundColor: "var(--primary)",
+	color: "white",
 	whiteSpace: "nowrap",
-}));
+};
 
 interface SelectedMaskProps {
 	/** Element to bind the mask to */
 	screenEle: HTMLDivElement;
 }
 
-/**
- * Show the information of a selected block
- */
 export const SelectedMask = observer((props: SelectedMaskProps) => {
 	const { screenEle } = props;
-
-	// create the state
 
 	const [size, setSize] = useState<{
 		top: number;
@@ -59,19 +53,15 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 	} | null>(null);
 	const [local, setLocal] = useState(false);
 
-	// get the store
 	const { state } = useBlocks();
 	const { designer } = useDesigner();
 
-	// get the block
 	const block = state.getBlock(designer.selected);
 	const variableName = state.getAlias(designer.selected);
 
-	// check if it is draggable
 	const isDraggable =
 		block && BlockSettingsRegistry[block.widget] && block.widget !== "page";
 
-	// check if all blocks are draggable
 	const areAllBlocksDraggable = (): boolean => {
 		return designer.selectedBlocks.every((id) => {
 			const block = state.getBlock(id);
@@ -83,21 +73,16 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 		});
 	};
 
-	/**
-	 * Handle the mousedown on the block.
-	 */
 	const handleMouseDown = () => {
 		if (designer.selectedBlocks.length > 1) {
 			if (!areAllBlocksDraggable()) {
 				return;
 			}
-			// Handle drag for multiple selected blocks
 			designer.activateDrag(
 				designer.selectedBlocks
 					.map((id) => state.getBlock(id).widget)
 					.join(","),
 				(parent) => {
-					// Ensure none of the selected blocks are children of the parent
 					return !designer.selectedBlocks.some((id) =>
 						state.containsBlock(id, parent),
 					);
@@ -109,53 +94,38 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 				),
 			);
 
-			// Clear the hovered block
 			designer.setHovered("");
-
-			// Set as inactive
 			setLocal(true);
 		} else {
-			// Existing logic for single block drag
 			if (!isDraggable) {
 				return;
 			}
-			// set the dragged
 			designer.activateDrag(
 				block.widget,
 				(parent) => {
-					// if the parent block is a child of the selected, we cannot add
 					if (state.containsBlock(designer.selected, parent)) {
 						return false;
 					}
-
 					return true;
 				},
 				block.id,
 				BlockSettingsRegistry[block.widget].icon,
 			);
 
-			// Clear the hovered block
 			designer.setHovered("");
-
-			// Set as inactive
 			setLocal(true);
 		}
 	};
 
-	/**
-	 * Handle the mouseup event on the document
-	 */
 	const handleDocumentMouseUp = useCallback(() => {
 		if (!designer.drag.active) {
 			return;
 		}
-		// apply the action
 		const placeholderAction = designer.drag.placeholderAction;
 
 		if (placeholderAction) {
 			if (designer.selectedBlocks.length > 1) {
-				// Handle multiple block movements
-				let lastSiblingId = placeholderAction.id; // Start with the placeholder ID
+				let lastSiblingId = placeholderAction.id;
 				designer.selectedBlocks.forEach((id) => {
 					const sw = state.getBlock(placeholderAction.id);
 
@@ -163,7 +133,7 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 						placeholderAction.type === "before" ||
 						placeholderAction.type === "after"
 					) {
-						const siblingWidget = state.getBlock(lastSiblingId); // Use the last sibling ID
+						const siblingWidget = state.getBlock(lastSiblingId);
 
 						if (siblingWidget.parent) {
 							const parent = state.getBlock(sw.parent.id);
@@ -192,7 +162,6 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 								},
 							});
 
-							// Update the lastSiblingId to the current block
 							lastSiblingId = id;
 						}
 					} else if (placeholderAction.type === "replace") {
@@ -221,7 +190,6 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 					}
 				});
 			} else {
-				// Existing logic for single block movement
 				const sw = state.getBlock(placeholderAction.id);
 
 				if (
@@ -280,13 +248,8 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 			}
 		}
 
-		// Clear the drag
 		designer.deactivateDrag();
-
-		// Clear the hovered block
 		designer.setHovered("");
-
-		// Set as active
 		setLocal(false);
 	}, [
 		designer.selected,
@@ -297,39 +260,31 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 		designer,
 	]);
 
-	// reposition the mask
 	const repositionMask = () => {
-		// Use designer.selected or fallback to the first ID in designer.selectedIds
 		const selectedId = designer.selected || designer.selectedBlocks[0];
 		if (!selectedId) {
 			return;
 		}
 
 		const blockEle = getBlockElement(selectedId);
-
 		if (!blockEle) {
 			return;
 		}
 
-		// Calculate and set the size
 		const updated = getRelativeSize(blockEle, screenEle);
 		setSize(updated);
 	};
 
-	// update the mask when the screen is resized
 	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional mount-only listener
 	useEffect(() => {
 		window.addEventListener("resize", repositionMask);
 	}, []);
 
-	// block resized is a custom event emitted by SizeSettings
-	// so we know to updated the mask when width/height changes
 	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional mount-only listener
 	useEffect(() => {
 		window.addEventListener("blockResized", repositionMask);
 	}, []);
 
-	// get the root, watch changes, and reposition the mask
 	// biome-ignore lint/correctness/useExhaustiveDependencies: repositionMask is stable
 	useLayoutEffect(() => {
 		const observer = new MutationObserver(() => {
@@ -341,13 +296,11 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 			childList: true,
 		});
 
-		// reposition it
 		repositionMask();
 
 		return () => observer.disconnect();
 	}, [designer.selected]);
 
-	// add the mouse up listener when dragged
 	useEffect(() => {
 		if (!designer.drag.active || !local) {
 			return;
@@ -382,9 +335,10 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 					const blockSize = getRelativeSize(blockElement, screenEle);
 
 					return (
-						<StyledContainer
+						<div
 							key={id}
 							style={{
+								...containerStyle,
 								top: `${blockSize.top}px`,
 								left: `${blockSize.left}px`,
 								height: `${blockSize.height}px`,
@@ -392,34 +346,32 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 								opacity: designer.drag.active ? 0 : 1,
 							}}
 						>
-							<StyledTitle onMouseDown={handleMouseDown}>
-								<Stack direction={"row"}>
-									<Typography variant={"body2"}>
-										{variableName
-											? variableName
-											: String(
-													handleRename(
-														designer.selected,
-													),
-												)}
-									</Typography>
-								</Stack>
+							{/* biome-ignore lint/a11y/noStaticElementInteractions: drag handle — keyboard drag not applicable */}
+							<div
+								style={titleStyle}
+								onMouseDown={handleMouseDown}
+							>
+								<span className="text-sm">
+									{variableName
+										? variableName
+										: String(
+												handleRename(designer.selected),
+											)}
+								</span>
 								{areAllBlocksDraggable() && (
-									<DragIndicator
-										fontSize="inherit"
-										sx={{ marginLeft: "2px" }}
-									/>
+									<GripVertical className="ml-0.5 size-4" />
 								)}
-							</StyledTitle>
-						</StyledContainer>
+							</div>
+						</div>
 					);
 				})}
 			</>
 		);
 	} else {
 		return (
-			<StyledContainer
+			<div
 				style={{
+					...containerStyle,
 					top: `${size.top}px`,
 					left: `${size.left}px`,
 					height: `${size.height}px`,
@@ -427,22 +379,16 @@ export const SelectedMask = observer((props: SelectedMaskProps) => {
 					opacity: designer.drag.active ? 0 : 1,
 				}}
 			>
-				<StyledTitle onMouseDown={handleMouseDown}>
-					<Stack direction={"row"}>
-						<Typography variant={"body2"}>
-							{variableName
-								? variableName
-								: String(handleRename(designer.selected))}
-						</Typography>
-					</Stack>
-					{isDraggable && (
-						<DragIndicator
-							fontSize="inherit"
-							sx={{ marginLeft: "2px" }}
-						/>
-					)}
-				</StyledTitle>
-			</StyledContainer>
+				{/* biome-ignore lint/a11y/noStaticElementInteractions: drag handle — keyboard drag not applicable */}
+				<div style={titleStyle} onMouseDown={handleMouseDown}>
+					<span className="text-sm">
+						{variableName
+							? variableName
+							: String(handleRename(designer.selected))}
+					</span>
+					{isDraggable && <GripVertical className="ml-0.5 size-4" />}
+				</div>
+			</div>
 		);
 	}
 });

--- a/packages/client/src/components/designer/settings-mask/TextSettingsMask.tsx
+++ b/packages/client/src/components/designer/settings-mask/TextSettingsMask.tsx
@@ -1,75 +1,50 @@
 import { observer } from "mobx-react-lite";
 import { useLayoutEffect, useState } from "react";
 import { ActionMessages, useBlocks } from "@semoss/renderer";
-import { Autocomplete, Divider, styled, TextField } from "@semoss/ui";
+import {
+	Input,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@semoss/ui/next";
 import { useDesigner } from "@/hooks";
 
-const StyledInputContainer = styled("div")(({ theme }) => ({
-	display: "flex",
-	alignItems: "center",
-	gap: "8px",
-	boxShadow:
-		"0px 5px 22px 0px rgba(0, 0, 0, 0.10), 0px 4px 4px 0.5px rgba(0, 0, 0, 0.03)",
-	backgroundColor: "white",
-	padding: theme.spacing(1),
-	borderRadius: theme.shape.borderRadius,
-}));
-
 const FontStyleOptions = [
-	{
-		value: "Roboto",
-		display: "Roboto",
-	},
-	{
-		value: "Helvetica",
-		display: "Helvetica",
-	},
-	{
-		value: "Arial",
-		display: "Arial",
-	},
-	{
-		value: "Times New Roman",
-		display: "Times New Roman",
-	},
-	{
-		value: "Georgia",
-		display: "Georgia",
-	},
+	{ value: "Roboto", display: "Roboto" },
+	{ value: "Helvetica", display: "Helvetica" },
+	{ value: "Arial", display: "Arial" },
+	{ value: "Times New Roman", display: "Times New Roman" },
+	{ value: "Georgia", display: "Georgia" },
 ];
 
 export const TextSettingsMask = observer(() => {
-	// get the store
 	const { registry, state } = useBlocks();
 	const { designer } = useDesigner();
 
-	// get the block
 	const block = state.getBlock(designer.selected);
 
-	// check if it is visible
 	const isVisible =
 		block && registry[block.widget] && block.widget !== "page";
 
-	// track the value
 	const [value, setValue] = useState<{
 		fontFamily: string;
-		fontSize: number;
+		fontSize: number | null;
 	}>({
 		fontFamily: "",
 		fontSize: null,
 	});
 
-	// get the current style of the block
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — sync on block selection change
 	useLayoutEffect(() => {
 		if (!isVisible || block.widget !== "text") {
 			return;
 		}
-		// get the current style of the block
 		// biome-ignore lint/suspicious/noExplicitAny: suppressed as part of merge
 		const blockStyle: any = block.data.style;
 		if (blockStyle) {
 			const { fontFamily: ff, fontSize: fs } = blockStyle;
-			// set the initial value from the block's style
 			setValue({
 				fontFamily: ff ?? "",
 				fontSize:
@@ -78,25 +53,18 @@ export const TextSettingsMask = observer(() => {
 		}
 	}, [designer.selected, isVisible]);
 
-	/**
-	 * Sync the data on change
-	 */
 	const onChange = (
 		path: string,
 		newValue: string | number,
 		isValid: boolean,
 	) => {
-		// validate the path
 		if (!path) {
 			console.log("Invalid path passed!");
 			return;
 		}
-		// update the value
 		setValue({ ...value, [path]: newValue });
 
-		// check if the value is valid
 		if (isValid) {
-			// update the store
 			state.dispatch({
 				message: ActionMessages.SET_BLOCK_DATA,
 				payload: {
@@ -108,49 +76,51 @@ export const TextSettingsMask = observer(() => {
 		}
 	};
 
+	const hasFontSizeError =
+		value.fontSize !== null && (value.fontSize < 8 || value.fontSize > 94);
+
 	return (
-		<StyledInputContainer>
-			<Autocomplete
-				disablePortal
-				size="small"
-				options={FontStyleOptions.map((option) => option.value)}
-				sx={{ width: "70%" }}
-				renderInput={(params) => (
-					<TextField {...params} label="Fonts Style" />
-				)}
-				multiple={false}
-				value={value.fontFamily}
-				onChange={(e, newValue) =>
+		<div
+			className="flex items-center gap-2 rounded bg-white p-2"
+			style={{
+				boxShadow:
+					"0px 5px 22px 0px rgba(0, 0, 0, 0.10), 0px 4px 4px 0.5px rgba(0, 0, 0, 0.03)",
+			}}
+		>
+			<Select
+				value={value.fontFamily || undefined}
+				onValueChange={(newValue) =>
 					onChange("fontFamily", newValue, true)
 				}
-			/>
-			<Divider
-				orientation="vertical"
-				variant="middle"
-				sx={{ borderBottomWidth: 30 }}
-			/>
-			<TextField
-				size="small"
-				label="Size"
-				sx={{ width: "30%" }}
+			>
+				<SelectTrigger className="w-[70%]">
+					<SelectValue placeholder="Font Style" />
+				</SelectTrigger>
+				<SelectContent>
+					{FontStyleOptions.map((opt) => (
+						<SelectItem key={opt.value} value={opt.value}>
+							{opt.display}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+
+			<div className="h-8 border-l" />
+
+			<Input
 				type="number"
-				inputProps={{
-					min: 8,
-					max: 94,
-				}}
+				className={`w-[30%] ${hasFontSizeError ? "border-destructive" : ""}`}
+				placeholder="Size"
+				min={8}
+				max={94}
 				value={value.fontSize ?? ""}
 				onChange={(e) => {
-					// sync the data on change
 					const isValid =
 						Number(e.target.value) >= 8 &&
 						Number(e.target.value) <= 94;
 					onChange("fontSize", e.target.value, isValid);
 				}}
-				error={
-					value.fontSize &&
-					(value.fontSize < 8 || value.fontSize > 94)
-				}
 			/>
-		</StyledInputContainer>
+		</div>
 	);
 });


### PR DESCRIPTION
- Replace MUI icons with lucide-react across all designer components
- Migrate MUI Menu/Modal/styled to Radix DropdownMenu/Dialog/Tailwind
- Fix selected/hovered mask outline color (var(--primary) not hsl wrapper)
- Remove purple hover image swap; use primary-colored border on hover
- Wire form block database/table/column dropdowns to real engine data
- Fix SelectInputSettings allowUnset to use sentinel value (Radix constraint)