### PR TITLE
fix(playground): allow footer warning content to wrap no matter the screen size

### DIFF
--- a/packages/playground/src/components/common/global-footer.tsx
+++ b/packages/playground/src/components/common/global-footer.tsx
@@ -11,7 +11,7 @@ export const GlobalFooter: React.FC = observer(() => {
 
 	return (
 		<footer
-			className="flex h-10 w-full shrink-0 overflow-hidden"
+			className="flex min-h-10 w-full shrink-0 flex-wrap"
 			// biome-ignore lint/security/noDangerouslySetInnerHtml: read from theme db we control
 			dangerouslySetInnerHTML={{
 				__html: root.theme.footer,


### PR DESCRIPTION
## Description
Footers with too much text would be cutoff. The cutoff would increase or decrease based on screen size/zoom. Made changes to fix that problem

## Changes Made
- In global-footer.tsx line 14 added "flex-wrap" and removed "overflow-hidden".
-  so new code is - "flex min-h-10 w-full shrink-0 flex-wrap"

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Pull branch to SemossWeb and update frontend
2. Footer ( if you have one) should show all the text and adjust based on zoom