### PR TITLE
feat(client): migrate remaining @semoss/ui to @semoss/ui/next

### DIFF
--- a/libs/renderer/src/components/block-defaults/pdfViewer-block/PDFViewerBlock.tsx
+++ b/libs/renderer/src/components/block-defaults/pdfViewer-block/PDFViewerBlock.tsx
@@ -150,17 +150,16 @@ export const PDFViewerBlock: BlockComponent = observer(({ id }) => {
 			{error && <p className="p-2.5 text-destructive text-sm">{error}</p>}
 
 			{pdfContent && !loading && !error && (
-				<div className="mt-1 min-h-0 flex-1 overflow-hidden rounded-md border">
+				<div className="relative mt-1 min-h-0 flex-1 overflow-hidden rounded-md border">
 					<object
 						data={pdfContent}
 						type="application/pdf"
-						className="h-full w-full"
+						className="absolute inset-0 h-full w-full"
 					>
 						<iframe
 							src={pdfContent}
 							title={fileName}
-							className="h-full min-h-[340px] w-full border-none"
-							style={{ height: "calc(100% - 35px)" }}
+							className="absolute inset-0 h-full w-full border-none"
 						/>
 					</object>
 				</div>

--- a/libs/ui/src/next/file-dropzone.tsx
+++ b/libs/ui/src/next/file-dropzone.tsx
@@ -124,7 +124,7 @@ const FileDropzone = React.forwardRef<HTMLDivElement, FileDropzoneProps>(
 						{files.map((f) => (
 							<li
 								key={f.name}
-								className="flex items-center justify-between rounded-md border border-border bg-muted/30 px-3 py-1.5 text-sm"
+								className="flex min-w-0 items-center justify-between rounded-md border border-border bg-muted/30 px-3 py-1.5 text-sm"
 							>
 								<span className="truncate">{f.name}</span>
 								{!disabled && (

--- a/libs/ui/src/next/index.ts
+++ b/libs/ui/src/next/index.ts
@@ -7,6 +7,7 @@ export * from "../lib";
 // export the hooks
 
 export * from "../hooks";
+export { darkTheme, lightTheme } from "../theme";
 // Re-export all components (only export what exists)
 export * from "./accordion";
 export * from "./alert";
@@ -31,6 +32,7 @@ export * from "./input";
 export * from "./input-group";
 export * from "./item";
 export * from "./label";
+export * from "./loading-screen";
 export * from "./markdown";
 export * from "./pagination";
 export * from "./popover";

--- a/libs/ui/src/next/loading-screen.tsx
+++ b/libs/ui/src/next/loading-screen.tsx
@@ -1,0 +1,113 @@
+import type React from "react";
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useState,
+} from "react";
+import { cn } from "@/lib/utils";
+import { Spinner } from "./spinner";
+
+type LoadingScreenContextType = {
+	loading: boolean;
+	start: (message?: React.ReactNode, description?: React.ReactNode) => void;
+	stop: () => void;
+	set: (
+		open: boolean,
+		message?: React.ReactNode,
+		description?: React.ReactNode,
+	) => void;
+};
+
+const LoadingScreenContext = createContext<
+	LoadingScreenContextType | undefined
+>(undefined);
+
+export function useLoadingScreen() {
+	const ctx = useContext(LoadingScreenContext);
+	if (!ctx)
+		throw new Error("useLoadingScreen must be used within a LoadingScreen");
+	return ctx;
+}
+
+interface LoadingScreenProps {
+	relative?: boolean;
+	children: React.ReactNode;
+}
+
+function LoadingScreenRoot({ relative = false, children }: LoadingScreenProps) {
+	const [count, setCount] = useState(0);
+	const [message, setMessage] = useState<React.ReactNode>(null);
+	const [description, setDescription] = useState<React.ReactNode>(null);
+
+	const loading = count > 0;
+
+	const start = useCallback(
+		(msg: React.ReactNode = "Loading", desc?: React.ReactNode) => {
+			setMessage(msg);
+			if (desc) setDescription(desc);
+			setCount((c) => c + 1);
+		},
+		[],
+	);
+
+	const stop = useCallback(() => {
+		setCount((c) => Math.max(0, c - 1));
+	}, []);
+
+	const set = useCallback(
+		(open: boolean, msg?: React.ReactNode, desc?: React.ReactNode) => {
+			if (open) {
+				start(msg, desc);
+			} else {
+				setCount(0);
+			}
+		},
+		[start],
+	);
+
+	return (
+		<LoadingScreenContext.Provider value={{ loading, start, stop, set }}>
+			{loading && (
+				<div
+					className={cn(
+						"z-[1501] flex items-center justify-center bg-white/50",
+						relative ? "absolute inset-0" : "fixed inset-0",
+					)}
+				>
+					<div className="flex flex-col items-center gap-2">
+						<Spinner className="size-8" />
+						{message && <p className="text-sm">{message}</p>}
+						{description && (
+							<p className="text-muted-foreground text-xs">
+								{description}
+							</p>
+						)}
+					</div>
+				</div>
+			)}
+			{children}
+		</LoadingScreenContext.Provider>
+	);
+}
+
+interface TriggerProps {
+	message?: React.ReactNode;
+	description?: React.ReactNode;
+}
+
+function LoadingScreenTrigger({ message, description }: TriggerProps) {
+	const { set } = useLoadingScreen();
+
+	useEffect(() => {
+		set(true, message, description);
+		return () => set(false);
+	}, [message, description, set]);
+
+	return null;
+}
+
+export const LoadingScreen = Object.assign(LoadingScreenRoot, {
+	Trigger: LoadingScreenTrigger,
+});

--- a/libs/ui/src/next/markdown.tsx
+++ b/libs/ui/src/next/markdown.tsx
@@ -147,7 +147,7 @@ function Markdown({
 		<div
 			data-slot="markdown"
 			className={cn(
-				"prose prose-slate dark:prose-invert max-w-none",
+				"prose prose-slate dark:prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
 				className,
 			)}
 			{...props}

--- a/packages/client/src/app-wrapper.tsx
+++ b/packages/client/src/app-wrapper.tsx
@@ -1,8 +1,7 @@
 import { observer } from "mobx-react-lite";
 import { useEffect } from "react";
 import { HashRouter } from "react-router-dom";
-import { LoadingScreen } from "@semoss/ui";
-import { ThemeProvider, Toaster } from "@semoss/ui/next";
+import { LoadingScreen, ThemeProvider, Toaster } from "@semoss/ui/next";
 import { Router } from "@/pages";
 import { CookieWrapper } from "./components/cookies";
 import { useRootStore } from "./hooks";

--- a/packages/client/src/components/app/app-settings.tsx
+++ b/packages/client/src/components/app/app-settings.tsx
@@ -10,7 +10,6 @@ import {
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { FileDropzone } from "@semoss/ui";
 import {
 	Avatar,
 	AvatarFallback,
@@ -18,6 +17,7 @@ import {
 	Collapsible,
 	CollapsibleContent,
 	CollapsibleTrigger,
+	FileDropzone,
 	Input,
 	Large,
 	Separator,

--- a/packages/client/src/components/app/save-app/AppUploadStep.tsx
+++ b/packages/client/src/components/app/save-app/AppUploadStep.tsx
@@ -1,8 +1,8 @@
 import type { Dispatch, SetStateAction } from "react";
 import { useId, useState } from "react";
 import { type Control, Controller } from "react-hook-form";
-import { FileDropzone } from "@semoss/ui";
 import {
+	FileDropzone,
 	Label,
 	Select,
 	SelectContent,

--- a/packages/client/src/components/app/save-app/SaveAppModal.tsx
+++ b/packages/client/src/components/app/save-app/SaveAppModal.tsx
@@ -83,7 +83,7 @@ export const SaveAppModal = (props: SaveAppProps) => {
 
 	return (
 		<Dialog open={open} onOpenChange={() => !isLoading && handleClose()}>
-			<DialogContent className="sm:max-w-lg">
+			<DialogContent className="sm:max-w-2xl" showCloseButton={false}>
 				<DialogHeader>
 					<div className="flex items-center justify-between">
 						<DialogTitle>{title}</DialogTitle>

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/App.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/image-block/SelectionTabs/App.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { upload, usePixel } from "@semoss/sdk/react";
-import { FileDropzone } from "@semoss/ui";
-import { toast } from "@semoss/ui/next";
+import { FileDropzone, toast } from "@semoss/ui/next";
 import { getImageFiles, imageExtensions } from "../utils";
 import SelectedItem from "./SelectedItem";
 import SelectImage from "./SelectImage";

--- a/packages/client/src/components/blocks-workspace/blocks/block-settings/theme-block/config.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks/block-settings/theme-block/config.tsx
@@ -1,12 +1,13 @@
 import { Copy, ExternalLink, X } from "lucide-react";
 import { type CSSProperties, useState } from "react";
-import { darkTheme, lightTheme } from "@semoss/ui";
 import {
 	Button,
 	Dialog,
 	DialogContent,
 	DialogHeader,
 	DialogTitle,
+	darkTheme,
+	lightTheme,
 	Select,
 	SelectContent,
 	SelectItem,

--- a/packages/client/src/components/blocks-workspace/menus/default-menu.ts
+++ b/packages/client/src/components/blocks-workspace/menus/default-menu.ts
@@ -1,5 +1,5 @@
 import type { BlockJSON } from "@semoss/renderer";
-import { lightTheme } from "@semoss/ui";
+import { lightTheme } from "@semoss/ui/next";
 import * as BLOCK_IMAGES from "@/assets/blocks";
 import type { DesignerMenuItem } from "./menu-types";
 

--- a/packages/client/src/components/common/TextEditor/TextEditorCodeGeneration.tsx
+++ b/packages/client/src/components/common/TextEditor/TextEditorCodeGeneration.tsx
@@ -2,63 +2,22 @@ import { Copy, Sparkles } from "lucide-react";
 import { useState } from "react";
 import {
 	Button,
-	Menu,
-	Modal,
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Label,
 	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
 	Skeleton,
-	Stack,
-	styled,
-	TextField,
-	Typography,
-} from "@semoss/ui";
-import { toast } from "@semoss/ui/next";
+	Textarea,
+	toast,
+} from "@semoss/ui/next";
 import { useLLM, useRootStore } from "@/hooks";
-
-const StyledGenerateButton = styled(Button, {
-	shouldForwardProp: (prop) => prop !== "full",
-})<{
-	/** Track if the button should be full width */
-	full: boolean;
-}>(({ theme, full }) => {
-	return {
-		backgroundColor: theme.palette.purple["400"],
-		color: theme.palette.background.paper,
-		gap: theme.spacing(1),
-		width: full ? "100%" : "",
-		"&:hover": {
-			backgroundColor: theme.palette.purple["200"],
-		},
-	};
-});
-
-const StyledExpandCode = styled("div")(({ theme }) => ({
-	width: "100%",
-	height: "100%",
-	display: "flex",
-	justifyContent: "space-between",
-	padding: theme.spacing(1),
-	background: theme.palette.secondary.main,
-	borderRadius: `${theme.shape.borderRadius}px ${theme.shape.borderRadius}px 0px 0px`,
-}));
-
-const StyledCodeBlock = styled("pre")(({ theme }) => ({
-	display: "flex",
-	alignItems: "flex-start",
-	gap: "40px",
-	background: theme.palette.secondary.light,
-	borderRadius: `0px 0px ${theme.shape.borderRadius}px ${theme.shape.borderRadius}px`,
-	padding: theme.spacing(2),
-	margin: "0px",
-	overflowX: "scroll",
-}));
-
-const StyledCodeContent = styled("code")(() => ({
-	flex: 1,
-}));
-
-const StyledSkeletonContainer = styled("div")(() => ({
-	height: "200px",
-}));
 
 export const TextEditorCodeGeneration = () => {
 	const { modelId, modelOptions, setModel: setModelId } = useLLM();
@@ -68,10 +27,6 @@ export const TextEditorCodeGeneration = () => {
 	const [code, setCode] = useState("");
 	const [prompt, setPrompt] = useState("");
 
-	/**
-	 * Assitant for adding code
-	 *
-	 */
 	const generateCode = async () => {
 		try {
 			if (!modelId) {
@@ -82,7 +37,6 @@ export const TextEditorCodeGeneration = () => {
 				throw new Error("Prompt is required");
 			}
 
-			// turn on loading
 			setIsLoading(true);
 
 			const response = await monolithStore.runQuery(
@@ -94,35 +48,24 @@ export const TextEditorCodeGeneration = () => {
 				throw new Error(output);
 			}
 
-			// Regex anything between the 3 backticks
 			const codeMatch = output.response.replace(/^```|```$/g, "");
 
-			// TODO: Figure out if there is a particular LLM that will have a consistent response structure
 			if (!codeMatch) {
 				throw new Error("Unable to parse generated code");
 			}
 
-			// // Will this be multiple indexes
-			// if (codeMatch.length > 1) {
 			setCode(codeMatch);
-			// }
 		} catch (e) {
 			console.log(e);
 			toast.error(e.message);
 		} finally {
-			// turn off loading
 			setIsLoading(false);
 		}
 	};
 
-	/**
-	 * Copy text and add it to the clipboard
-	 * @param text - text to copy
-	 */
 	const copy = async (text: string) => {
 		try {
 			await navigator.clipboard.writeText(text);
-
 			toast.success("Successfully copied code");
 		} catch (_e) {
 			toast.error("Unable to copy code");
@@ -131,102 +74,95 @@ export const TextEditorCodeGeneration = () => {
 
 	return (
 		<>
-			<StyledGenerateButton
-				full={true}
-				startIcon={<Sparkles className="size-4" />}
-				variant="contained"
-				color="secondary"
-				onClick={() => {
-					setIsOpen(true);
-				}}
+			<Button
+				className="w-full gap-1 bg-purple-400 text-white hover:bg-purple-300"
+				onClick={() => setIsOpen(true)}
 			>
+				<Sparkles className="size-4" />
 				Generate Code
-			</StyledGenerateButton>
-			{/* Generate Code Modal */}
-			<Modal open={isOpen} maxWidth="xl">
-				<Modal.Title>
-					<Typography variant="h5">Generate Code</Typography>
-				</Modal.Title>
-				<Modal.Content>
-					<Stack direction="column">
-						<Select
-							fullWidth={true}
-							label={"Model"}
-							value={modelId}
-							onChange={(e) => setModelId(e.target.value)}
-						>
-							{modelOptions.map((m) => (
-								<Menu.Item key={m.app_id} value={m.app_id}>
-									{m.app_name}
-								</Menu.Item>
-							))}
-						</Select>
-						<TextField
-							fullWidth={true}
-							label="Prompt"
-							helperText={
-								'Example prompt: "Write me an HTML form that takes in patient information"'
-							}
-							onKeyDown={(e) => {
-								if (e.code === "Enter") {
-									generateCode();
-								}
-							}}
-							onChange={(e) => {
-								setPrompt(e.target.value);
-							}}
-							rows={3}
-						></TextField>
-						{isLoading ? (
-							<StyledSkeletonContainer>
-								<Skeleton
-									variant={"rectangular"}
-									width={"100%"}
-									height={"100%"}
-								/>
-							</StyledSkeletonContainer>
-						) : null}
-						{!isLoading && code ? (
-							<div>
-								<StyledExpandCode>
-									&nbsp;
+			</Button>
+
+			<Dialog open={isOpen} onOpenChange={setIsOpen}>
+				<DialogContent className="sm:max-w-2xl" showCloseButton={false}>
+					<DialogHeader>
+						<DialogTitle>Generate Code</DialogTitle>
+					</DialogHeader>
+
+					<div className="flex flex-col gap-3 py-2">
+						<div className="flex flex-col gap-1.5">
+							<Label>Model</Label>
+							<Select
+								value={modelId}
+								onValueChange={(val) => setModelId(val)}
+							>
+								<SelectTrigger className="w-full">
+									<SelectValue placeholder="Select a model" />
+								</SelectTrigger>
+								<SelectContent>
+									{modelOptions.map((m) => (
+										<SelectItem
+											key={m.app_id}
+											value={m.app_id}
+										>
+											{m.app_name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label>Prompt</Label>
+							<Textarea
+								placeholder='Example: "Write me an HTML form that takes in patient information"'
+								rows={3}
+								onKeyDown={(e) => {
+									if (e.code === "Enter") generateCode();
+								}}
+								onChange={(e) => setPrompt(e.target.value)}
+							/>
+						</div>
+
+						{isLoading && <Skeleton className="h-[200px] w-full" />}
+
+						{!isLoading && code && (
+							<div className="overflow-hidden rounded-md border">
+								<div className="flex items-center justify-between bg-secondary px-3 py-2">
+									<span className="text-muted-foreground text-xs">
+										Generated code
+									</span>
 									<Button
-										size={"medium"}
-										variant="outlined"
-										color="secondary"
-										startIcon={<Copy className="size-4" />}
+										size="sm"
+										variant="outline"
 										onClick={() => copy(code)}
 									>
+										<Copy className="size-3.5" />
 										Copy
 									</Button>
-								</StyledExpandCode>
-								<StyledCodeBlock>
-									<StyledCodeContent>
-										{code}
-									</StyledCodeContent>
-								</StyledCodeBlock>
+								</div>
+								<pre className="overflow-x-auto bg-secondary/50 p-4 text-sm">
+									<code>{code}</code>
+								</pre>
 							</div>
-						) : null}
-					</Stack>
-				</Modal.Content>
-				<Modal.Actions>
-					<Button
-						onClick={() => {
-							setIsOpen(false);
-						}}
-					>
-						Cancel
-					</Button>
-					<StyledGenerateButton
-						full={false}
-						onClick={() => {
-							generateCode();
-						}}
-					>
-						Generate
-					</StyledGenerateButton>
-				</Modal.Actions>
-			</Modal>
+						)}
+					</div>
+
+					<DialogFooter>
+						<Button
+							variant="ghost"
+							onClick={() => setIsOpen(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							className="gap-1 bg-purple-400 text-white hover:bg-purple-300"
+							onClick={generateCode}
+						>
+							Generate
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</>
 	);
 };

--- a/packages/client/src/components/engine/FeedbackButtons.tsx
+++ b/packages/client/src/components/engine/FeedbackButtons.tsx
@@ -1,18 +1,12 @@
 import { ThumbsDown, ThumbsUp } from "lucide-react";
 import { useState } from "react";
-import { IconButton, Stack, styled } from "@semoss/ui";
-import { toast } from "@semoss/ui/next";
+import { Button, toast } from "@semoss/ui/next";
 
 interface FeedbackButtonsProps {
 	messageId: string;
 	onFeedbackCall: (messageId: string, value: "true" | "false") => void;
 	initialValue?: "true" | "false" | null;
 }
-
-const StyledIcon = styled(IconButton)(() => ({
-	opacity: 0.7,
-	padding: 0,
-}));
 
 export const FeedbackButtons: React.FC<FeedbackButtonsProps> = ({
 	messageId,
@@ -33,20 +27,26 @@ export const FeedbackButtons: React.FC<FeedbackButtonsProps> = ({
 	};
 
 	return (
-		<Stack direction="row" display="flex" alignItems="center">
-			<StyledIcon
+		<div className="flex items-center">
+			<Button
+				variant="ghost"
+				size="icon-sm"
 				onClick={() => handleFeedback("true")}
 				disabled={!!feedback}
+				className="opacity-70"
 			>
 				<ThumbsUp className="size-4" />
-			</StyledIcon>
+			</Button>
 
-			<StyledIcon
+			<Button
+				variant="ghost"
+				size="icon-sm"
 				onClick={() => handleFeedback("false")}
 				disabled={!!feedback}
+				className="opacity-70"
 			>
 				<ThumbsDown className="size-4" />
-			</StyledIcon>
-		</Stack>
+			</Button>
+		</div>
 	);
 };

--- a/packages/client/src/components/import/refactor/UploadData.tsx
+++ b/packages/client/src/components/import/refactor/UploadData.tsx
@@ -1,4 +1,4 @@
-import { FileDropzone } from "@semoss/ui";
+import { FileDropzone } from "@semoss/ui/next";
 
 /**
  * @deprecated

--- a/packages/client/src/components/workspace/WorkspaceLoading.tsx
+++ b/packages/client/src/components/workspace/WorkspaceLoading.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react-lite";
-import { LoadingScreen } from "@semoss/ui";
+import { LoadingScreen } from "@semoss/ui/next";
 import { useWorkspace } from "@/hooks";
 
 /**

--- a/packages/client/src/pages/LoginPage.tsx
+++ b/packages/client/src/pages/LoginPage.tsx
@@ -1,199 +1,27 @@
 import { observer } from "mobx-react-lite";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { type Location, Navigate, useLocation } from "react-router-dom";
 import {
 	Alert,
-	Box,
+	AlertDescription,
 	Button,
-	ButtonGroup,
-	Divider,
-	LinearProgress,
-	Modal,
-	Snackbar,
-	Stack,
-	styled,
-	TextField,
+	cn,
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Input,
+	Label,
+	Separator,
 	Tooltip,
-	Typography,
-} from "@semoss/ui";
+	TooltipContent,
+	TooltipTrigger,
+	toast,
+} from "@semoss/ui/next";
 import GIF from "@/assets/img/login-gif.gif";
 import { useRootStore } from "@/hooks";
-
-const StyledMain = styled("div")(({ theme }) => ({
-	display: "flex",
-	flexDirection: "column",
-	height: "100vh",
-	width: "100vw",
-	background: theme.palette.background.paper,
-}));
-
-const StyledRow = styled("div")(() => ({
-	flex: "1",
-	display: "flex",
-	flexDirection: "row",
-	position: "relative",
-	width: "100%",
-	overflow: "hidden",
-}));
-
-const StyledProgress = styled(LinearProgress)(() => ({
-	width: "100%",
-}));
-
-const StyledScroll = styled("div")(({ theme }) => ({
-	flexShrink: 0,
-	position: "relative",
-	display: "flex",
-	flexDirection: "column",
-	alignItems: "center",
-	zIndex: 1,
-	background: theme.palette.background.paper,
-	overflowY: "auto",
-	overflowX: "hidden",
-	[theme.breakpoints.down("md")]: {
-		height: "100%",
-		width: "100%",
-	},
-}));
-
-const StyledContent = styled("div")(({ theme }) => ({
-	display: "flex",
-	flexDirection: "column",
-	gap: theme.spacing(3),
-	width: "610px",
-	marginTop: theme.spacing(18), // 144px
-	marginBottom: theme.spacing(2), // 16px
-	marginLeft: theme.spacing(13.5), // 108px
-	marginRight: theme.spacing(13.5), // 108px
-	[theme.breakpoints.down("md")]: {
-		margin: 0,
-		padding: theme.spacing(4),
-		maxWidth: "610px",
-		width: "100%",
-	},
-}));
-
-const StyledGradient = styled("div")(({ theme }) => ({
-	height: "100%",
-	width: theme.spacing(42), // 336px
-	background:
-		"linear-gradient(90deg, #FFF 0%, rgba(255, 255, 255, 0.00) 100%)",
-	zIndex: 1,
-}));
-
-const StyledImageHolder = styled("div")(() => ({
-	position: "absolute",
-	top: "0px",
-	right: "0px",
-	bottom: "0px",
-	overflow: "hidden",
-	zIndex: 0,
-}));
-
-const StyledImage = styled("img")(() => ({
-	height: "100%",
-	// width: '100%',
-	objectFit: "cover",
-}));
-
-const StyledAction = styled(ButtonGroup.Item)({
-	display: "flex",
-	alignItems: "center",
-	justifyContent: "center",
-	overflow: "hidden",
-});
-
-const StyledActionBox = styled("div")({
-	display: "flex",
-	alignItems: "center",
-	gap: "16px",
-	padding: "4px",
-});
-
-// const StyledActionImage = styled('img')(({ theme }) => ({
-//     height: theme.spacing(3),
-// }));
-
-const StyledActionText = styled("span")(() => ({
-	fontFamily: "Inter",
-	fontSize: "14px",
-	fontStyle: "normal",
-	fontWeight: 500,
-	lineHeight: "24px",
-	letterSpacing: "0.4px",
-	color: "#000",
-}));
-
-const StyledDivider = styled(Divider)({
-	background: "transparent",
-});
-
-const StyledDividerBox = styled(Box)({
-	color: "#000",
-	fontFeatureSettings: '"clig" off, "liga" off',
-	fontFamily: "Inter",
-	fontSize: "16px",
-	fontStyle: "normal",
-	fontWeight: 700,
-	lineHeight: "150%" /* 24px */,
-	letterSpacing: " 0.15px",
-});
-
-const StyledButtonGroup = styled(ButtonGroup)({
-	".MuiButtonGroup-grouped": {
-		borderColor: "#fff",
-	},
-});
-
-const StyledButtonGroupItem = styled(ButtonGroup.Item, {
-	shouldForwardProp: (prop) => prop !== "selected",
-})<{
-	/** Track if Button is selected */
-	selected: boolean;
-}>(({ theme, selected }) => ({
-	color: selected ? theme.palette.common.white : theme.palette.primary.main,
-	backgroundColor: selected
-		? theme.palette.primary.main
-		: theme.palette.common.white,
-	"&:hover": {
-		backgroundColor: selected ? theme.palette.primary.dark : "",
-		borderColor: theme.palette.common.white,
-	},
-}));
-
-const StyledRegisterNowBox = styled(Box)({
-	display: "flex",
-	align: "center",
-	alignItems: "center",
-	justifyContent: "center",
-});
-
-const StyledLogoContainer = styled(Stack)(({ theme }) => ({
-	marginBottom: theme.spacing(1),
-}));
-
-const StyledTitle = styled(Typography)(({ theme }) => ({
-	marginBottom: theme.spacing(1),
-}));
-
-const StyledInstructions = styled(Typography)(({ theme }) => ({
-	marginBottom: theme.spacing(4),
-}));
-
-const StyledButtonText = styled(ButtonGroup.Item)({
-	fontFamily: "Inter",
-	fontSize: "15px",
-	fontStyle: "normal",
-	fontWeight: 600,
-	lineHeight: "26px" /* 173.333% */,
-	letterSpacing: "0.46px",
-});
-
-const StyledGoBackBox = styled(Box)({
-	display: "flex",
-	justifyContent: "space-between",
-});
 
 interface TypeUserLogin {
 	USERNAME: string;
@@ -214,12 +42,10 @@ interface TypeUserRegister {
 	PASSWORD_CONFIRMATION: "";
 }
 
-/**
- * LoginPage
- */
 export const LoginPage = observer(() => {
 	const { configStore } = useRootStore();
 	const location = useLocation();
+	const uid = useId();
 
 	const [forgotPassword, setForgotPassword] = useState(false);
 	const [loginType, setLoginType] = useState<
@@ -227,15 +53,6 @@ export const LoginPage = observer(() => {
 	>("");
 	const [register, setRegister] = useState(false);
 	const [showOTPCodeField, setShowOTPCodeField] = useState(false);
-	const [snackbar, setSnackbar] = useState<{
-		open: boolean;
-		message: string;
-		color: "success" | "info" | "warning" | "error";
-	}>({
-		open: false,
-		message: "",
-		color: "success",
-	});
 	const [error, setError] = useState("");
 	const [success, setSuccess] = useState("");
 	const [isLoading, setIsLoading] = useState(false);
@@ -286,17 +103,6 @@ export const LoginPage = observer(() => {
 		};
 	};
 
-	const passwordTooltipContent = (
-		<Box>
-			<Typography variant="body2">• At least 8 characters</Typography>
-			<Typography variant="body2">• One uppercase letter</Typography>
-			<Typography variant="body2">• One lowercase letter</Typography>
-			<Typography variant="body2">
-				• One special character [!, @, #, $, %, ^, &, *]
-			</Typography>
-		</Box>
-	);
-
 	// get a map of all providers
 	const availableProvidersMap: Record<
 		string,
@@ -308,11 +114,9 @@ export const LoginPage = observer(() => {
 		}
 	> = configStore.store.config.availableProviders.reduce((acc, val) => {
 		acc[val.provider] = acc;
-
 		return acc;
 	}, {});
 
-	// check if there is oAuth
 	const hasOAuth = configStore.store.config.availableProviders.some(
 		(val) => val.isOauth,
 	);
@@ -321,13 +125,11 @@ export const LoginPage = observer(() => {
 		isLdap = Object.hasOwn(availableProvidersMap, "ldap"),
 		isLinOTP = Object.hasOwn(availableProvidersMap, "linotp");
 
-	// check if it requires username or password
 	const hasUsernamePassword = isNative || isLdap || isLinOTP;
 
 	const hasMoreThanOneUserNamePassword =
 		(isNative && isLdap) || (isNative && isLinOTP) || (isLdap && isLinOTP);
 
-	// set initial selected login type from config.
 	useEffect(() => {
 		if (isNative) {
 			setLoginType("native");
@@ -338,12 +140,8 @@ export const LoginPage = observer(() => {
 		}
 	}, [isNative, isLdap, isLinOTP]);
 
-	/**
-	 * Allow the user to login
-	 */
 	const login = handleSubmit(
 		async (data: TypeUserLogin): Promise<TypeUserLogin> => {
-			// turn on loading
 			setIsLoading(true);
 			setSuccess("");
 
@@ -356,28 +154,20 @@ export const LoginPage = observer(() => {
 				if (loginType === "native") {
 					await configStore
 						.login(data.USERNAME, data.PASSWORD)
-						.then(() => {
-							// noop
-						})
-						.catch((error) => {
-							setError(error.message);
+						.catch((err) => {
+							setError(err.message);
 						})
 						.finally(() => {
-							// turn off loading
 							setIsLoading(false);
 						});
 				}
 				if (loginType === "ldap") {
 					await configStore
 						.loginLDAP(data.USERNAME, data.PASSWORD)
-						.then(() => {
-							// noop
-						})
-						.catch((error) => {
-							setError(error.message);
+						.catch((err) => {
+							setError(err.message);
 						})
 						.finally(() => {
-							// turn off loading
 							setIsLoading(false);
 						});
 				}
@@ -385,14 +175,12 @@ export const LoginPage = observer(() => {
 					await configStore
 						.loginOTP(data.USERNAME, data.PASSWORD)
 						.then(() => {
-							// noop
 							setShowOTPCodeField(true);
 						})
-						.catch((error) => {
-							setError(error.message);
+						.catch((err) => {
+							setError(err.message);
 						})
 						.finally(() => {
-							// turn off loading
 							setIsLoading(false);
 						});
 				}
@@ -400,14 +188,10 @@ export const LoginPage = observer(() => {
 			if (showOTPCodeField) {
 				await configStore
 					.confirmOTP(data.OTP_CONFIRM)
-					.then(() => {
-						// noop
-					})
-					.catch((error) => {
-						setError(error.message);
+					.catch((err) => {
+						setError(err.message);
 					})
 					.finally(() => {
-						// turn off loading
 						setIsLoading(false);
 					});
 				setShowOTPCodeField(true);
@@ -415,12 +199,8 @@ export const LoginPage = observer(() => {
 		},
 	);
 
-	/**
-	 * Allow the user to login
-	 */
 	const registerAccount = registerSubmit(
 		async (data: TypeUserRegister): Promise<TypeUserRegister> => {
-			// turn on loading
 			setIsLoading(true);
 
 			if (
@@ -464,486 +244,488 @@ export const LoginPage = observer(() => {
 						reset();
 					}
 				})
-				.catch((error) => {
+				.catch((err) => {
 					setIsLoading(false);
-					setError(error.message);
+					setError(err.message);
 				})
 				.finally(() => {
-					// turn off loading
 					setIsLoading(false);
 				});
 		},
 	);
 
-	/**
-	 * Login with oauth
-	 * @param provider - provider to oauth with
-	 */
 	const oauth = async (provider: string) => {
-		// turn on loading
 		setIsLoading(true);
 
 		await configStore
 			.oauth(provider)
 			.then(() => {
-				// turn off loading
 				setIsLoading(false);
-
-				// noop
-				// (handled  by the configStore)
-
-				setSnackbar({
-					open: true,
-					message: `Successfully logged in`,
-					color: "success",
-				});
+				toast.success("Successfully logged in");
 			})
-			.catch((error) => {
-				// turn off loading
+			.catch((err) => {
 				setIsLoading(false);
-
-				setError(error.message);
-
-				setSnackbar({
-					open: true,
-					message: error.message,
-					color: "error",
-				});
+				setError(err.message);
+				toast.error(err.message);
 			});
 	};
 
-	// get the path the user is coming from
 	const path = (location.state as { from: Location })?.from?.pathname || "/";
 
-	// navigate if already logged in
 	if (configStore.store.status === "SUCCESS") {
 		return <Navigate to={path} replace />;
 	}
 
 	return (
 		<>
-			<Snackbar
-				open={snackbar.open}
-				anchorOrigin={{ vertical: "top", horizontal: "right" }}
-				autoHideDuration={6000}
-				onClose={() => {
-					setSnackbar({
-						open: false,
-						message: "",
-						color: "success",
-					});
-				}}
-			>
-				<Alert severity={snackbar.color} sx={{ width: "100%" }}>
-					{snackbar.message}
-				</Alert>
-			</Snackbar>
-			<StyledMain>
-				<StyledRow>
-					<StyledScroll>
-						<StyledContent>
+			<div className="flex h-screen w-screen flex-col bg-background">
+				<div className="relative flex w-full flex-1 flex-row overflow-hidden">
+					<div className="relative z-10 flex shrink-0 flex-col items-center overflow-y-auto overflow-x-hidden bg-background max-md:h-full max-md:w-full">
+						<div className="mx-[108px] mt-36 mb-4 flex w-[610px] flex-col gap-6 max-md:m-0 max-md:w-full max-md:max-w-[610px] max-md:p-8">
 							<div>
-								<StyledLogoContainer
-									direction={"row"}
-									alignItems={"center"}
-									spacing={1}
-								>
+								<div className="mb-2 flex flex-row items-center gap-2">
 									{configStore.theme.logo ? (
-										<img src={configStore.theme.logo} />
+										<img
+											src={configStore.theme.logo}
+											alt={
+												configStore.theme.name || "logo"
+											}
+										/>
 									) : null}
-									<Typography
-										variant="h6"
-										sx={{ fontWeight: 700 }}
-									>
+									<span className="font-bold text-xl">
 										{configStore.theme.name}
-									</Typography>
-								</StyledLogoContainer>
-								<StyledTitle variant="h4">Welcome!</StyledTitle>
-								<StyledInstructions variant="body1">
+									</span>
+								</div>
+								<h4 className="mb-2 scroll-m-20 font-semibold text-3xl tracking-tight">
+									Welcome!
+								</h4>
+								<p className="mb-8 text-base">
 									{register
 										? "Register below"
 										: "Log in below"}
-								</StyledInstructions>
+								</p>
 							</div>
+
 							{!register && hasMoreThanOneUserNamePassword && (
-								<StyledButtonGroup variant="outlined">
+								<div className="flex overflow-hidden rounded-md border border-input">
 									{isNative && (
-										<StyledButtonGroupItem
+										<button
+											type="button"
 											onClick={() => {
 												setLoginType("native");
 												setSuccess("");
 												setError("");
 											}}
-											selected={loginType === "native"}
-											data-testid={
-												"loginPage-button-native"
-											}
+											className={cn(
+												"flex-1 px-4 py-2 font-medium text-sm transition-colors",
+												loginType === "native"
+													? "bg-primary text-primary-foreground"
+													: "bg-background text-primary hover:bg-muted",
+											)}
+											data-testid="loginPage-button-native"
 										>
 											Native
-										</StyledButtonGroupItem>
+										</button>
 									)}
 									{isLdap && (
-										<StyledButtonGroupItem
+										<button
+											type="button"
 											onClick={() => {
 												setLoginType("ldap");
 												setSuccess("");
 												setError("");
 											}}
-											selected={loginType === "ldap"}
-											data-testid={
-												"loginPage-button-ldap"
-											}
+											className={cn(
+												"flex-1 px-4 py-2 font-medium text-sm transition-colors",
+												loginType === "ldap"
+													? "bg-primary text-primary-foreground"
+													: "bg-background text-primary hover:bg-muted",
+											)}
+											data-testid="loginPage-button-ldap"
 										>
 											LDAP
-										</StyledButtonGroupItem>
+										</button>
 									)}
 									{isLinOTP && (
-										<StyledButtonGroupItem
+										<button
+											type="button"
 											onClick={() => {
 												setLoginType("linotp");
 												setSuccess("");
 												setError("");
 											}}
-											selected={loginType === "linotp"}
-											data-testid={
-												"loginPage-button-linotp"
-											}
+											className={cn(
+												"flex-1 px-4 py-2 font-medium text-sm transition-colors",
+												loginType === "linotp"
+													? "bg-primary text-primary-foreground"
+													: "bg-background text-primary hover:bg-muted",
+											)}
+											data-testid="loginPage-button-linotp"
 										>
 											LinOTP
-										</StyledButtonGroupItem>
+										</button>
 									)}
-								</StyledButtonGroup>
+								</div>
 							)}
+
 							{error && (
-								<Alert severity="error" color="error">
-									{error}
+								<Alert variant="destructive">
+									<AlertDescription>{error}</AlertDescription>
 								</Alert>
 							)}
+
 							{success && (
-								<Alert severity="success" color="success">
+								<div className="rounded-lg border border-green-500 bg-green-50 px-4 py-3 text-green-700 text-sm dark:bg-green-950/30 dark:text-green-400">
 									{success}
-								</Alert>
+								</div>
 							)}
+
 							<form>
-								<Stack spacing={2}>
+								<div className="flex flex-col gap-4">
 									{hasUsernamePassword && (
 										<>
 											{!showOTPCodeField && register && (
 												<>
+													<div className="flex gap-3">
+														<Controller
+															name="FIRST_NAME"
+															control={
+																registerControl
+															}
+															rules={{
+																required:
+																	"First name is required",
+															}}
+															render={({
+																field,
+															}) => (
+																<div className="flex flex-1 flex-col gap-1.5">
+																	<Label
+																		htmlFor={`${uid}-reg-firstName`}
+																	>
+																		First
+																		Name *
+																	</Label>
+																	<Input
+																		id={`${uid}-reg-firstName`}
+																		value={
+																			field.value ||
+																			""
+																		}
+																		onChange={(
+																			e,
+																		) =>
+																			field.onChange(
+																				e
+																					.target
+																					.value,
+																			)
+																		}
+																		data-testid="loginPage-textField-firstNameRegister"
+																		aria-invalid={
+																			!!errors.FIRST_NAME
+																		}
+																	/>
+																	{errors.FIRST_NAME && (
+																		<p className="text-destructive text-sm">
+																			{
+																				errors
+																					.FIRST_NAME
+																					.message
+																			}
+																		</p>
+																	)}
+																</div>
+															)}
+														/>
+														<Controller
+															name="LAST_NAME"
+															control={
+																registerControl
+															}
+															rules={{
+																required:
+																	"Last name is required",
+															}}
+															render={({
+																field,
+															}) => (
+																<div className="flex flex-1 flex-col gap-1.5">
+																	<Label
+																		htmlFor={`${uid}-reg-lastName`}
+																	>
+																		Last
+																		Name *
+																	</Label>
+																	<Input
+																		id={`${uid}-reg-lastName`}
+																		value={
+																			field.value ||
+																			""
+																		}
+																		onChange={(
+																			e,
+																		) =>
+																			field.onChange(
+																				e
+																					.target
+																					.value,
+																			)
+																		}
+																		data-testid="loginPage-textField-lastNameRegister"
+																		aria-invalid={
+																			!!errors.LAST_NAME
+																		}
+																	/>
+																	{errors.LAST_NAME && (
+																		<p className="text-destructive text-sm">
+																			{
+																				errors
+																					.LAST_NAME
+																					.message
+																			}
+																		</p>
+																	)}
+																</div>
+															)}
+														/>
+													</div>
+													<div className="flex gap-3">
+														<Controller
+															name="USERNAME"
+															control={
+																registerControl
+															}
+															rules={{
+																required:
+																	"Username is required",
+															}}
+															render={({
+																field,
+															}) => (
+																<div className="flex flex-1 flex-col gap-1.5">
+																	<Label
+																		htmlFor={`${uid}-reg-username`}
+																	>
+																		Username
+																		*
+																	</Label>
+																	<Input
+																		id={`${uid}-reg-username`}
+																		value={
+																			field.value ||
+																			""
+																		}
+																		onChange={(
+																			e,
+																		) =>
+																			field.onChange(
+																				e
+																					.target
+																					.value,
+																			)
+																		}
+																		data-testid="loginPage-textField-usernameRegister"
+																		aria-invalid={
+																			!!errors.USERNAME
+																		}
+																	/>
+																	{errors.USERNAME && (
+																		<p className="text-destructive text-sm">
+																			{
+																				errors
+																					.USERNAME
+																					.message
+																			}
+																		</p>
+																	)}
+																</div>
+															)}
+														/>
+														<Controller
+															name="EMAIL"
+															control={
+																registerControl
+															}
+															rules={{
+																required:
+																	"Email is required",
+																pattern: {
+																	value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+																	message:
+																		"Please enter a valid email address",
+																},
+															}}
+															render={({
+																field,
+															}) => (
+																<div className="flex flex-1 flex-col gap-1.5">
+																	<Label
+																		htmlFor={`${uid}-reg-email`}
+																	>
+																		Email *
+																	</Label>
+																	<Input
+																		id={`${uid}-reg-email`}
+																		value={
+																			field.value ||
+																			""
+																		}
+																		onChange={(
+																			e,
+																		) =>
+																			field.onChange(
+																				e
+																					.target
+																					.value,
+																			)
+																		}
+																		data-testid="loginPage-textField-emailRegister"
+																		aria-invalid={
+																			!!errors.EMAIL
+																		}
+																	/>
+																	{errors.EMAIL && (
+																		<p className="text-destructive text-sm">
+																			{
+																				errors
+																					.EMAIL
+																					.message
+																			}
+																		</p>
+																	)}
+																</div>
+															)}
+														/>
+													</div>
+													<div className="flex gap-3">
+														<Controller
+															name="PHONE"
+															control={
+																registerControl
+															}
+															rules={{
+																pattern: {
+																	value: /^\d{10}$/,
+																	message:
+																		"Please enter valid Phone Number",
+																},
+															}}
+															render={({
+																field,
+															}) => (
+																<div className="flex flex-1 flex-col gap-1.5">
+																	<Label
+																		htmlFor={`${uid}-reg-phone`}
+																	>
+																		Phone
+																		Number
+																	</Label>
+																	<Input
+																		id={`${uid}-reg-phone`}
+																		value={
+																			field.value ||
+																			""
+																		}
+																		onChange={(
+																			e,
+																		) =>
+																			field.onChange(
+																				e
+																					.target
+																					.value,
+																			)
+																		}
+																		data-testid="loginPage-textField-phone"
+																		aria-invalid={
+																			!!errors.PHONE
+																		}
+																	/>
+																	{errors.PHONE && (
+																		<p className="text-destructive text-sm">
+																			{
+																				errors
+																					.PHONE
+																					.message
+																			}
+																		</p>
+																	)}
+																</div>
+															)}
+														/>
+														<Controller
+															name="EXTENTION"
+															control={
+																registerControl
+															}
+															render={({
+																field,
+															}) => (
+																<div className="flex flex-1 flex-col gap-1.5">
+																	<Label
+																		htmlFor={`${uid}-reg-extension`}
+																	>
+																		Phone
+																		Extension
+																	</Label>
+																	<Input
+																		id={`${uid}-reg-extension`}
+																		value={
+																			field.value ||
+																			""
+																		}
+																		onChange={(
+																			e,
+																		) =>
+																			field.onChange(
+																				e
+																					.target
+																					.value,
+																			)
+																		}
+																		data-testid="loginPage-textField-extension"
+																	/>
+																</div>
+															)}
+														/>
+														<Controller
+															name="COUNTRY_CODE"
+															control={
+																registerControl
+															}
+															render={({
+																field,
+															}) => (
+																<div className="flex flex-1 flex-col gap-1.5">
+																	<Label
+																		htmlFor={`${uid}-reg-countryCode`}
+																	>
+																		Country
+																		Code
+																	</Label>
+																	<Input
+																		id={`${uid}-reg-countryCode`}
+																		value={
+																			field.value ||
+																			""
+																		}
+																		onChange={(
+																			e,
+																		) =>
+																			field.onChange(
+																				e
+																					.target
+																					.value,
+																			)
+																		}
+																		data-testid="loginPage-textField-countryCode"
+																	/>
+																</div>
+															)}
+														/>
+													</div>
 													<Controller
-														name={"FIRST_NAME"}
-														control={
-															registerControl
-														}
-														rules={{
-															required:
-																"First name is required",
-														}}
-														render={({ field }) => {
-															return (
-																<TextField
-																	label="First Name *"
-																	variant="outlined"
-																	size="small"
-																	fullWidth
-																	value={
-																		field.value
-																			? field.value
-																			: ""
-																	}
-																	onChange={(
-																		e,
-																	) =>
-																		field.onChange(
-																			e
-																				.target
-																				.value,
-																		)
-																	}
-																	inputProps={{
-																		"data-testid":
-																			"loginPage-textField-firstNameRegister",
-																	}}
-																	error={
-																		!!errors.FIRST_NAME
-																	}
-																	helperText={
-																		errors
-																			.FIRST_NAME
-																			?.message
-																	}
-																/>
-															);
-														}}
-													/>
-													<Controller
-														name={"LAST_NAME"}
-														control={
-															registerControl
-														}
-														rules={{
-															required:
-																"Last name is required",
-														}}
-														render={({ field }) => {
-															return (
-																<TextField
-																	label="Last Name *"
-																	size="small"
-																	variant="outlined"
-																	fullWidth
-																	value={
-																		field.value
-																			? field.value
-																			: ""
-																	}
-																	onChange={(
-																		e,
-																	) =>
-																		field.onChange(
-																			e
-																				.target
-																				.value,
-																		)
-																	}
-																	inputProps={{
-																		"data-testid":
-																			"loginPage-textField-lastNameRegister",
-																	}}
-																	error={
-																		!!errors.LAST_NAME
-																	}
-																	helperText={
-																		errors
-																			.LAST_NAME
-																			?.message
-																	}
-																/>
-															);
-														}}
-													/>
-													<Controller
-														name={"USERNAME"}
-														control={
-															registerControl
-														}
-														rules={{
-															required:
-																"Username is required",
-														}}
-														render={({ field }) => {
-															return (
-																<TextField
-																	label="Username *"
-																	size="small"
-																	variant="outlined"
-																	fullWidth
-																	value={
-																		field.value
-																			? field.value
-																			: ""
-																	}
-																	onChange={(
-																		e,
-																	) =>
-																		field.onChange(
-																			e
-																				.target
-																				.value,
-																		)
-																	}
-																	inputProps={{
-																		"data-testid":
-																			"loginPage-textField-usernameRegister",
-																	}}
-																	error={
-																		!!errors.USERNAME
-																	}
-																	helperText={
-																		errors
-																			.USERNAME
-																			?.message
-																	}
-																/>
-															);
-														}}
-													/>
-													<Controller
-														name={"EMAIL"}
-														control={
-															registerControl
-														}
-														rules={{
-															required:
-																"Email is required",
-															pattern: {
-																value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-																message:
-																	"Please enter a valid email address",
-															},
-														}}
-														render={({ field }) => {
-															return (
-																<TextField
-																	label="Email *"
-																	size="small"
-																	variant="outlined"
-																	fullWidth
-																	value={
-																		field.value
-																			? field.value
-																			: ""
-																	}
-																	onChange={(
-																		e,
-																	) =>
-																		field.onChange(
-																			e
-																				.target
-																				.value,
-																		)
-																	}
-																	inputProps={{
-																		"data-testid":
-																			"loginPage-textField-emailRegister",
-																	}}
-																	error={
-																		!!errors.EMAIL
-																	}
-																	helperText={
-																		errors
-																			.EMAIL
-																			?.message
-																	}
-																/>
-															);
-														}}
-													/>
-													<Controller
-														name={"PHONE"}
-														control={
-															registerControl
-														}
-														rules={{
-															pattern: {
-																value: /^\d{10}$/,
-																message:
-																	"Please enter valid Phone Number",
-															},
-														}}
-														render={({ field }) => {
-															return (
-																<TextField
-																	label="Phone Number"
-																	size="small"
-																	variant="outlined"
-																	fullWidth
-																	value={
-																		field.value
-																			? field.value
-																			: ""
-																	}
-																	onChange={(
-																		e,
-																	) =>
-																		field.onChange(
-																			e
-																				.target
-																				.value,
-																		)
-																	}
-																	inputProps={{
-																		"data-testid":
-																			"loginPage-textField-phone",
-																	}}
-																	error={
-																		!!errors.PHONE
-																	}
-																	helperText={
-																		errors
-																			.PHONE
-																			?.message
-																	}
-																/>
-															);
-														}}
-													/>
-													<Controller
-														name={"EXTENTION"}
-														control={
-															registerControl
-														}
-														rules={{
-															required: false,
-														}}
-														render={({ field }) => {
-															return (
-																<TextField
-																	label="Phone Extention"
-																	size="small"
-																	variant="outlined"
-																	fullWidth
-																	value={
-																		field.value
-																			? field.value
-																			: ""
-																	}
-																	onChange={(
-																		e,
-																	) =>
-																		field.onChange(
-																			e
-																				.target
-																				.value,
-																		)
-																	}
-																	inputProps={{
-																		"data-testid":
-																			"loginPage-textField-extension",
-																	}}
-																/>
-															);
-														}}
-													/>
-													<Controller
-														name={"COUNTRY_CODE"}
-														control={
-															registerControl
-														}
-														rules={{
-															required: false,
-														}}
-														render={({ field }) => {
-															return (
-																<TextField
-																	label="Country Code"
-																	size="small"
-																	variant="outlined"
-																	fullWidth
-																	value={
-																		field.value
-																			? field.value
-																			: ""
-																	}
-																	onChange={(
-																		e,
-																	) =>
-																		field.onChange(
-																			e
-																				.target
-																				.value,
-																		)
-																	}
-																	inputProps={{
-																		"data-testid":
-																			"loginPage-textField-countryCode",
-																	}}
-																/>
-															);
-														}}
-													/>
-													<Controller
-														name={"PASSWORD"}
+														name="PASSWORD"
 														control={
 															registerControl
 														}
@@ -976,56 +758,91 @@ export const LoginPage = observer(() => {
 																return true;
 															},
 														}}
-														render={({ field }) => {
-															return (
-																<Tooltip
-																	title={
-																		passwordTooltipContent
-																	}
-																	placement="right"
-																	arrow
+														render={({ field }) => (
+															<div className="flex flex-col gap-1.5">
+																<Label
+																	htmlFor={`${uid}-reg-password`}
 																>
-																	<TextField
-																		label="Password *"
-																		error={
-																			!!errors.PASSWORD
-																		}
-																		helperText={
+																	Password *
+																</Label>
+																<Tooltip>
+																	<TooltipTrigger
+																		asChild
+																	>
+																		<Input
+																			id={`${uid}-reg-password`}
+																			type="password"
+																			value={
+																				field.value ||
+																				""
+																			}
+																			onChange={(
+																				e,
+																			) =>
+																				field.onChange(
+																					e
+																						.target
+																						.value,
+																				)
+																			}
+																			data-testid="loginPage-textField-passwordRegister"
+																			aria-invalid={
+																				!!errors.PASSWORD
+																			}
+																		/>
+																	</TooltipTrigger>
+																	<TooltipContent
+																		side="right"
+																		className="flex flex-col gap-0.5"
+																	>
+																		<p>
+																			• At
+																			least
+																			8
+																			characters
+																		</p>
+																		<p>
+																			•
+																			One
+																			uppercase
+																			letter
+																		</p>
+																		<p>
+																			•
+																			One
+																			lowercase
+																			letter
+																		</p>
+																		<p>
+																			•
+																			One
+																			special
+																			character
+																			[!,
+																			@,
+																			#,
+																			$,
+																			%,
+																			^,
+																			&,
+																			*]
+																		</p>
+																	</TooltipContent>
+																</Tooltip>
+																{errors.PASSWORD && (
+																	<p className="text-destructive text-sm">
+																		{
 																			errors
 																				.PASSWORD
-																				?.message
+																				.message
 																		}
-																		size="small"
-																		variant="outlined"
-																		type="password"
-																		fullWidth
-																		value={
-																			field.value
-																				? field.value
-																				: ""
-																		}
-																		onChange={(
-																			e,
-																		) =>
-																			field.onChange(
-																				e
-																					.target
-																					.value,
-																			)
-																		}
-																		inputProps={{
-																			"data-testid":
-																				"loginPage-textField-passwordRegister",
-																		}}
-																	/>
-																</Tooltip>
-															);
-														}}
+																	</p>
+																)}
+															</div>
+														)}
 													/>
 													<Controller
-														name={
-															"PASSWORD_CONFIRMATION"
-														}
+														name="PASSWORD_CONFIRMATION"
 														control={
 															registerControl
 														}
@@ -1037,26 +854,21 @@ export const LoginPage = observer(() => {
 																	regPassword ||
 																"Passwords do not match",
 														}}
-														render={({ field }) => {
-															return (
-																<TextField
-																	label="Password Confirmation *"
-																	size="small"
-																	error={
-																		!!errors.PASSWORD_CONFIRMATION
-																	}
-																	helperText={
-																		errors
-																			.PASSWORD_CONFIRMATION
-																			?.message
-																	}
-																	variant="outlined"
+														render={({ field }) => (
+															<div className="flex flex-col gap-1.5">
+																<Label
+																	htmlFor={`${uid}-reg-passwordConfirm`}
+																>
+																	Password
+																	Confirmation
+																	*
+																</Label>
+																<Input
+																	id={`${uid}-reg-passwordConfirm`}
 																	type="password"
-																	fullWidth
 																	value={
-																		field.value
-																			? field.value
-																			: ""
+																		field.value ||
+																		""
 																	}
 																	onChange={(
 																		e,
@@ -1067,65 +879,72 @@ export const LoginPage = observer(() => {
 																				.value,
 																		)
 																	}
-																	inputProps={{
-																		"data-testid":
-																			"loginPage-textField-passwordConfirm",
-																	}}
+																	data-testid="loginPage-textField-passwordConfirm"
+																	aria-invalid={
+																		!!errors.PASSWORD_CONFIRMATION
+																	}
 																/>
-															);
-														}}
+																{errors.PASSWORD_CONFIRMATION && (
+																	<p className="text-destructive text-sm">
+																		{
+																			errors
+																				.PASSWORD_CONFIRMATION
+																				.message
+																		}
+																	</p>
+																)}
+															</div>
+														)}
 													/>
-													<StyledGoBackBox>
-														<ButtonGroup.Item
-															fullWidth
-															variant={"text"}
+													<div className="flex justify-between gap-2">
+														<Button
+															type="button"
+															variant="ghost"
+															className="flex-1"
 															onClick={() =>
 																setRegister(
 																	false,
 																)
 															}
-															data-testid={
-																"loginPage-button-back"
-															}
+															data-testid="loginPage-button-back"
 														>
 															Go Back
-														</ButtonGroup.Item>
-														<ButtonGroup.Item
-															fullWidth
-															variant={
-																"contained"
-															}
+														</Button>
+														<Button
+															type="button"
+															className="flex-1"
 															onClick={
 																registerAccount
 															}
-															data-testid={
-																"loginPage-button-register"
-															}
+															data-testid="loginPage-button-register"
 														>
 															Register
-														</ButtonGroup.Item>
-													</StyledGoBackBox>
+														</Button>
+													</div>
 												</>
 											)}
+
 											{!showOTPCodeField && !register && (
 												<>
 													<Controller
-														name={"USERNAME"}
+														name="USERNAME"
 														control={control}
 														rules={{
 															required:
 																"Username is required",
 														}}
-														render={({ field }) => {
-															return (
-																<TextField
-																	label="Username"
-																	variant="outlined"
-																	fullWidth
+														render={({ field }) => (
+															<div className="flex flex-col gap-1.5">
+																<Label
+																	htmlFor={`${uid}-login-username`}
+																>
+																	Username
+																</Label>
+																<Input
+																	id={`${uid}-login-username`}
 																	value={
-																		field.value
-																			? field.value
-																			: ""
+																		field.value ||
+																		""
 																	}
 																	onChange={(
 																		e,
@@ -1136,40 +955,43 @@ export const LoginPage = observer(() => {
 																				.value,
 																		)
 																	}
-																	inputProps={{
-																		"data-testid":
-																			"loginPage-textField-username",
-																	}}
-																	error={
+																	data-testid="loginPage-textField-username"
+																	aria-invalid={
 																		!!formErrors.USERNAME
 																	}
-																	helperText={
-																		formErrors
-																			.USERNAME
-																			?.message
-																	}
 																/>
-															);
-														}}
+																{formErrors.USERNAME && (
+																	<p className="text-destructive text-sm">
+																		{
+																			formErrors
+																				.USERNAME
+																				.message
+																		}
+																	</p>
+																)}
+															</div>
+														)}
 													/>
 													<Controller
-														name={"PASSWORD"}
+														name="PASSWORD"
 														control={control}
 														rules={{
 															required:
 																"Password is required",
 														}}
-														render={({ field }) => {
-															return (
-																<TextField
-																	label="Password"
-																	variant="outlined"
+														render={({ field }) => (
+															<div className="flex flex-col gap-1.5">
+																<Label
+																	htmlFor={`${uid}-login-password`}
+																>
+																	Password
+																</Label>
+																<Input
+																	id={`${uid}-login-password`}
 																	type="password"
-																	fullWidth
 																	value={
-																		field.value
-																			? field.value
-																			: ""
+																		field.value ||
+																		""
 																	}
 																	onChange={(
 																		e,
@@ -1180,41 +1002,44 @@ export const LoginPage = observer(() => {
 																				.value,
 																		)
 																	}
-																	inputProps={{
-																		"data-testid":
-																			"loginPage-textField-password",
-																	}}
-																	error={
+																	data-testid="loginPage-textField-password"
+																	aria-invalid={
 																		!!formErrors.PASSWORD
 																	}
-																	helperText={
-																		formErrors
-																			.PASSWORD
-																			?.message
-																	}
 																/>
-															);
-														}}
+																{formErrors.PASSWORD && (
+																	<p className="text-destructive text-sm">
+																		{
+																			formErrors
+																				.PASSWORD
+																				.message
+																		}
+																	</p>
+																)}
+															</div>
+														)}
 													/>
 												</>
 											)}
+
 											{showOTPCodeField && (
 												<Controller
-													name={"OTP_CONFIRM"}
+													name="OTP_CONFIRM"
 													control={control}
-													rules={{
-														required: true,
-													}}
-													render={({ field }) => {
-														return (
-															<TextField
-																label="OTP Confirmation Code"
-																variant="outlined"
-																fullWidth
+													rules={{ required: true }}
+													render={({ field }) => (
+														<div className="flex flex-col gap-1.5">
+															<Label
+																htmlFor={`${uid}-login-otp`}
+															>
+																OTP Confirmation
+																Code
+															</Label>
+															<Input
+																id={`${uid}-login-otp`}
 																value={
-																	field.value
-																		? field.value
-																		: ""
+																	field.value ||
+																	""
 																}
 																onChange={(e) =>
 																	field.onChange(
@@ -1222,35 +1047,32 @@ export const LoginPage = observer(() => {
 																			.value,
 																	)
 																}
-																inputProps={{
-																	"data-testid":
-																		"loginPage-textField-otpCode",
-																}}
+																data-testid="loginPage-textField-otpCode"
 															/>
-														);
-													}}
+														</div>
+													)}
 												/>
 											)}
+
 											{!register && (
 												<>
-													<ButtonGroup.Item
-														fullWidth
-														variant={"contained"}
+													<Button
+														type="button"
+														className="w-full"
 														onClick={login}
-														type="submit"
-														data-testid={
-															"loginPage-button-login"
-														}
+														data-testid="loginPage-button-login"
 													>
 														Login
-													</ButtonGroup.Item>
+													</Button>
 													{configStore.store.config
 														.nativeRegistration && (
-														<StyledRegisterNowBox>
+														<div className="flex items-center justify-center gap-1">
 															Don&apos;t have an
 															account?{" "}
-															<StyledButtonText
-																variant="text"
+															<Button
+																type="button"
+																variant="link"
+																className="h-auto p-0"
 																onClick={() => {
 																	setRegister(
 																		true,
@@ -1259,97 +1081,83 @@ export const LoginPage = observer(() => {
 																		"",
 																	);
 																}}
-																data-testid={
-																	"loginPage-button-registerPage"
-																}
+																data-testid="loginPage-button-registerPage"
 															>
 																Register Now
-															</StyledButtonText>
-														</StyledRegisterNowBox>
+															</Button>
+														</div>
 													)}
 												</>
 											)}
 										</>
 									)}
+
 									{!register && (
 										<>
 											{hasUsernamePassword &&
 												hasOAuth && (
-													<>
-														<StyledDivider>
-															<StyledDividerBox>
-																or
-															</StyledDividerBox>
-														</StyledDivider>
-													</>
+													<div className="flex items-center gap-4">
+														<Separator className="flex-1" />
+														<span className="font-bold text-base">
+															or
+														</span>
+														<Separator className="flex-1" />
+													</div>
 												)}
 											{configStore.store.config.availableProviders.map(
 												(p) => {
-													// skip ones that aren't oauth
-													if (!p.isOauth) {
-														return null;
-													}
-
+													if (!p.isOauth) return null;
 													return (
-														<StyledAction
+														<Button
 															key={p.provider}
-															variant="outlined"
-															onClick={() => {
+															type="button"
+															variant="outline"
+															className="w-full"
+															onClick={() =>
 																oauth(
 																	p.provider,
-																);
-															}}
-															fullWidth
+																)
+															}
 														>
-															<StyledActionBox>
-																{/* <StyledActionImage
-                                                                    src={MS}
-                                                                /> */}
-																<StyledActionText>
-																	{p.name}
-																</StyledActionText>
-															</StyledActionBox>
-														</StyledAction>
+															{p.name}
+														</Button>
 													);
 												},
 											)}
 										</>
 									)}
-								</Stack>
+								</div>
 							</form>
-						</StyledContent>
-					</StyledScroll>
-					<StyledGradient />
-					<StyledImageHolder>
-						<StyledImage src={GIF} />
-					</StyledImageHolder>
-				</StyledRow>
-				{isLoading && <StyledProgress />}
-			</StyledMain>
-			<Modal
-				open={forgotPassword}
-				maxWidth={"md"}
-				onClose={() => {
-					setForgotPassword(false);
-				}}
-			>
-				<Modal.Title>Forgot your password?</Modal.Title>
-				<Modal.Content>
-					<Box>
-						Please contact your administrator to reset password.
-					</Box>
-				</Modal.Content>
-				<Modal.Actions>
-					<ButtonGroup.Item
-						variant={"outlined"}
-						onClick={() => {
-							setForgotPassword(false);
-						}}
-					>
-						Ok
-					</ButtonGroup.Item>
-				</Modal.Actions>
-			</Modal>
+						</div>
+					</div>
+					<div className="z-10 h-full w-[336px] shrink-0 bg-gradient-to-r from-background to-transparent" />
+					<div className="absolute inset-y-0 right-0 z-0 overflow-hidden">
+						<img src={GIF} alt="" className="h-full object-cover" />
+					</div>
+				</div>
+				{isLoading && (
+					<div className="h-1 w-full overflow-hidden bg-primary/20">
+						<div className="h-full animate-pulse bg-primary" />
+					</div>
+				)}
+			</div>
+
+			<Dialog open={forgotPassword} onOpenChange={setForgotPassword}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Forgot your password?</DialogTitle>
+					</DialogHeader>
+					<p>Please contact your administrator to reset password.</p>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setForgotPassword(false)}
+						>
+							Ok
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</>
 	);
 });

--- a/packages/client/src/pages/app/app-detail-tabs/settings-tab.tsx
+++ b/packages/client/src/pages/app/app-detail-tabs/settings-tab.tsx
@@ -6,7 +6,6 @@ import {
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { FileDropzone } from "@semoss/ui";
 import {
 	Avatar,
 	AvatarFallback,
@@ -17,6 +16,7 @@ import {
 	CardHeader,
 	CardTitle,
 	Field,
+	FileDropzone,
 	H3,
 	H4,
 	Input,

--- a/packages/client/src/pages/engine/engine-model-chat-page.tsx
+++ b/packages/client/src/pages/engine/engine-model-chat-page.tsx
@@ -319,7 +319,7 @@ export const EngineModelChatPage = () => {
 												</Avatar>
 												<div className="flex max-w-[90%] flex-col gap-1 sm:max-w-[85%]">
 													<div className="rounded-2xl rounded-bl-sm bg-muted px-4 py-2.5">
-														<Markdown>
+														<Markdown className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
 															{message.content}
 														</Markdown>
 													</div>

--- a/packages/client/src/pages/engine/engine-model-chat-page.tsx
+++ b/packages/client/src/pages/engine/engine-model-chat-page.tsx
@@ -319,7 +319,7 @@ export const EngineModelChatPage = () => {
 												</Avatar>
 												<div className="flex max-w-[90%] flex-col gap-1 sm:max-w-[85%]">
 													<div className="rounded-2xl rounded-bl-sm bg-muted px-4 py-2.5">
-														<Markdown className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+														<Markdown>
 															{message.content}
 														</Markdown>
 													</div>


### PR DESCRIPTION
## Summary

- Migrates remaining `@semoss/ui` (MUI) usages in `packages/client` and `libs` to `@semoss/ui/next` (Tailwind + Radix UI)
- Fixes several UI bugs found during migration

## Changes

**Migrations:**
- `LoginPage.tsx` — full page migration (TextField→Input, Alert/Snackbar→Alert+toast, Modal→Dialog, ButtonGroup toggle→Tailwind, Tooltip→Radix, LinearProgress→animated div); register form fields grouped into side-by-side rows
- `TextEditorCodeGeneration.tsx` — Modal→Dialog, Select, Skeleton, TextField→Textarea, styled→Tailwind
- `FeedbackButtons.tsx` — IconButton/Stack→Button+flex div

**Bug fixes:**
- PDF viewer height now scales with container (absolute inset positioning)
- PDF viewer scroll enabled in both edit and presentation modes
- App upload modal: removed duplicate X button, widened to sm:max-w-2xl, filename truncation fixed
- LLM chat response top whitespace removed (prose mt-0 on first child)

**@semoss/ui/next additions (libs/ui):**
- loading-screen.tsx — context-based LoadingScreen component
- index.ts — exports lightTheme, darkTheme, LoadingScreen, FileDropzone

## Test plan

- [ ] Login page renders correctly — logo, title, login form, OAuth buttons
- [ ] Register form: First Name/Last Name, Username/Email, Phone/Extension/CountryCode each appear side-by-side
- [ ] Password tooltip appears on hover in register form
- [ ] LLM model chat page — no extra whitespace above first response bubble
- [ ] Text editor Generate Code dialog opens, generates, copies correctly
- [ ] PDF viewer in blocks — scrollable, resizes with Appearance panel, X only shows in design mode
- [ ] App upload modal — single X, wide enough for long filenames