### PR TITLE
1014 fix favorites chat history

### DIFF
--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -100,6 +100,32 @@ export const GlobalNav = observer(() => {
 
 	const navigate = useNavigate();
 
+	const getPinnedRooms = useIteratorPixel<
+		{
+			ROOM_ID: string;
+			ROOM_NAME: string;
+			DATE_CREATED: string;
+			WORKSPACE_ID?: string;
+			PINNED?: boolean;
+		}[],
+		{
+			ROOM_ID: string;
+			ROOM_NAME: string;
+			DATE_CREATED: string;
+			WORKSPACE_ID?: string;
+			PINNED?: boolean;
+		}
+	>(
+		(limit, offset) =>
+			open
+				? `GetPlaygroundRooms(pinned=[true], limit=${limit}, offset=${offset}, sort=["DESC"]);`
+				: "",
+		() => -1,
+		(response) => response,
+		{ limit: 500 },
+		[],
+	);
+
 	const getRooms = useIteratorPixel<
 		{
 			ROOM_ID: string;
@@ -181,7 +207,12 @@ export const GlobalNav = observer(() => {
 		// keep this counter
 		chat.keys.roomCounter;
 		getRooms.reset();
-	}, [getRooms.reset, chat.keys.roomCounter]);
+		getPinnedRooms.reset();
+		if (scrollElementRef.current) {
+			scrollElementRef.current.scrollTop = 0;
+			setSavedScrollPosition(0);
+		}
+	}, [getRooms.reset, getPinnedRooms.reset, chat.keys.roomCounter]);
 
 	/**
 	 * Save and restore scroll position when sidebar opens/closes
@@ -205,17 +236,15 @@ export const GlobalNav = observer(() => {
 	/**
 	 * Bucket the rooms by date
 	 */
+	const pinnedRoomIds = new Set(getPinnedRooms.data.map((r) => r.ROOM_ID));
+
 	const bucketedRooms = getRooms.data.reduce(
 		(acc, val) => {
+			// Skip rooms handled by the dedicated pinned query
+			if (val.PINNED || pinnedRoomIds.has(val.ROOM_ID)) return acc;
+
 			const d = dayjs(`${val.DATE_CREATED}Z`);
 
-			// Pinned rooms only go in Favorites bucket
-			if (val.PINNED) {
-				acc[t("buckets.favorites")].push(val);
-				return acc; // Don't add to date buckets
-			}
-
-			// Non-pinned rooms go in date-based buckets
 			if (systemDate.isSame(d, "day")) {
 				acc[t("buckets.today")].push(val);
 			} else if (systemDate.subtract(1, "day").isSame(d, "day")) {
@@ -235,7 +264,7 @@ export const GlobalNav = observer(() => {
 			return acc;
 		},
 		{
-			[t("buckets.favorites")]: [],
+			[t("buckets.favorites")]: [...getPinnedRooms.data],
 			[t("buckets.today")]: [],
 			[t("buckets.yesterday")]: [],
 			[t("buckets.fewDaysAgo")]: [],
@@ -260,6 +289,7 @@ export const GlobalNav = observer(() => {
 
 			// Refetch rooms after toggling favorite
 			getRooms.reset();
+			getPinnedRooms.reset();
 		} catch {
 			toast.error(
 				isFavorite

--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -118,11 +118,11 @@ export const GlobalNav = observer(() => {
 	>(
 		(limit, offset) =>
 			open
-				? `GetPlaygroundRooms(pinned=[true], limit=${limit}, offset=${offset}, sort=["DESC"]);`
+				? `GetPlaygroundRooms(pinned=[true], offset=${offset}, sort=["DESC"]);`
 				: "",
 		() => -1,
 		(response) => response,
-		{ limit: 500 },
+		{},
 		[],
 	);
 


### PR DESCRIPTION
## Description
Provides a fix for the event where not all favorite chatrooms show up on UI upon load

## Changes Made
Major FE changes are in the global-nav, which correspond to BE changes
GetPlaygroundRooms reactor now has "pinned" param so 1 call can be made for all pinned rooms, and another call is made for non-pinned rooms (limit 25)

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Load the UI, and see if all favorites are present in the chat history sidebar
2. Check the network tab for the 2 BE calls, and see if they were completed successfully