### PR TITLE
feat(client): migrate block-settings icons and PDF viewer settings to @semoss/ui/next

### DIFF
--- a/libs/renderer/src/components/block-defaults/pdfViewer-block/PDFViewerBlock.tsx
+++ b/libs/renderer/src/components/block-defaults/pdfViewer-block/PDFViewerBlock.tsx
@@ -2,9 +2,9 @@ import { X } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { Env, runPixel } from "@semoss/sdk/react";
+import { runPixel } from "@semoss/sdk/react";
 import { Button, Spinner } from "@semoss/ui/next";
-import { useBlock } from "../../../hooks";
+import { useBlock, useBlocks } from "../../../hooks";
 import type { BlockComponent, BlockDef, ListenerActions } from "../../../store";
 
 export interface PDFViewerBlockDef extends BlockDef<"pdfViewer"> {
@@ -31,6 +31,8 @@ export const PDF_FILE_PREFIX = "data:application/pdf;base64,";
 
 export const PDFViewerBlock: BlockComponent = observer(({ id }) => {
 	const { attrs, data, setData, listeners } = useBlock<PDFViewerBlockDef>(id);
+	const { state } = useBlocks();
+	const isInteractive = state.mode === "interactive";
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [pdfContent, setPdfContent] = useState<string | null>(null);
@@ -61,38 +63,15 @@ export const PDFViewerBlock: BlockComponent = observer(({ id }) => {
 								base64Content.replace(/^data:.*?;base64,/, "");
 				} else {
 					const response = await runPixel<[string]>(
-						`DownloadAsset(filePath=["${path}"], space=["${appId}"]);`,
+						`GetAppAssetsBase64(filePath=["${path}"], project=["${appId}"]);`,
 					);
-					const fileKey = response?.pixelReturn[0]?.output;
-					const savedInsightId = response?.insightId;
-					if (!fileKey) throw new Error("Failed to get file key");
-					const url = `${Env.MODULE}/api/engine/downloadFile?insightId=${savedInsightId}&fileKey=${encodeURIComponent(fileKey as string)}`;
-					const fileResponse = await fetch(url, {
-						method: "GET",
-						headers: new Headers({
-							"Content-Type": "application/pdf",
-						}),
-					});
-					const blob = await fileResponse.blob();
-					return new Promise((resolve, reject) => {
-						const reader = new FileReader();
-						reader.onloadend = () => {
-							const base64data = reader.result as string;
-							if (!base64data.startsWith(PDF_FILE_PREFIX)) {
-								resolve(
-									PDF_FILE_PREFIX +
-										base64data.replace(
-											/^data:.*?;base64,/,
-											"",
-										),
-								);
-							} else {
-								resolve(base64data);
-							}
-						};
-						reader.onerror = reject;
-						reader.readAsDataURL(blob);
-					});
+					const base64Content = response?.pixelReturn[0]?.output;
+					if (!base64Content)
+						throw new Error("Failed to get base64 PDF");
+					return base64Content.startsWith(PDF_FILE_PREFIX)
+						? base64Content
+						: PDF_FILE_PREFIX +
+								base64Content.replace(/^data:.*?;base64,/, "");
 				}
 			} catch {
 				setError("Failed to load PDF");
@@ -173,12 +152,20 @@ export const PDFViewerBlock: BlockComponent = observer(({ id }) => {
 						data={pdfContent}
 						type="application/pdf"
 						className="h-full w-full"
+						style={
+							isInteractive
+								? { pointerEvents: "none" }
+								: undefined
+						}
 					>
 						<iframe
 							src={pdfContent}
 							title={fileName}
 							className="h-full min-h-[340px] w-full border-none"
-							style={{ height: "calc(100% - 35px)" }}
+							style={{
+								height: "calc(100% - 35px)",
+								pointerEvents: isInteractive ? "none" : "auto",
+							}}
 						/>
 					</object>
 				</div>

--- a/libs/ui/src/next/file-dropzone.tsx
+++ b/libs/ui/src/next/file-dropzone.tsx
@@ -1,0 +1,151 @@
+import { Upload, X } from "lucide-react";
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface FileDropzoneProps {
+	multiple?: boolean;
+	value?: File | File[] | null;
+	onChange?: (value: File | File[] | null) => void;
+	disabled?: boolean;
+	extensions?: string[];
+	description?: string;
+	className?: string;
+}
+
+const FileDropzone = React.forwardRef<HTMLDivElement, FileDropzoneProps>(
+	(
+		{
+			multiple = false,
+			value,
+			onChange,
+			disabled = false,
+			extensions = [],
+			description = "Click to browse or drop a file",
+			className,
+		},
+		ref,
+	) => {
+		const inputRef = React.useRef<HTMLInputElement>(null);
+		const [dragging, setDragging] = React.useState(false);
+
+		const files: File[] = React.useMemo(() => {
+			if (!value) return [];
+			return Array.isArray(value) ? value : [value];
+		}, [value]);
+
+		const accept = extensions.length ? extensions.join(",") : undefined;
+
+		const processFiles = (incoming: FileList | File[]) => {
+			const list = Array.from(incoming).filter((f) => {
+				if (!extensions.length) return true;
+				const ext = `.${f.name.split(".").pop()?.toLowerCase()}`;
+				return extensions.some(
+					(e) =>
+						e.toLowerCase() === ext ||
+						e.toLowerCase() === ext.slice(1),
+				);
+			});
+
+			if (!list.length) return;
+
+			if (multiple) {
+				const merged = [...files, ...list].filter(
+					(f, i, arr) =>
+						arr.findIndex((x) => x.name === f.name) === i,
+				);
+				onChange?.(merged);
+			} else {
+				onChange?.(list[0]);
+			}
+		};
+
+		const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+			if (e.target.files) processFiles(e.target.files);
+			e.target.value = "";
+		};
+
+		const handleDrop = (e: React.DragEvent) => {
+			e.preventDefault();
+			setDragging(false);
+			if (disabled) return;
+			processFiles(e.dataTransfer.files);
+		};
+
+		const removeFile = (name: string) => {
+			if (multiple) {
+				const next = (files as File[]).filter((f) => f.name !== name);
+				onChange?.(next.length ? next : null);
+			} else {
+				onChange?.(null);
+			}
+		};
+
+		return (
+			<div ref={ref} className={cn("flex flex-col gap-2", className)}>
+				<button
+					type="button"
+					disabled={disabled}
+					onClick={() => inputRef.current?.click()}
+					onDragEnter={(e) => {
+						e.preventDefault();
+						if (!disabled) setDragging(true);
+					}}
+					onDragOver={(e) => {
+						e.preventDefault();
+					}}
+					onDragLeave={(e) => {
+						e.preventDefault();
+						setDragging(false);
+					}}
+					onDrop={handleDrop}
+					className={cn(
+						"flex w-full flex-col items-center justify-center gap-1 rounded-md border border-dashed px-4 py-5 text-sm transition-colors",
+						dragging
+							? "border-primary bg-primary/5 text-primary"
+							: "border-border text-muted-foreground hover:border-primary hover:text-foreground",
+						disabled && "pointer-events-none opacity-50",
+					)}
+				>
+					<Upload className="size-5" />
+					<span>{description}</span>
+					<input
+						ref={inputRef}
+						type="file"
+						accept={accept}
+						multiple={multiple}
+						disabled={disabled}
+						className="hidden"
+						onChange={handleInput}
+					/>
+				</button>
+
+				{files.length > 0 && (
+					<ul className="flex flex-col gap-1">
+						{files.map((f) => (
+							<li
+								key={f.name}
+								className="flex items-center justify-between rounded-md border border-border bg-muted/30 px-3 py-1.5 text-sm"
+							>
+								<span className="truncate">{f.name}</span>
+								{!disabled && (
+									<button
+										type="button"
+										onClick={() => removeFile(f.name)}
+										className="ml-2 shrink-0 rounded p-0.5 hover:bg-accent"
+										aria-label={`Remove ${f.name}`}
+									>
+										<X className="size-3.5 text-muted-foreground" />
+									</button>
+								)}
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+		);
+	},
+);
+
+FileDropzone.displayName = "FileDropzone";
+
+export { FileDropzone, type FileDropzoneProps };

--- a/libs/ui/src/next/index.ts
+++ b/libs/ui/src/next/index.ts
@@ -25,6 +25,7 @@ export * from "./dialog";
 export * from "./drawer";
 export * from "./dropdown-menu";
 export * from "./field";
+export * from "./file-dropzone";
 export * from "./hover-card";
 export * from "./input";
 export * from "./input-group";

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/accordion-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/accordion-block/config.tsx
@@ -1,4 +1,4 @@
-import { Schema } from "@mui/icons-material";
+import { Network } from "lucide-react";
 import { ColorSettings } from "../../settings";
 import { SwitchSettings } from "../../settings/shared/SwitchSettings";
 import { BLOCK_TYPE_LAYOUT } from "../block-defaults.constants";
@@ -13,7 +13,7 @@ import type { BlockSettingsConfig } from "../settings.types";
 
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_LAYOUT,
-	icon: Schema,
+	icon: Network,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/audio-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/audio-block/config.tsx
@@ -1,4 +1,4 @@
-import HeadsetIcon from "@mui/icons-material/Headset";
+import { Headphones } from "lucide-react";
 import type { CSSProperties } from "react";
 import { InputSettings, QueryInputSettings } from "../../settings/";
 import { SwitchSettings } from "../../settings/shared/SwitchSettings";
@@ -11,7 +11,7 @@ export const DefaultStyles: CSSProperties = {};
 // export the config for the block
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_ACTION,
-	icon: HeadsetIcon,
+	icon: Headphones,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/audio-input-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/audio-input-block/config.tsx
@@ -1,5 +1,4 @@
-import { KeyboardVoice } from "@mui/icons-material";
-import { CSSProperties } from "react";
+import { Mic } from "lucide-react";
 import { QuerySelectionSettings, SelectInputSettings } from "../../settings";
 import { InputAudioSettings } from "../../settings/shared/InputAudioSettings";
 import { BLOCK_TYPE_INPUT } from "../block-defaults.constants";
@@ -13,7 +12,7 @@ import type { BlockSettingsConfig } from "../settings.types";
 // export the config for the block
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_INPUT,
-	icon: KeyboardVoice,
+	icon: Mic,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/button-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/button-block/config.tsx
@@ -1,4 +1,4 @@
-import { SmartButton } from "@mui/icons-material";
+import { Square } from "lucide-react";
 import type { CSSProperties } from "react";
 import {
 	InputSettings,
@@ -18,7 +18,7 @@ export const DefaultStyles: CSSProperties = {};
 // export the config for the block
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_ACTION,
-	icon: SmartButton,
+	icon: Square,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/checkbox-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/checkbox-block/config.tsx
@@ -1,5 +1,5 @@
-import { CheckBox } from "@mui/icons-material";
-import { InputSettings, SelectInputSettings } from "../../settings";
+import { CheckSquare } from "lucide-react";
+import { InputSettings } from "../../settings";
 import { SwitchSettings } from "../../settings/shared/SwitchSettings";
 import { BLOCK_TYPE_INPUT } from "../block-defaults.constants";
 import { buildListener, buildShowField } from "../block-defaults.shared";
@@ -8,7 +8,7 @@ import type { BlockSettingsConfig } from "../settings.types";
 // export the config for the block
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_INPUT,
-	icon: CheckBox,
+	icon: CheckSquare,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/chip-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/chip-block/config.tsx
@@ -1,4 +1,4 @@
-import { LabelRounded } from "@mui/icons-material";
+import { Tag } from "lucide-react";
 import type { CSSProperties } from "react";
 import {
 	ColorSettings,
@@ -15,7 +15,7 @@ export const DefaultStyles: CSSProperties = {};
 
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_DISPLAY,
-	icon: LabelRounded,
+	icon: Tag,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/divider-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/divider-block/config.tsx
@@ -1,4 +1,4 @@
-import { HorizontalRule } from "@mui/icons-material";
+import { Minus } from "lucide-react";
 import type { CSSProperties } from "react";
 import { InputSettings, SelectInputSettings } from "../../settings";
 import { SwitchSettings } from "../../settings/shared/SwitchSettings";
@@ -15,7 +15,7 @@ export const DefaultStyles: CSSProperties = {};
 // export the config for the block
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_DISPLAY,
-	icon: HorizontalRule,
+	icon: Minus,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/form-block/fields.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/form-block/fields.tsx
@@ -1,4 +1,3 @@
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { observer } from "mobx-react-lite";
 import { useMemo, useState } from "react";
 import {
@@ -7,49 +6,17 @@ import {
 	type Paths,
 	useBlocks,
 } from "@semoss/renderer";
-import { Accordion, Box, Menu, Select, styled, Typography } from "@semoss/ui";
-
-const StyledAccordionTrigger = styled(Accordion.Trigger)(({ theme }) => ({
-	"& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
-		transform: "rotate(180deg)",
-	},
-	"&.Mui-expanded": {
-		backgroundColor: theme.palette.primary.selected,
-	},
-	transition: "background-color 0.2s ease",
-}));
-
-const StyledSpan = styled("span")(() => ({
-	fontSize: "14px",
-	fontStyle: "normal",
-	lineHeight: "143%",
-	letterSpacing: "0.17px",
-	fontFamily: '"Inter", sans-serif',
-	textTransform: "uppercase",
-	fontWeight: 400,
-}));
-
-const StyledBox = styled(Box)(({ theme }) => ({
-	width: "100%",
-	maxWidth: "700px",
-	margin: "auto",
-}));
-
-const MainAccordion = styled(Accordion)(({ theme }) => ({
-	marginBottom: theme.spacing(1),
-}));
-
-const StyledAccordion = styled(Accordion)(({ theme }) => ({
-	marginBottom: theme.spacing(1),
-	boxShadow: "none",
-	border: "none",
-}));
-
-const InnerBox = styled(Box)(() => ({
-	display: "flex",
-	flexDirection: "column",
-	gap: 1,
-}));
+import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@semoss/ui/next";
 
 interface SelectInputSettingsProps<D extends BlockDef = BlockDef> {
 	id: string;
@@ -59,7 +26,7 @@ interface SelectInputSettingsProps<D extends BlockDef = BlockDef> {
 export const FieldSettings = observer(
 	<D extends BlockDef = BlockDef>({
 		id,
-		path,
+		path: _path,
 	}: SelectInputSettingsProps<D>) => {
 		const { state } = useBlocks();
 		const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -69,9 +36,7 @@ export const FieldSettings = observer(
 
 		if (!block) {
 			return (
-				<Typography variant={"h6"} fontWeight="regular">
-					No block found for ID
-				</Typography>
+				<p className="font-normal text-base">No block found for ID</p>
 			);
 		}
 
@@ -103,120 +68,108 @@ export const FieldSettings = observer(
 		};
 
 		return (
-			<StyledBox>
+			<div className="mx-auto w-full max-w-[700px]">
 				{childrenIds.length === 0 ? (
-					<Typography
-						color="textSecondary"
-						variant={"h6"}
-						fontWeight="regular"
-					>
+					<p className="font-normal text-base text-muted-foreground">
 						No children found
-					</Typography>
+					</p>
 				) : (
-					childrenIds.map((childId) => {
-						const child = state.getBlock(childId);
-						const childData = (child && child.data) || {};
-						const requiredStr = String(!!childData.required);
-						const disabledStr = String(!!childData.disabled);
+					<Accordion
+						type="single"
+						collapsible
+						value={expandedId}
+						onValueChange={(val) => setExpandedId(val)}
+					>
+						{childrenIds.map((childId) => {
+							const child = state.getBlock(childId);
+							const childData = child?.data || {};
+							const requiredStr = String(!!childData.required);
+							const disabledStr = String(!!childData.disabled);
 
-						if (!child) {
-							return (
-								<MainAccordion key={childId}>
-									<Accordion.Content
-										aria-controls={`${childId}-content`}
-										key={`${childId}-header`}
+							if (!child) {
+								return (
+									<AccordionItem
+										key={childId}
+										value={childId}
 									>
-										<Typography
-											fontWeight="bold"
-											variant={"button"}
-										>
+										<AccordionTrigger>
+											<span className="font-bold text-sm uppercase">
+												{childId}
+											</span>
+										</AccordionTrigger>
+										<AccordionContent />
+									</AccordionItem>
+								);
+							}
+
+							return (
+								<AccordionItem key={childId} value={childId}>
+									<AccordionTrigger>
+										<span className="text-sm uppercase tracking-wide">
 											{childId}
-										</Typography>
-									</Accordion.Content>
-								</MainAccordion>
+										</span>
+									</AccordionTrigger>
+									<AccordionContent>
+										<div className="flex flex-col gap-1">
+											<p className="font-normal text-muted-foreground text-sm">
+												Required
+											</p>
+											<Select
+												value={requiredStr}
+												onValueChange={(val) => {
+													handleTextToggle(
+														childId,
+														"required",
+														val,
+													);
+												}}
+											>
+												<SelectTrigger className="w-full">
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="true">
+														True
+													</SelectItem>
+													<SelectItem value="false">
+														False
+													</SelectItem>
+												</SelectContent>
+											</Select>
+
+											<p className="font-normal text-muted-foreground text-sm">
+												Disabled
+											</p>
+											<Select
+												value={disabledStr}
+												onValueChange={(val) => {
+													handleTextToggle(
+														childId,
+														"disabled",
+														val,
+													);
+												}}
+											>
+												<SelectTrigger className="w-full">
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="true">
+														True
+													</SelectItem>
+													<SelectItem value="false">
+														False
+													</SelectItem>
+												</SelectContent>
+											</Select>
+										</div>
+									</AccordionContent>
+								</AccordionItem>
 							);
-						}
-
-						const isExpanded = expandedId === childId;
-
-						return (
-							<StyledAccordion
-								expanded={isExpanded}
-								onChange={() =>
-									setExpandedId((prev) =>
-										prev === childId ? null : childId,
-									)
-								}
-								key={childId}
-							>
-								<StyledAccordionTrigger
-									expandIcon={<ExpandMoreIcon />}
-								>
-									<StyledSpan>{childId}</StyledSpan>
-								</StyledAccordionTrigger>
-
-								<Accordion.Content>
-									<InnerBox>
-										<Typography
-											variant="body2"
-											fontWeight="regular"
-											color="textSecondary"
-										>
-											Required
-										</Typography>
-										<Select
-											fullWidth
-											size="small"
-											value={requiredStr}
-											onChange={(e) => {
-												handleTextToggle(
-													childId,
-													"required",
-													e.target.value,
-												);
-											}}
-										>
-											<Menu.Item value={"true"}>
-												True
-											</Menu.Item>
-											<Menu.Item value={"false"}>
-												False
-											</Menu.Item>
-										</Select>
-
-										<Typography
-											variant="body2"
-											fontWeight="regular"
-											color="textSecondary"
-										>
-											Disabled
-										</Typography>
-										<Select
-											fullWidth
-											size="small"
-											value={disabledStr}
-											onChange={(e) => {
-												handleTextToggle(
-													childId,
-													"disabled",
-													e.target.value,
-												);
-											}}
-										>
-											<Menu.Item value={"true"}>
-												True
-											</Menu.Item>
-											<Menu.Item value={"false"}>
-												False
-											</Menu.Item>
-										</Select>
-									</InnerBox>
-								</Accordion.Content>
-							</StyledAccordion>
-						);
-					})
+						})}
+					</Accordion>
 				)}
-			</StyledBox>
+			</div>
 		);
 	},
 );

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/grid-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/grid-block/config.tsx
@@ -1,4 +1,4 @@
-import { TableChart } from "@mui/icons-material";
+import { Table } from "lucide-react";
 import { GridBlockMenu } from "./../../settings/custom/grid-two/GridBlockMenu";
 import { BLOCK_TYPE_DATA } from "../block-defaults.constants";
 import type { BlockSettingsConfig } from "../settings.types";
@@ -6,6 +6,6 @@ import type { BlockSettingsConfig } from "../settings.types";
 // export the config for the block
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_DATA,
-	icon: TableChart,
+	icon: Table,
 	menu: GridBlockMenu,
 };

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/icon-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/icon-block/config.tsx
@@ -1,4 +1,4 @@
-import { InsertEmoticon } from "@mui/icons-material";
+import { Smile } from "lucide-react";
 import { ColorSettings } from "../../settings";
 import {
 	IconSelectSettings,
@@ -14,7 +14,7 @@ import type { BlockSettingsConfig } from "../settings.types";
 
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_DISPLAY,
-	icon: InsertEmoticon,
+	icon: Smile,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/GeneralSettings.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/GeneralSettings.tsx
@@ -1,7 +1,6 @@
 import { observer } from "mobx-react-lite";
 import { useParams } from "react-router-dom";
 import { useBlock } from "@semoss/renderer";
-import { Box, styled } from "@semoss/ui";
 import { useRootStore } from "@/hooks";
 import TabsComponent from "./SelectionTabs";
 
@@ -9,17 +8,13 @@ interface GeneralSettingsProps {
 	id: string;
 }
 
-const StyledBox = styled(Box)({
-	width: "100%",
-});
-
 const GeneralSettings: React.FC<GeneralSettingsProps> = observer(({ id }) => {
 	const { data, setData } = useBlock(id);
 	const { configStore } = useRootStore();
 	const { appId } = useParams();
 
 	return (
-		<StyledBox>
+		<div className="w-full">
 			<TabsComponent
 				{...{
 					data,
@@ -29,7 +24,7 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = observer(({ id }) => {
 					setData,
 				}}
 			/>
-		</StyledBox>
+		</div>
 	);
 });
 

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/App.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/App.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { upload, usePixel } from "@semoss/sdk/react";
-import { FileDropzone, Typography } from "@semoss/ui";
+import { FileDropzone } from "@semoss/ui";
 import { toast } from "@semoss/ui/next";
 import { getImageFiles, imageExtensions } from "../utils";
 import SelectedItem from "./SelectedItem";
@@ -8,7 +8,7 @@ import SelectImage from "./SelectImage";
 
 const AppTab = ({ id, data, setData, appId, insightId }) => {
 	const [isLoading, setIsLoading] = useState(false);
-	// biome-ignore lint/suspicious/noExplicitAny: pixel response shape uses any
+	// biome-ignore lint/suspicious/noExplicitAny: pixel response data is untyped
 	const getAssets = usePixel<{ status: string; data: any }>(
 		`BrowseAppAssets(project=["${appId}"], filePath=["/"]);`,
 	);
@@ -34,7 +34,7 @@ const AppTab = ({ id, data, setData, appId, insightId }) => {
 		}
 	};
 	if (isLoading) {
-		return <Typography variant="body1">Loading...</Typography>;
+		return <p className="text-sm">Loading...</p>;
 	}
 	if (data?.src instanceof Object) {
 		return <SelectedItem file={data.src} setData={setData} />;
@@ -47,9 +47,7 @@ const AppTab = ({ id, data, setData, appId, insightId }) => {
 				setData={setData}
 				data-testid="select-image"
 			/>
-			<Typography variant="body1" align="center">
-				Or
-			</Typography>
+			<p className="text-center text-sm">Or</p>
 			<FileDropzone
 				description="Upload your image here"
 				extensions={imageExtensions}

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/External.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/External.tsx
@@ -1,4 +1,11 @@
-import { Select, TextField } from "@semoss/ui";
+import {
+	Input,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@semoss/ui/next";
 import { BaseSettingSection, InputSettings } from "../../../settings";
 import SelectedItem from "./SelectedItem";
 
@@ -9,15 +16,12 @@ const ExternalTab = ({ id, data, setData }) => (
 		) : (
 			<>
 				<BaseSettingSection label={"Image URL"}>
-					<TextField
-						fullWidth
+					<Input
 						value={data.src ?? ""}
 						onChange={(e) => {
 							setData("src", e.target.value);
 						}}
 						type={"text"}
-						size="small"
-						variant="outlined"
 						autoComplete="off"
 						data-testid="image-url"
 					/>
@@ -30,22 +34,25 @@ const ExternalTab = ({ id, data, setData }) => (
 				/>
 				<BaseSettingSection label="If Image is Unavailable">
 					<Select
-						fullWidth
 						value={data.unavailable ?? ""}
-						onChange={(e) => {
-							const value = e.target.value as string;
+						onValueChange={(value) => {
 							setData("unavailable", value);
 						}}
-						size="small"
-						variant="outlined"
-						data-testid="image-unavailable"
 					>
-						<Select.Item value="placeholder">
-							Add placeholder text
-						</Select.Item>
-						<Select.Item value="default">
-							Use system default image
-						</Select.Item>
+						<SelectTrigger
+							className="w-full"
+							data-testid="image-unavailable"
+						>
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="placeholder">
+								Add placeholder text
+							</SelectItem>
+							<SelectItem value="default">
+								Use system default image
+							</SelectItem>
+						</SelectContent>
 					</Select>
 				</BaseSettingSection>
 			</>

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/Insight.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/Insight.tsx
@@ -4,6 +4,7 @@ import SelectedItem from "./SelectedItem";
 import SelectImage from "./SelectImage";
 
 const InsightTab = ({ insightId, data, setData }) => {
+	// biome-ignore lint/suspicious/noExplicitAny: pixel response data is untyped
 	const getAssets = usePixel<{ status: string; data: any }>(
 		`BrowseAsset(filePath=["/"] );`,
 		{},

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/SelectImage.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/SelectImage.tsx
@@ -1,9 +1,14 @@
-import { Select } from "@semoss/ui";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@semoss/ui/next";
 import { BaseSettingSection } from "../../../settings";
 
 const SelectImage = ({ data, imageFiles, setData }) => {
-	const onImageChange = (e) => {
-		const selectedName = e.target.value;
+	const onImageChange = (selectedName: string) => {
 		const selectedFile = imageFiles.find((f) => f.name === selectedName);
 		if (selectedFile) {
 			setData("src", {
@@ -17,18 +22,19 @@ const SelectImage = ({ data, imageFiles, setData }) => {
 	return (
 		<BaseSettingSection label="">
 			<Select
-				label="Select Image"
-				size="small"
-				fullWidth
 				value={(data.src?.fileName ?? "") as string}
-				onChange={onImageChange}
-				data-testid="select-image"
+				onValueChange={onImageChange}
 			>
-				{imageFiles?.map((file) => (
-					<Select.Item key={file.name} value={file.name}>
-						{file.name}
-					</Select.Item>
-				))}
+				<SelectTrigger className="w-full" data-testid="select-image">
+					<SelectValue placeholder="Select Image" />
+				</SelectTrigger>
+				<SelectContent>
+					{imageFiles?.map((file) => (
+						<SelectItem key={file.name} value={file.name}>
+							{file.name}
+						</SelectItem>
+					))}
+				</SelectContent>
 			</Select>
 		</BaseSettingSection>
 	);

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/SelectedItem.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/SelectedItem.tsx
@@ -1,46 +1,28 @@
-import DeleteIcon from "@mui/icons-material/Delete";
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import { Box, IconButton, List, styled, Typography } from "@semoss/ui";
-
-const StyledListItem = styled(Box)(({ theme }) => ({
-	display: "flex",
-	alignItems: "center",
-	gap: theme.spacing(1),
-}));
-
-const StyledInfo = styled(Typography)(({ theme }) => ({
-	color: theme.palette.text.disabled,
-	display: "flex",
-	alignItems: "center",
-	gap: theme.spacing(1),
-	marginTop: 0,
-}));
-
-const StyledInfoIcon = styled(InfoOutlinedIcon)({
-	fontSize: 2,
-});
+import { Info, Trash2 } from "lucide-react";
+import { Button } from "@semoss/ui/next";
 
 const SelectedItem = ({ file, setData }) => {
 	return file ? (
-		<Box>
-			<StyledListItem>
-				<List.ItemText>{file.fileName}</List.ItemText>
-				<IconButton
+		<div>
+			<div className="flex items-center gap-2">
+				<span className="text-sm">{file.fileName}</span>
+				<Button
+					variant="ghost"
+					size="icon-sm"
 					data-testid="remove-image"
-					edge="end"
 					aria-label="delete"
 					onClick={() => {
 						setData("src", "");
 					}}
 				>
-					<DeleteIcon color="error" />
-				</IconButton>
-			</StyledListItem>
-			<StyledInfo variant="caption">
-				<StyledInfoIcon />
+					<Trash2 className="size-4 text-destructive" />
+				</Button>
+			</div>
+			<p className="mt-0 flex items-center gap-1 text-muted-foreground text-xs">
+				<Info className="size-4" />
 				Delete current file to upload a new one.
-			</StyledInfo>
-		</Box>
+			</p>
+		</div>
 	) : null;
 };
 

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/index.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/index.tsx
@@ -1,40 +1,34 @@
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { Info as InfoOutlinedIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useMemo, useState } from "react";
-import { Stack, styled, Tab, Tabs, Tooltip } from "@semoss/ui";
+import {
+	Tabs,
+	TabsList,
+	TabsTrigger,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@semoss/ui/next";
 import AppTab from "./App";
 import ExternalTab from "./External";
 import InsightTab from "./Insight";
 
 type TabRenderProps = {
 	id: string;
+	// biome-ignore lint/suspicious/noExplicitAny: image block data is untyped
 	data: any;
+	// biome-ignore lint/suspicious/noExplicitAny: upload callback uses untyped promise
 	uploadFile?: (file: File, appId: string, path: string) => Promise<any>;
 	appId: string;
 	insightId?: string;
+	// biome-ignore lint/suspicious/noExplicitAny: setData path/value are dynamically typed
 	setData?: (path: string, value: any, force?: boolean) => void;
 };
-
-const StyledTabs = styled(Tabs)({
-	display: "flex",
-	justifyContent: "space-between",
-	minHeight: 36,
-});
-
-const StyledTab = styled(Tab)({
-	minHeight: 30,
-	px: 2,
-	py: 1,
-	flex: 1,
-});
-
-const StyledInfoIcon = styled(InfoOutlinedIcon)({
-	fontSize: 2,
-});
 
 const tabConfig = [
 	{
 		label: "Insight",
+		value: "insight",
 		tooltip: "Image generated when the app runs",
 		render: ({ insightId, data, setData }: TabRenderProps) => (
 			<InsightTab insightId={insightId} data={data} setData={setData} />
@@ -42,6 +36,7 @@ const tabConfig = [
 	},
 	{
 		label: "App",
+		value: "app",
 		tooltip: "Image stored in app assets",
 		render: ({ id, data, setData, appId, insightId }: TabRenderProps) => (
 			<AppTab
@@ -55,6 +50,7 @@ const tabConfig = [
 	},
 	{
 		label: "External",
+		value: "external",
 		tooltip: "Add image from external link",
 		render: ({ id, data, setData }: TabRenderProps) => (
 			<ExternalTab id={id} data={data} setData={setData} />
@@ -64,18 +60,18 @@ const tabConfig = [
 
 const TabsComponent = observer(
 	({ data, setData, insightId, appId, id }: TabRenderProps) => {
-		const [value, setValue] = useState(0);
-		const handleChange = (_: React.SyntheticEvent, newValue: number) => {
-			setValue(newValue);
-		};
+		const [value, setValue] = useState("insight");
 
+		// biome-ignore lint/suspicious/noExplicitAny: image data value is dynamically typed
 		const updateData = (path: string, value: any) => {
 			setData(path, value, true);
 		};
 
+		const activeTab = tabConfig.find((t) => t.value === value);
+		// biome-ignore lint/correctness/useExhaustiveDependencies: updateData is stable within render
 		const tabContent = useMemo(
 			() =>
-				tabConfig[value]?.render?.({
+				activeTab?.render?.({
 					id,
 					data,
 					setData: updateData,
@@ -86,35 +82,30 @@ const TabsComponent = observer(
 		);
 
 		return (
-			<>
-				<StyledTabs
-					value={value}
-					onChange={handleChange}
-					TabIndicatorProps={{
-						sx: {
-							top: "inherit",
-							bottom: "unset",
-						},
-					}}
-					data-testid="image-tabs"
-				>
+			<Tabs
+				value={value}
+				onValueChange={setValue}
+				data-testid="image-tabs"
+			>
+				<TabsList className="w-full">
 					{tabConfig.map((tab) => (
-						<StyledTab
-							key={tab.label}
-							label={tab.label}
-							iconPosition="end"
-							icon={
-								<Tooltip title={tab.tooltip} placement="top">
-									<StyledInfoIcon />
-								</Tooltip>
-							}
-						/>
+						<TabsTrigger
+							key={tab.value}
+							value={tab.value}
+							className="flex-1"
+						>
+							{tab.label}
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<InfoOutlinedIcon className="ml-1 size-3" />
+								</TooltipTrigger>
+								<TooltipContent>{tab.tooltip}</TooltipContent>
+							</Tooltip>
+						</TabsTrigger>
 					))}
-				</StyledTabs>
-				<Stack flexDirection={"column"} marginTop={2}>
-					{tabContent}
-				</Stack>
-			</>
+				</TabsList>
+				<div className="mt-2 flex flex-col">{tabContent}</div>
+			</Tabs>
 		);
 	},
 );

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/config.tsx
@@ -1,9 +1,9 @@
 import {
-	AspectRatio,
-	FitScreen,
-	ImageAspectRatio,
-	PanoramaOutlined,
-} from "@mui/icons-material";
+	Maximize as FitScreen,
+	Ratio as ImageAspectRatio,
+	Maximize2,
+	Image as PanoramaOutlined,
+} from "lucide-react";
 import { ButtonGroupSettings, SelectInputSettings } from "../../settings";
 import { BLOCK_TYPE_DISPLAY } from "../block-defaults.constants";
 import {
@@ -56,7 +56,7 @@ export const config: BlockSettingsConfig = {
 								},
 								{
 									value: "cover",
-									icon: AspectRatio,
+									icon: Maximize2,
 									title: "cover",
 									isDefault: false,
 								},

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/input-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/input-block/config.tsx
@@ -1,4 +1,4 @@
-import { FormatShapes } from "@mui/icons-material";
+import { Shapes } from "lucide-react";
 import type { CSSProperties } from "react";
 import { InputSettings, QuerySelectionSettings } from "../../settings";
 import { InputModalSettings } from "../../settings/shared/InputModalSettings";
@@ -15,7 +15,7 @@ export const DefaultStyles: CSSProperties = {
 // export the config for the block
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_INPUT,
-	icon: FormatShapes,
+	icon: Shapes,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/markdown-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/markdown-block/config.tsx
@@ -1,15 +1,11 @@
-import { FormatListBulleted } from "@mui/icons-material";
+import { List } from "lucide-react";
 import { QueryInputSettings } from "../../settings";
 import { ShowLoadingSettings } from "../../settings/shared/ShowLoadingSettings";
 import { SwitchSettings } from "../../settings/shared/SwitchSettings";
 import { BLOCK_TYPE_DISPLAY } from "../block-defaults.constants";
 import {
-	buildBorderSection,
-	buildColorSection,
-	buildDimensionsSection,
 	buildListener,
 	buildShowField,
-	buildSpacingSection,
 	buildTextAlignSection,
 	buildTypographySection,
 } from "../block-defaults.shared";
@@ -18,7 +14,7 @@ import type { BlockSettingsConfig } from "../settings.types";
 // export the config for the block
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_DISPLAY,
-	icon: FormatListBulleted,
+	icon: List,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/modal-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/modal-block/config.tsx
@@ -1,7 +1,13 @@
-import { Schema } from "@mui/icons-material";
+import { Network } from "lucide-react";
 import { useRef, useState } from "react";
 import type { Block, BlockDef, Paths, PathValue } from "@semoss/renderer";
-import { Autocomplete, TextField } from "@semoss/ui";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@semoss/ui/next";
 import { useBlockSettings } from "@/hooks";
 import { InputSettings, QueryInputSettings } from "../../settings";
 import { BaseSettingSection } from "../../settings/BaseSettingSection";
@@ -59,42 +65,27 @@ const SettingAutocomplete = <D extends BlockDef>({
 	};
 
 	return (
-		<Autocomplete
-			fullWidth
-			options={options}
-			multiple={false}
-			value={options.find((opt) => opt.value === selectedValue) || null}
-			onChange={(_, newValue) => {
-				setBlockData(
-					typeof newValue === "object" && newValue !== null
-						? newValue.value
-						: undefined,
-				);
-			}}
-			getOptionLabel={(option) =>
-				typeof option === "object" && option !== null
-					? option.label
-					: ""
-			}
-			isOptionEqualToValue={(option, value) =>
-				typeof option === "object" &&
-				option !== null &&
-				typeof value === "object" &&
-				value !== null &&
-				"value" in option &&
-				"value" in value &&
-				option.value === value.value
-			}
-			renderInput={(params) => (
-				<TextField {...params} size="small" variant="outlined" />
-			)}
-		/>
+		<Select
+			value={selectedValue ?? ""}
+			onValueChange={(val) => setBlockData(val)}
+		>
+			<SelectTrigger className="w-full">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				{options.map((opt) => (
+					<SelectItem key={opt.value} value={opt.value}>
+						{opt.label}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
 	);
 };
 
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_LAYOUT,
-	icon: Schema,
+	icon: Network,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/page-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/page-block/config.tsx
@@ -1,4 +1,4 @@
-import { FileCopyOutlined } from "@mui/icons-material";
+import { Copy } from "lucide-react";
 import type { CSSProperties } from "react";
 import {
 	BorderSettings,
@@ -26,7 +26,7 @@ export const DefaultStyles: CSSProperties = {
 // export the config for the block
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_LAYOUT,
-	icon: FileCopyOutlined,
+	icon: Copy,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/popover-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/popover-block/config.tsx
@@ -1,5 +1,5 @@
-import { Schema } from "@mui/icons-material";
-import { useEffect, useRef, useState } from "react";
+import { Network } from "lucide-react";
+import { useRef, useState } from "react";
 import {
 	type Block,
 	type BlockDef,
@@ -7,14 +7,19 @@ import {
 	type PathValue,
 	useBlocks,
 } from "@semoss/renderer";
-import { Autocomplete, TextField, Typography } from "@semoss/ui";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@semoss/ui/next";
 import { useBlockSettings } from "@/hooks";
 import { BaseSettingSection, ColorSettings } from "../../settings";
 import { SwitchSettings } from "../../settings/shared/SwitchSettings";
 import { BLOCK_TYPE_LAYOUT } from "../block-defaults.constants";
 import {
 	buildBorderSection,
-	buildColorSection,
 	buildDimensionsSection,
 	buildListener,
 	buildShowField,
@@ -68,36 +73,21 @@ const SettingAutocomplete = <D extends BlockDef>({
 	};
 
 	return (
-		<Autocomplete
-			fullWidth
-			options={options}
-			multiple={false}
-			value={options.find((opt) => opt.value === selectedValue) || null}
-			onChange={(_, newValue) => {
-				setBlockData(
-					typeof newValue === "object" && newValue !== null
-						? newValue.value
-						: undefined,
-				);
-			}}
-			getOptionLabel={(option) =>
-				typeof option === "object" && option !== null
-					? option.label
-					: ""
-			}
-			isOptionEqualToValue={(option, value) =>
-				typeof option === "object" &&
-				option !== null &&
-				typeof value === "object" &&
-				value !== null &&
-				"value" in option &&
-				"value" in value &&
-				option.value === value.value
-			}
-			renderInput={(params) => (
-				<TextField {...params} size="small" variant="outlined" />
-			)}
-		/>
+		<Select
+			value={selectedValue ?? ""}
+			onValueChange={(val) => setBlockData(val)}
+		>
+			<SelectTrigger className="w-full">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				{options.map((opt) => (
+					<SelectItem key={opt.value} value={opt.value}>
+						{opt.label}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
 	);
 };
 
@@ -110,7 +100,7 @@ const LayersDropdown = ({ id }) => {
 	const getAllBlock = allBlocks.map((block) => block.id);
 
 	if (getAllBlock.length === 0) {
-		return <Typography variant="body2">Layers panel not found</Typography>;
+		return <p className="text-sm">Layers panel not found</p>;
 	}
 
 	const options = getAllBlock.map((block) => {
@@ -136,7 +126,7 @@ export default LayersDropdown;
 
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_LAYOUT,
-	icon: Schema,
+	icon: Network,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/radio-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/radio-block/config.tsx
@@ -1,6 +1,4 @@
-import AddIcon from "@mui/icons-material/Add";
-import CloseIcon from "@mui/icons-material/Close";
-import RadioButtonCheckedOutlinedIcon from "@mui/icons-material/RadioButtonCheckedOutlined";
+import { CircleDot, Plus, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type {
 	Block,
@@ -10,14 +8,14 @@ import type {
 	RadioBlockDef,
 } from "@semoss/renderer";
 import {
-	Autocomplete,
-	Box,
 	Button,
-	IconButton,
-	Stack,
-	TextField,
-	Typography,
-} from "@semoss/ui";
+	Input,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@semoss/ui/next";
 import { useBlockSettings } from "@/hooks";
 import { InputSettings } from "../../settings";
 import { BaseSettingSection } from "../../settings/BaseSettingSection";
@@ -89,37 +87,21 @@ const SettingAutocomplete = <D extends BlockDef>({
 	};
 
 	return (
-		<Autocomplete
-			fullWidth
-			multiple={false}
-			options={options}
-			value={options.find((opt) => opt.value === selectedValue) || null}
-			onChange={(_, newValue) => {
-				setBlockData(
-					typeof newValue === "object" && newValue !== null
-						? newValue.value
-						: undefined,
-				);
-			}}
-			getOptionLabel={(option) =>
-				typeof option === "object" && option !== null
-					? option.label
-					: ""
-			}
-			isOptionEqualToValue={(option, value) =>
-				typeof option === "object" &&
-				option !== null &&
-				typeof value === "object" &&
-				value !== null &&
-				"value" in option &&
-				"value" in value &&
-				option.value === value.value
-			}
-			renderInput={(params) => (
-				<TextField {...params} size="small" variant="outlined" />
-			)}
-			disableClearable
-		/>
+		<Select
+			value={selectedValue ?? ""}
+			onValueChange={(val) => setBlockData(val)}
+		>
+			<SelectTrigger className="w-full">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				{options.map((opt) => (
+					<SelectItem key={opt.value} value={opt.value}>
+						{opt.label}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
 	);
 };
 
@@ -140,35 +122,31 @@ const OptionRow = ({
 	onChange?: (field: "label" | "value", value: string) => void;
 	onDelete?: () => void;
 }) => (
-	<Box sx={{ width: "100%", mb: 2 }}>
-		<Stack direction="row" spacing={2} alignItems="center">
-			<Box sx={{ flex: 1 }}>
-				<TextField
-					size="small"
+	<div className="mb-2 w-full">
+		<div className="flex flex-row items-center gap-2">
+			<div className="flex-1">
+				<Input
 					value={label}
 					onChange={(e) => onChange?.("label", e.target.value)}
-					fullWidth
 				/>
-			</Box>
-			<Box sx={{ flex: 1 }}>
-				<TextField
-					size="small"
+			</div>
+			<div className="flex-1">
+				<Input
 					value={value}
 					onChange={(e) => onChange?.("value", e.target.value)}
-					fullWidth
 				/>
-			</Box>
+			</div>
 
-			<IconButton onClick={onDelete} size="small">
-				<CloseIcon />
-			</IconButton>
-		</Stack>
-	</Box>
+			<Button variant="ghost" size="icon-sm" onClick={onDelete}>
+				<X className="size-4" />
+			</Button>
+		</div>
+	</div>
 );
 
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_INPUT,
-	icon: RadioButtonCheckedOutlinedIcon,
+	icon: CircleDot,
 	contentMenu: [
 		{
 			name: "General",
@@ -208,6 +186,7 @@ export const config: BlockSettingsConfig = {
 						});
 
 						// Ensure we always have at least one complete option
+						// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only run when configOptions length changes
 						useEffect(() => {
 							const completeOptions = configOptions.filter(
 								(opt) => opt.label.trim() && opt.value.trim(),
@@ -322,27 +301,21 @@ export const config: BlockSettingsConfig = {
 						};
 						// Find the current option object for the selected value
 						return (
-							<Box sx={{ width: "100%" }}>
+							<div className="w-full">
 								{/* Headers */}
-								<Box sx={{ mb: 2, display: "flex", gap: 2 }}>
-									<Box sx={{ flex: 1 }}>
-										<Typography
-											variant="caption"
-											fontWeight="medium"
-										>
+								<div className="mb-2 flex gap-2">
+									<div className="flex-1">
+										<p className="font-medium text-xs">
 											Label
-										</Typography>
-									</Box>
-									<Box sx={{ flex: 1 }}>
-										<Typography
-											variant="caption"
-											fontWeight="medium"
-										>
+										</p>
+									</div>
+									<div className="flex-1">
+										<p className="font-medium text-xs">
 											Value
-										</Typography>
-									</Box>
-									<Box sx={{ width: 40 }} />
-								</Box>
+										</p>
+									</div>
+									<div className="w-10" />
+								</div>
 
 								{/* Options */}
 								{configOptions.map((option) => (
@@ -365,69 +338,50 @@ export const config: BlockSettingsConfig = {
 
 								{/* Add Button */}
 								<Button
-									startIcon={<AddIcon />}
+									variant="outline"
+									size="sm"
+									className="mb-2 w-full"
 									onClick={handleAddOption}
-									variant="outlined"
-									size="small"
-									fullWidth
-									sx={{ mb: 2 }}
 								>
+									<Plus className="mr-1 size-4" />
 									Add Option
 								</Button>
 
 								{/* Current Value Selection */}
 								<BaseSettingSection label="Selected Value">
-									<Autocomplete
-										multiple={false}
+									<Select
 										value={
 											configOptions.find(
 												(opt) =>
 													opt.value === data.value,
-											) || null
+											)?.value ?? ""
 										}
-										options={configOptions.filter(
-											(opt) =>
-												opt.label.trim() &&
-												opt.value.trim(),
-										)}
-										onChange={(_, newValue) => {
-											if (newValue) {
-												setData(
-													"value",
-													typeof newValue ===
-														"object" &&
-														newValue !== null
-														? newValue.value
-														: undefined,
-												);
-											}
+										onValueChange={(val) => {
+											setData("value", val);
 										}}
-										getOptionLabel={(option) =>
-											typeof option === "object" &&
-											option !== null
-												? option.label
-												: ""
-										}
-										isOptionEqualToValue={(option, value) =>
-											typeof option === "object" &&
-											option !== null &&
-											typeof value === "object" &&
-											value !== null &&
-											"value" in option &&
-											"value" in value &&
-											option.value === value.value
-										}
-										renderInput={(params) => (
-											<TextField
-												{...params}
-												size="small"
-												variant="outlined"
-											/>
-										)}
-										fullWidth
-									/>
+									>
+										<SelectTrigger className="w-full">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{configOptions
+												.filter(
+													(opt) =>
+														opt.label.trim() &&
+														opt.value.trim(),
+												)
+												.map((opt) => (
+													<SelectItem
+														key={opt.id}
+														value={opt.value}
+													>
+														{opt.label}
+													</SelectItem>
+												))}
+										</SelectContent>
+									</Select>
 								</BaseSettingSection>
-							</Box>
+							</div>
 						);
 					},
 				},

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/slider-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/slider-block/config.tsx
@@ -1,6 +1,12 @@
-import { BlurLinear } from "@mui/icons-material";
+import { SlidersHorizontal } from "lucide-react";
 import { observer } from "mobx-react-lite";
-import { Menu, Select } from "@semoss/ui";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@semoss/ui/next";
 import { useBlockSettings } from "@/hooks";
 import {
 	ColorSettings,
@@ -15,7 +21,7 @@ import type { BlockSettingsConfig } from "../settings.types";
 // export the config for the block
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_INPUT,
-	icon: BlurLinear,
+	icon: SlidersHorizontal,
 	contentMenu: [
 		{
 			name: "General",
@@ -35,26 +41,26 @@ export const config: BlockSettingsConfig = {
 								display: "Discrete",
 							},
 						];
-						const onChange = (value: string) => {
-							setData("type", value);
-						};
 						return (
 							<Select
-								label="Type"
-								fullWidth
-								size="small"
 								value={data.type}
-								onChange={(e) => {
-									onChange(e.target.value);
+								onValueChange={(value) => {
+									setData("type", value);
 								}}
 							>
-								{Array.from(options, (option, i) => {
-									return (
-										<Menu.Item key={i} value={option.value}>
+								<SelectTrigger className="w-full">
+									<SelectValue placeholder="Type" />
+								</SelectTrigger>
+								<SelectContent>
+									{options.map((option) => (
+										<SelectItem
+											key={option.value}
+											value={option.value}
+										>
 											{option.display}
-										</Menu.Item>
-									);
-								})}
+										</SelectItem>
+									))}
+								</SelectContent>
 							</Select>
 						);
 					}),

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/tab-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/tab-block/config.tsx
@@ -1,4 +1,4 @@
-import { Tab } from "@mui/icons-material";
+import { PanelTop } from "lucide-react";
 import {
 	InputSettings,
 	SelectInputSettings,
@@ -11,7 +11,7 @@ import type { BlockSettingsConfig } from "../settings.types";
 
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_LAYOUT,
-	icon: Tab,
+	icon: PanelTop,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/text-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/text-block/config.tsx
@@ -1,4 +1,4 @@
-import { TextFields } from "@mui/icons-material";
+import { Type } from "lucide-react";
 import type { CSSProperties } from "react";
 import { QueryInputSettings } from "../../settings";
 import { ShowLoadingSettings } from "../../settings/shared/ShowLoadingSettings";
@@ -21,7 +21,7 @@ export const DefaultStyles: CSSProperties = {
 // export the config for the block
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_DISPLAY,
-	icon: TextFields,
+	icon: Type,
 	contentMenu: [
 		{
 			name: "General",

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/theme-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/theme-block/config.tsx
@@ -1,18 +1,22 @@
-import { Close, FileCopyOutlined, OpenInNew } from "@mui/icons-material";
+import { Copy, ExternalLink, X } from "lucide-react";
 import { type CSSProperties, useState } from "react";
+import { darkTheme, lightTheme } from "@semoss/ui";
 import {
-	Divider,
-	darkTheme,
-	IconButton,
-	lightTheme,
-	Menu,
-	Modal,
+	Button,
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
 	Select,
-	Stack,
-	styled,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	Separator,
 	Tabs,
-	Typography,
-} from "@semoss/ui";
+	TabsList,
+	TabsTrigger,
+} from "@semoss/ui/next";
 import { useBlockSettings } from "@/hooks";
 import {
 	BaseSettingSection,
@@ -31,18 +35,6 @@ export const DefaultStyles: CSSProperties = {
 	fontFamily: "roboto",
 };
 
-const StyledModalHeader = styled(Stack)(({ theme }) => ({
-	padding: theme.spacing(2),
-	flexDirection: "row",
-	justifyContent: "space-between",
-	alignItems: "center",
-}));
-
-const StyledTabBox = styled(Stack)(({ theme }) => ({
-	borderRadius: "12px",
-	backgroundColor: theme.palette.background.paper,
-}));
-
 const capitalize = (s) => {
 	return String(s[0]).toUpperCase() + String(s).slice(1);
 };
@@ -50,7 +42,7 @@ const capitalize = (s) => {
 // export the config for the block
 export const config: BlockSettingsConfig = {
 	type: BLOCK_TYPE_THEME,
-	icon: FileCopyOutlined,
+	icon: Copy,
 	contentMenu: [
 		{
 			name: "Theme Type",
@@ -80,20 +72,24 @@ export const config: BlockSettingsConfig = {
 						};
 						return (
 							<Select
-								fullWidth
-								size="small"
 								value={themeType}
-								onChange={(e) => {
-									onChange(e.target.value);
+								onValueChange={(value) => {
+									onChange(value);
 								}}
 							>
-								{Array.from(options, (option, i) => {
-									return (
-										<Menu.Item key={i} value={option.value}>
+								<SelectTrigger className="w-full">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{options.map((option) => (
+										<SelectItem
+											key={option.value}
+											value={option.value}
+										>
 											{option.display}
-										</Menu.Item>
-									);
-								})}
+										</SelectItem>
+									))}
+								</SelectContent>
 							</Select>
 						);
 					},
@@ -116,62 +112,62 @@ export const config: BlockSettingsConfig = {
 						const secondTabSet = ["warning", "info", "success"];
 						const variants = ["main", "dark", "light"];
 						return (
-							<StyledTabBox gap={2}>
+							<div className="flex flex-col gap-2 rounded-xl bg-background">
 								<Tabs
 									value={selectedFirstTab}
-									onChange={(_, value: string) => {
+									onValueChange={(value) => {
 										setSelectedFirstTab(value);
 									}}
-									color="primary"
 								>
-									{firstTabSet.map((key, idx: number) => (
-										<Tabs.Item
-											key={`${key}-${idx}`}
-											label={capitalize(key)}
-											value={key}
-										/>
-									))}
+									<TabsList>
+										{firstTabSet.map(
+											(key, _idx: number) => (
+												<TabsTrigger
+													key={key}
+													value={key}
+												>
+													{capitalize(key)}
+												</TabsTrigger>
+											),
+										)}
+									</TabsList>
 								</Tabs>
-								<>
-									{variants.map((variant, idx: number) => (
-										<ColorSettings
-											key={`${variant}-${idx}`}
-											id={id}
-											label={`${capitalize(
-												variant,
-											)} Color`}
-											path={`theme.palette.${selectedFirstTab}.${variant}`}
-										/>
-									))}
-								</>
+								{variants.map((variant, _idx: number) => (
+									<ColorSettings
+										key={variant}
+										id={id}
+										label={`${capitalize(variant)} Color`}
+										path={`theme.palette.${selectedFirstTab}.${variant}`}
+									/>
+								))}
 								<Tabs
 									value={selectedSecondtTab}
-									onChange={(_, value: string) => {
+									onValueChange={(value) => {
 										setSelectedSecondTab(value);
 									}}
-									color="primary"
 								>
-									{secondTabSet.map((key, idx: number) => (
-										<Tabs.Item
-											key={`${key}-${idx}`}
-											label={capitalize(key)}
-											value={key}
-										/>
-									))}
+									<TabsList>
+										{secondTabSet.map(
+											(key, _idx: number) => (
+												<TabsTrigger
+													key={key}
+													value={key}
+												>
+													{capitalize(key)}
+												</TabsTrigger>
+											),
+										)}
+									</TabsList>
 								</Tabs>
-								<>
-									{variants.map((variant, idx: number) => (
-										<ColorSettings
-											key={`${variant}-${idx}`}
-											id={id}
-											label={`${capitalize(
-												variant,
-											)} Color`}
-											path={`theme.palette.${selectedSecondtTab}.${variant}`}
-										/>
-									))}
-								</>
-							</StyledTabBox>
+								{variants.map((variant, _idx: number) => (
+									<ColorSettings
+										key={variant}
+										id={id}
+										label={`${capitalize(variant)} Color`}
+										path={`theme.palette.${selectedSecondtTab}.${variant}`}
+									/>
+								))}
+							</div>
 						);
 					},
 				},
@@ -194,55 +190,49 @@ export const config: BlockSettingsConfig = {
 							"main",
 						];
 						return (
-							<StyledTabBox gap={2}>
+							<div className="flex flex-col gap-2 rounded-xl bg-background">
 								<Tabs
 									value={selectedFirstTab}
-									onChange={(_, value: string) => {
+									onValueChange={(value) => {
 										setSelectedFirstTab(value);
 									}}
-									color="primary"
 								>
-									{firstTabSet.map((key, idx: number) => (
-										<Tabs.Item
-											key={`${key}-${idx}`}
-											label={capitalize(key)}
-											value={key}
-										/>
-									))}
+									<TabsList>
+										{firstTabSet.map(
+											(key, _idx: number) => (
+												<TabsTrigger
+													key={key}
+													value={key}
+												>
+													{capitalize(key)}
+												</TabsTrigger>
+											),
+										)}
+									</TabsList>
 								</Tabs>
-								{selectedFirstTab == "background" && (
-									<>
-										{paperVariants.map(
-											(variant, idx: number) => (
-												<ColorSettings
-													key={`${variant}-${idx}`}
-													id={id}
-													label={`${capitalize(
-														variant,
-													)} Color`}
-													path={`theme.palette.${selectedFirstTab}.${variant}`}
-												/>
-											),
-										)}
-									</>
-								)}
-								{selectedFirstTab == "text" && (
-									<>
-										{textVariants.map(
-											(variant, idx: number) => (
-												<ColorSettings
-													key={`${variant}-${idx}`}
-													id={id}
-													label={`${capitalize(
-														variant,
-													)} Color`}
-													path={`theme.palette.${selectedFirstTab}.${variant}`}
-												/>
-											),
-										)}
-									</>
-								)}
-							</StyledTabBox>
+								{selectedFirstTab === "background" &&
+									paperVariants.map(
+										(variant, _idx: number) => (
+											<ColorSettings
+												key={variant}
+												id={id}
+												label={`${capitalize(variant)} Color`}
+												path={`theme.palette.${selectedFirstTab}.${variant}`}
+											/>
+										),
+									)}
+								{selectedFirstTab === "text" &&
+									textVariants.map(
+										(variant, _idx: number) => (
+											<ColorSettings
+												key={variant}
+												id={id}
+												label={`${capitalize(variant)} Color`}
+												path={`theme.palette.${selectedFirstTab}.${variant}`}
+											/>
+										),
+									)}
+							</div>
 						);
 					},
 				},
@@ -273,33 +263,45 @@ export const config: BlockSettingsConfig = {
 						return (
 							<>
 								<BaseSettingSection label={"Edit MUI Theme"}>
-									<IconButton
-										size="small"
+									<Button
+										variant="ghost"
+										size="icon-sm"
 										onClick={() => setOpen(true)}
 										disabled={false}
 									>
-										<OpenInNew />
-									</IconButton>
+										<ExternalLink className="size-4" />
+									</Button>
 								</BaseSettingSection>
-								<Modal open={open} fullWidth maxWidth={"lg"}>
-									<StyledModalHeader>
-										<Typography variant="h5">{`Edit MUI theme`}</Typography>
-										<IconButton
-											onClick={() => setOpen(false)}
-										>
-											<Close />
-										</IconButton>
-									</StyledModalHeader>
-									<Divider />
-									<Modal.Content>
+								<Dialog
+									open={open}
+									onOpenChange={(o) => setOpen(o)}
+								>
+									<DialogContent className="max-w-4xl">
+										<DialogHeader>
+											<div className="flex flex-row items-center justify-between">
+												<DialogTitle>
+													Edit MUI theme
+												</DialogTitle>
+												<Button
+													variant="ghost"
+													size="icon-sm"
+													onClick={() =>
+														setOpen(false)
+													}
+												>
+													<X className="size-4" />
+												</Button>
+											</div>
+										</DialogHeader>
+										<Separator />
 										<JsonSettings
 											id={id}
 											path="theme"
 											height="500px"
 											callback={() => setOpen(false)}
 										/>
-									</Modal.Content>
-								</Modal>
+									</DialogContent>
+								</Dialog>
 							</>
 						);
 					},

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/upload-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/upload-block/config.tsx
@@ -1,4 +1,4 @@
-import { Upload } from "@mui/icons-material";
+import { Upload } from "lucide-react";
 import type { CSSProperties } from "react";
 import { InputSettings, QuerySelectionSettings } from "../../settings";
 import { SelectSettings } from "../../settings/shared/SelectSettings";

--- a/packages/client/src/components/blocks-workspace/blocks/settings/shared/PDFViewerSettings.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/settings/shared/PDFViewerSettings.tsx
@@ -11,14 +11,14 @@ import {
 	useBlock,
 } from "@semoss/renderer";
 import { runPixel, upload } from "@semoss/sdk/react";
-import { FileDropzone } from "@semoss/ui";
 import {
-	Accordion,
-	AccordionContent,
-	AccordionItem,
-	AccordionTrigger,
-	Muted,
+	FileDropzone,
 	P,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
 	Tabs,
 	TabsContent,
 	TabsList,
@@ -31,7 +31,7 @@ import {
 
 //styled section for the selected tab
 const SubSection = ({ children }: { children: React.ReactNode }) => (
-	<div className="mt-[10px] w-full p-2">{children}</div>
+	<div className="w-full pt-1">{children}</div>
 );
 
 interface Option {
@@ -53,12 +53,6 @@ type SetPdfViewerData = (
 	value: string,
 	tempOverrideMode?: boolean,
 ) => void;
-
-type EngineAsset = {
-	type?: string;
-	name?: string;
-	path?: string;
-};
 
 type engineIdType = {
 	engine_id: string;
@@ -82,17 +76,7 @@ export const PDFViewerSettings = observer(
 	<D extends BlockDef = BlockDef>({ id }: PDFViewerSettings<D>) => {
 		const { data, setData, insightId } = useBlock<PDFViewerBlockDef>(id);
 		const { appId } = useParams();
-		const [appOptions, setAppOptions] = useState<AppOption[]>([]);
-		const [engineOptions, setEngineOptions] = useState<
-			{
-				file_name: string;
-				file_type: string;
-				engine_type: string;
-				file_path: string;
-				engineId: string;
-				engine_name: string;
-			}[]
-		>([]);
+		const [allEngines, setAllEngines] = useState<engineIdType[]>([]);
 		const tabs = ["Insight", "Engine", "App"];
 		const [selectedPdfPath, setSelectedPdfPath] = useState(
 			data?.selectedPdf || "",
@@ -100,8 +84,6 @@ export const PDFViewerSettings = observer(
 		const [selectedTab, setSelectedTab] = useState(tabs[1]);
 		const [uploadFiles, setUploadFiles] = useState<File>(null);
 		const [isLoading, setIsLoading] = useState(false);
-		const [engineAutocompleteOpen, setEngineAutocompleteOpen] =
-			useState(false);
 		const allEngineTypes = [
 			"MODEL",
 			"DATABASE",
@@ -166,49 +148,11 @@ export const PDFViewerSettings = observer(
 			},
 		];
 
-		const getAssetsApp = useMemo(
-			() =>
-				runPixel(
-					`BrowseAppAssets(project=["${appId}"], filePath=["/"]);`,
-				),
-			[appId],
-		);
-
 		useEffect(() => {
-			// Fetch Engine Ids
 			const getengineId = `MyEngines(engineTypes=[${allEngineTypes.map((type) => `"${type}"`).join(",")}]);`;
-
-			//Fetch Engine Details
-			const engineIdResponse = runPixel(getengineId);
-
-			// Fetch App Assets
-			const fetchAssetsAndEngines = async () => {
-				try {
-					const result = await getAssetsApp;
-					const outputArray = result?.pixelReturn?.[0]?.output;
-					const outputNames = Array.isArray(outputArray)
-						? outputArray
-								.filter(
-									(item) =>
-										typeof item.name === "string" &&
-										item.name
-											.toLowerCase()
-											.endsWith(".pdf"),
-								)
-								.map((item) => ({
-									name: item.name,
-									path: item.path,
-								}))
-						: [];
-					setAppOptions(outputNames);
-				} catch (error) {
-					console.error("Error fetching assets:", error);
-				}
-
-				// Fetch Engine IDs
-				try {
-					const output = (await engineIdResponse).pixelReturn?.[0]
-						?.output;
+			runPixel(getengineId)
+				.then((res) => {
+					const output = res?.pixelReturn?.[0]?.output;
 					const engineIds = Array.isArray(output)
 						? Array.from(
 								new Map(
@@ -223,106 +167,12 @@ export const PDFViewerSettings = observer(
 								).values(),
 							)
 						: [];
-					fetchEngineOptions(engineIds);
-				} catch (error) {
-					console.error("Error fetching engines:", error);
-				}
-			};
-
-			fetchAssetsAndEngines();
+					setAllEngines(engineIds);
+				})
+				.catch((error) =>
+					console.error("Error fetching engines:", error),
+				);
 		}, []);
-
-		const fetchEngineOptions = async (engineIdsList: engineIdType[]) => {
-			let pdfFiles: {
-				file_name: string;
-				engine_type: string;
-				file_type: string;
-				file_path: string;
-				engineId: string;
-				engine_name: string;
-			}[] = [];
-			const getFiles = engineIdsList.map((id) => ({
-				promise: runPixel<unknown[]>(
-					`BrowseEngineAssets(engine=["${id.engine_id}"], filePath=["/"]);`,
-				),
-				engine_type: id.engine_type,
-				engine_id: id.engine_id,
-				engine_name: id.engine_name,
-			}));
-
-			for (const obj of getFiles) {
-				try {
-					const resolvedResult = await obj.promise;
-					const output = resolvedResult.pixelReturn?.[0]?.output;
-					const outputList = Array.isArray(output)
-						? (output as EngineAsset[])
-						: [];
-					const files = outputList.map((item) => ({
-						file_name: item.type === "pdf" ? item.name || "" : "",
-						file_path: item.type === "pdf" ? item.path || "" : "",
-						file_type: item.type === "pdf" ? item.type || "" : "",
-						engine_type: obj.engine_type || "",
-						engineId: obj.engine_id || "",
-						engine_name: obj.engine_name || "",
-					}));
-					pdfFiles = [...pdfFiles, ...files];
-				} catch (e) {
-					console.error("Error fetching engine assets:", e);
-				}
-			}
-			setEngineOptions([...pdfFiles]);
-		};
-
-		const engineOptionList: Option[] = useMemo(() => {
-			// Build group info and files by type in one pass
-			const filesByType: Record<string, Option[]> = {};
-			const allEngineGroups = allEngineTypes.map((type) => ({
-				type,
-				group: groupAliasMapper(type, "engine"),
-			}));
-
-			allEngineTypes.forEach((type) => {
-				filesByType[type] = [];
-			});
-
-			engineOptions.forEach((item, idx) => {
-				if (!filesByType[item.engine_type])
-					filesByType[item.engine_type] = [];
-				filesByType[item.engine_type].push({
-					id: `${item.engine_type}-${item.file_name}-${idx}`,
-					path: item.file_path,
-					display: item.file_name,
-					group: groupAliasMapper(item.engine_type, "engine"),
-					engineId: item.engineId,
-					engine_name: item.engine_name,
-				});
-			});
-
-			return allEngineGroups.flatMap(({ type, group }) =>
-				filesByType[type].length > 0
-					? filesByType[type]
-					: [
-							{
-								id: `${type}-empty`,
-								path: "",
-								display: "",
-								group,
-							},
-						],
-			);
-		}, [engineOptions]);
-
-		const nestedEngineOptions = engineOptionList.reduce(
-			(acc, option) => {
-				if (!option.group || !option.engine_name) return acc;
-				if (!acc[option.group]) acc[option.group] = {};
-				if (!acc[option.group][option.engine_name])
-					acc[option.group][option.engine_name] = [];
-				acc[option.group][option.engine_name].push(option);
-				return acc;
-			},
-			{} as Record<string, Record<string, Option[]>>,
-		);
 
 		const addFile = async (file: File) => {
 			try {
@@ -386,26 +236,14 @@ export const PDFViewerSettings = observer(
 
 					<TabsContent value="Insight">
 						<SubSection>
-							<span className="relative pl-[9px] text-secondary text-sm">
-								{selectedTab}
-							</span>
 							<InsightTab options={options} />
 						</SubSection>
 					</TabsContent>
 
 					<TabsContent value="Engine">
 						<SubSection>
-							<span className="relative pl-[9px] text-secondary text-sm">
-								{selectedTab}
-							</span>
 							<EngineTab
-								engineOptionList={engineOptionList}
-								nestedEngineOptions={nestedEngineOptions}
-								selectedPdfPath={selectedPdfPath}
-								engineAutocompleteOpen={engineAutocompleteOpen}
-								setEngineAutocompleteOpen={
-									setEngineAutocompleteOpen
-								}
+								allEngines={allEngines}
 								setData={setData}
 								setSelectedPdfPath={setSelectedPdfPath}
 							/>
@@ -414,13 +252,8 @@ export const PDFViewerSettings = observer(
 
 					<TabsContent value="App">
 						<SubSection>
-							<span className="relative pl-[9px] text-secondary text-sm">
-								{selectedTab === "App" && uploadFiles
-									? "File Selected"
-									: selectedTab}
-							</span>
 							<AppTab
-								appOptions={appOptions}
+								appId={appId || ""}
 								selectedPdfPath={selectedPdfPath}
 								setData={setData}
 								setSelectedPdfPath={setSelectedPdfPath}
@@ -438,7 +271,7 @@ export const PDFViewerSettings = observer(
 );
 
 const InsightTab: React.FC<{ options: Option[] }> = ({ options }) => (
-	<div className="mt-3 pl-[9px]">
+	<div className="mt-1">
 		<select className="w-full rounded border border-input bg-background px-3 py-2 text-sm focus:outline-none">
 			{options.map((option) => (
 				<option key={option.id} value={option.path}>
@@ -449,116 +282,177 @@ const InsightTab: React.FC<{ options: Option[] }> = ({ options }) => (
 	</div>
 );
 
+const ENGINE_TYPE_LABELS: Record<string, string> = {
+	MODEL: "Models",
+	DATABASE: "Databases",
+	VECTOR: "Vectors",
+	FUNCTION: "Functions",
+	STORAGE: "Storage",
+};
+
 const EngineTab: React.FC<{
-	engineOptionList: Option[];
-	nestedEngineOptions: Record<string, Record<string, Option[]>>;
-	selectedPdfPath: string;
-	engineAutocompleteOpen: boolean;
-	setEngineAutocompleteOpen: (open: boolean) => void;
+	allEngines: engineIdType[];
 	setData: SetPdfViewerData;
 	setSelectedPdfPath: (path: string) => void;
-}> = ({
-	// biome-ignore lint/correctness/noUnusedFunctionParameters: required by interface
-	engineOptionList,
-	nestedEngineOptions,
-	// biome-ignore lint/correctness/noUnusedFunctionParameters: required by interface
-	selectedPdfPath,
-	// biome-ignore lint/correctness/noUnusedFunctionParameters: required by interface
-	engineAutocompleteOpen,
-	setEngineAutocompleteOpen,
-	setData,
-	setSelectedPdfPath,
-}) => (
-	<div className="mt-3 pl-[9px]">
-		<Accordion type="multiple" className="w-full">
-			{Object.entries(nestedEngineOptions).map(([group, engines]) => (
-				<AccordionItem key={group} value={group}>
-					<AccordionTrigger className="font-bold text-sm">
-						{group}
-					</AccordionTrigger>
-					<AccordionContent>
-						{Object.entries(engines).map(([engineName, files]) => {
-							const allEmpty = files.every(
-								(f) => !f.display || !f.display.trim(),
-							);
-							return (
-								<Accordion
-									key={engineName}
-									type="multiple"
-									className="w-full"
-								>
-									<AccordionItem value={engineName}>
-										<AccordionTrigger className="pl-4 font-bold text-sm">
-											{engineName}
-										</AccordionTrigger>
-										<AccordionContent>
-											<ul className="mt-[5px] border-border border-b">
-												{allEmpty ? (
-													<li className="pl-8 text-destructive text-sm">
-														No Files found
-													</li>
-												) : (
-													files.map((option) => {
-														if (
-															!option.display?.trim()
-														)
-															return null;
-														return (
-															<li
-																key={
-																	option.engineId ||
-																	option.path
-																}
-																className="pl-8"
-															>
-																<button
-																	type="button"
-																	onClick={() => {
-																		setData(
-																			"engineId",
-																			option.engineId ||
-																				"",
-																			true,
-																		);
-																		setData(
-																			"selectedPdf",
-																			option.path,
-																			true,
-																		);
-																		setSelectedPdfPath(
-																			option.path,
-																		);
-																		setEngineAutocompleteOpen(
-																			false,
-																		);
-																	}}
-																	className="cursor-pointer border-none bg-transparent p-0 text-left text-sm hover:underline"
-																>
-																	<Muted>
-																		{
-																			option.display
-																		}
-																	</Muted>
-																</button>
-															</li>
-														);
-													})
-												)}
-											</ul>
-										</AccordionContent>
-									</AccordionItem>
-								</Accordion>
-							);
-						})}
-					</AccordionContent>
-				</AccordionItem>
-			))}
-		</Accordion>
-	</div>
-);
+}> = ({ allEngines, setData, setSelectedPdfPath }) => {
+	const [selectedType, setSelectedType] = useState("");
+	const [selectedEngineId, setSelectedEngineId] = useState("");
+	const [files, setFiles] = useState<{ name: string; path: string }[]>([]);
+	const [loadingFiles, setLoadingFiles] = useState(false);
+	const [selectedFilePath, setSelectedFilePath] = useState("");
+
+	const engineTypes = useMemo(() => {
+		const seen = new Set<string>();
+		return allEngines
+			.map((e) => e.engine_type)
+			.filter((t) => {
+				if (seen.has(t)) return false;
+				seen.add(t);
+				return true;
+			});
+	}, [allEngines]);
+
+	const engines = useMemo(() => {
+		if (!selectedType) return [];
+		const seen = new Set<string>();
+		return allEngines
+			.filter((e) => e.engine_type === selectedType)
+			.filter((e) => {
+				if (seen.has(e.engine_id)) return false;
+				seen.add(e.engine_id);
+				return true;
+			})
+			.map((e) => ({ id: e.engine_id, name: e.engine_name }));
+	}, [allEngines, selectedType]);
+
+	useEffect(() => {
+		if (engineTypes.length > 0 && !selectedType) {
+			setSelectedType(engineTypes[0]);
+		}
+	}, [engineTypes]);
+
+	useEffect(() => {
+		if (engines.length > 0) {
+			setSelectedEngineId(engines[0].id);
+		} else {
+			setSelectedEngineId("");
+			setFiles([]);
+		}
+	}, [engines]);
+
+	useEffect(() => {
+		if (!selectedEngineId) return;
+		setLoadingFiles(true);
+		setSelectedFilePath("");
+		runPixel<unknown[]>(
+			`SearchEngineAssets(engine=["${selectedEngineId}"], filePath=["/"], search=[".pdf"]);`,
+		)
+			.then((result) => {
+				const output = result?.pixelReturn?.[0]?.output;
+				setFiles(
+					Array.isArray(output)
+						? output.map(
+								(item: { name?: string; path?: string }) => ({
+									name: item.name || "",
+									path: item.path || "",
+								}),
+							)
+						: [],
+				);
+			})
+			.catch(() => setFiles([]))
+			.finally(() => setLoadingFiles(false));
+	}, [selectedEngineId]);
+
+	return (
+		<div className="mt-1 flex flex-col gap-2">
+			{engineTypes.length === 0 ? (
+				<p className="text-muted-foreground text-sm">
+					No engines available
+				</p>
+			) : (
+				<Select
+					value={selectedType}
+					onValueChange={(val) => {
+						setSelectedType(val);
+						setSelectedEngineId("");
+					}}
+				>
+					<SelectTrigger className="w-full">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{engineTypes.map((t) => (
+							<SelectItem key={t} value={t}>
+								{ENGINE_TYPE_LABELS[t] ?? t}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			)}
+
+			{selectedType &&
+				(engines.length === 0 ? (
+					<p className="text-muted-foreground text-sm">
+						No {ENGINE_TYPE_LABELS[selectedType] ?? selectedType}{" "}
+						exist
+					</p>
+				) : (
+					<Select
+						value={selectedEngineId}
+						onValueChange={(val) => setSelectedEngineId(val)}
+					>
+						<SelectTrigger className="w-full">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{engines.map((e) => (
+								<SelectItem key={e.id} value={e.id}>
+									<span className="flex flex-col text-left">
+										<span>{e.name}</span>
+										<span className="text-[11px] text-muted-foreground">
+											id: {e.id}
+										</span>
+									</span>
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				))}
+
+			{selectedEngineId &&
+				(loadingFiles ? (
+					<p className="text-muted-foreground text-sm">Loading...</p>
+				) : files.length === 0 ? (
+					<p className="text-muted-foreground text-sm">
+						No PDF files found
+					</p>
+				) : (
+					<select
+						className="w-full rounded border border-input bg-background px-3 py-2 text-sm focus:outline-none"
+						value={selectedFilePath}
+						onChange={(e) => {
+							const path = e.target.value;
+							setSelectedFilePath(path);
+							setData("engineId", selectedEngineId, true);
+							setData("selectedPdf", path, true);
+							setSelectedPdfPath(path);
+						}}
+					>
+						<option value="">Select File</option>
+						{files.map((f) => (
+							<option key={f.path} value={f.path}>
+								{f.name}
+							</option>
+						))}
+					</select>
+				))}
+		</div>
+	);
+};
 
 const AppTab: React.FC<{
-	appOptions: AppOption[];
+	appId: string;
 	selectedPdfPath: string;
 	setData: SetPdfViewerData;
 	setSelectedPdfPath: (path: string) => void;
@@ -567,7 +461,7 @@ const AppTab: React.FC<{
 	isLoading: boolean;
 	addFile: (file: File) => void;
 }> = ({
-	appOptions,
+	appId,
 	selectedPdfPath,
 	setData,
 	setSelectedPdfPath,
@@ -575,63 +469,102 @@ const AppTab: React.FC<{
 	setUploadFiles,
 	isLoading,
 	addFile,
-}) => (
-	<div className="mt-3 flex flex-col gap-2 pl-[9px]">
-		{uploadFiles ? (
-			<div className="flex flex-col gap-2">
-				<div className="flex items-center justify-between">
-					<P>{uploadFiles.name}</P>
-					<button
-						type="button"
-						onClick={() => setUploadFiles(null)}
-						className="rounded p-1 hover:bg-accent"
-					>
-						<Trash2 className="size-4 cursor-pointer text-destructive" />
-					</button>
+}) => {
+	const [appOptions, setAppOptions] = useState<AppOption[]>([]);
+	const [loadingOptions, setLoadingOptions] = useState(true);
+
+	useEffect(() => {
+		setLoadingOptions(true);
+		runPixel(
+			`SearchAppAssets(project=["${appId}"], filePath=["/"], search=[".pdf"]);`,
+		)
+			.then((result) => {
+				const output = result?.pixelReturn?.[0]?.output;
+				setAppOptions(
+					Array.isArray(output)
+						? output.map(
+								(item: { name?: string; path?: string }) => ({
+									name: item.name || "",
+									path: item.path || "",
+								}),
+							)
+						: [],
+				);
+			})
+			.catch(() => setAppOptions([]))
+			.finally(() => setLoadingOptions(false));
+	}, [appId]);
+
+	return (
+		<div className="mt-3 flex flex-col gap-2 pl-[9px]">
+			{uploadFiles ? (
+				<div className="flex flex-col gap-2">
+					<div className="flex items-center justify-between">
+						<P>{uploadFiles.name}</P>
+						<button
+							type="button"
+							onClick={() => setUploadFiles(null)}
+							className="rounded p-1 hover:bg-accent"
+						>
+							<Trash2 className="size-4 cursor-pointer text-destructive" />
+						</button>
+					</div>
+					<div className="flex items-center pt-2">
+						<Info className="size-4 cursor-pointer text-foreground" />
+						<span className="relative pl-[9px] text-base text-foreground">
+							Delete current file to upload a new one
+						</span>
+					</div>
 				</div>
-				<div className="flex items-center pt-2">
-					<Info className="size-4 cursor-pointer text-secondary" />
-					<span className="relative pl-[9px] text-secondary text-sm">
-						Delete current file to upload a new one
-					</span>
+			) : (
+				<div className="flex flex-col gap-2">
+					{loadingOptions ? (
+						<p className="text-muted-foreground text-sm">
+							Loading...
+						</p>
+					) : appOptions.length === 0 ? (
+						<p className="text-muted-foreground text-sm">
+							No PDF files in app assets
+						</p>
+					) : (
+						<select
+							className="w-full rounded border border-input bg-background px-3 py-2 text-sm focus:outline-none"
+							value={selectedPdfPath}
+							onChange={(e) => {
+								const opt = appOptions.find(
+									(o) => o.path === e.target.value,
+								);
+								setData("selectedPdf", opt?.path || "", true);
+								setData("engineId", "", true);
+								setSelectedPdfPath(opt?.path || "");
+							}}
+						>
+							<option value="">Select File</option>
+							{appOptions.map((opt) => (
+								<option key={opt.path} value={opt.path}>
+									{opt.name}
+								</option>
+							))}
+						</select>
+					)}
+					<div className="mb-2 flex items-center justify-center">
+						<span className="relative pl-[9px] text-base text-foreground">
+							Or
+						</span>
+					</div>
+					<FileDropzone
+						extensions={[".pdf"]}
+						description="Click to browse or drop a PDF"
+						disabled={isLoading}
+						onChange={(file) => {
+							const f = Array.isArray(file) ? file[0] : file;
+							if (!f) return;
+							setUploadFiles(f);
+							addFile(f);
+						}}
+					/>
 				</div>
-			</div>
-		) : (
-			<div className="flex flex-col gap-2">
-				<select
-					className="w-full rounded border border-input bg-background px-3 py-2 text-sm focus:outline-none"
-					value={selectedPdfPath}
-					onChange={(e) => {
-						const opt = appOptions.find(
-							(o) => o.path === e.target.value,
-						);
-						setData("selectedPdf", opt?.path || "", true);
-						setData("engineId", "", true);
-						setSelectedPdfPath(opt?.path || "");
-					}}
-				>
-					<option value="">Select File</option>
-					{appOptions.map((opt) => (
-						<option key={opt.path} value={opt.path}>
-							{opt.name}
-						</option>
-					))}
-				</select>
-				<div className="mb-2 flex items-center justify-center">
-					<span className="relative pl-[9px] text-secondary text-sm">
-						Or
-					</span>
-				</div>
-				<FileDropzone
-					multiple={false}
-					value={uploadFiles}
-					disabled={isLoading}
-					onChange={(newValue: File) => {
-						setUploadFiles(newValue);
-						addFile(newValue);
-					}}
-				/>
-			</div>
-		)}
-	</div>
-);
+			)}
+		</div>
+	);
+};


### PR DESCRIPTION
- Replace @mui/icons-material with lucide-react across all block-settings configs
- Rewrite PDFViewerSettings: on-demand SearchEngineAssets/SearchAppAssets per selection, cascading type->engine->file dropdowns, auto-select first option, FileDropzone migrated
- Add FileDropzone component to @semoss/ui/next (Tailwind, no MUI)
- PDFViewerBlock: use GetAppAssetsBase64 instead of DownloadAsset, disable pointer-events on iframe/object in interactive mode so block stays selectable in designer