### PR TITLE
fix: render breadcrumbs conditionally

### DIFF
--- a/packages/playground/src/pages/main-layout.tsx
+++ b/packages/playground/src/pages/main-layout.tsx
@@ -182,25 +182,39 @@ export const MainLayout = observer(() => {
 
 													return (
 														<React.Fragment
-															key={crumb.path}
+															key={`${index}-${crumb.path}`}
 														>
 															<BreadcrumbItem>
-																<BreadcrumbLink
-																	className={
-																		isLast
-																			? "text-foreground"
-																			: ""
-																	}
-																	asChild
-																>
-																	<Link
-																		to={`${crumb.path}`}
+																{crumb.path ? (
+																	<BreadcrumbLink
+																		className={
+																			isLast
+																				? "text-foreground"
+																				: ""
+																		}
+																		asChild
+																	>
+																		<Link
+																			to={`${crumb.path}`}
+																		>
+																			{
+																				crumb.name
+																			}
+																		</Link>
+																	</BreadcrumbLink>
+																) : (
+																	<span
+																		className={
+																			isLast
+																				? "text-foreground"
+																				: "text-muted-foreground"
+																		}
 																	>
 																		{
 																			crumb.name
 																		}
-																	</Link>
-																</BreadcrumbLink>
+																	</span>
+																)}
 															</BreadcrumbItem>
 															{!isLast && (
 																<BreadcrumbSeparator />

--- a/packages/playground/src/pages/room-page.tsx
+++ b/packages/playground/src/pages/room-page.tsx
@@ -11,7 +11,7 @@ import {
 	toast,
 } from "@semoss/ui/next";
 import { RoomContent, RoomSidebar, SaveWorkspaceDialog } from "@/components";
-import { useChat, useGlobalBreadcrumbs } from "@/hooks";
+import { useChat, useGlobalBreadcrumbs, useRoot } from "@/hooks";
 import type { RoomStore } from "@/stores";
 import type { Engine } from "@/types";
 /**
@@ -24,7 +24,10 @@ export const RoomPage = observer(() => {
 	const { setNavbarActions } = useGlobalBreadcrumbs({});
 	const { roomId } = useParams();
 	const { chat } = useChat();
+	const { root } = useRoot();
 	const navigate = useNavigate();
+
+	const platformLinksDisabled = root.theme.showPlatformLinks === false;
 
 	/**
 	 * State
@@ -35,13 +38,28 @@ export const RoomPage = observer(() => {
 	/**
 	 * Library hooks
 	 */
-	// set the breadcrumbs
-	const { setBreadcrumbs } = useGlobalBreadcrumbs({
+	// set the breadcrumbs (reactive to room state so we don't race with loadRoom)
+	const workspace = room?.options?.workspace;
+	useGlobalBreadcrumbs({
 		breadcrumbs: [
 			{
 				name: t("breadcrumbs.home"),
 				path: "/",
 			},
+			...(workspace?.workspace_id
+				? [
+						{
+							name: t("breadcrumbs.agent"),
+							path: platformLinksDisabled ? "" : "/agent",
+						},
+						{
+							name: workspace.name || workspace.workspace_id,
+							path: platformLinksDisabled
+								? ""
+								: `/agent/${workspace.workspace_id}`,
+						},
+					]
+				: []),
 			{
 				name: room?.metadata?.name || t("breadcrumbs.room"),
 				path: `/room/${roomId}`,
@@ -77,29 +95,7 @@ export const RoomPage = observer(() => {
 					chat.setSelectedModel(room.model);
 				}
 
-				if (room.options.workspace)
-					setBreadcrumbs([
-						{
-							name: t("breadcrumbs.home"),
-							path: "/",
-						},
-						{
-							name: t("breadcrumbs.agent"),
-							path: "/agent",
-						},
-						{
-							name:
-								room.options.workspace?.name ||
-								room.options.workspace.workspace_id,
-							path: `/agent/${room.options.workspace.workspace_id}`,
-						},
-						{
-							name: t("breadcrumbs.room"),
-							path: `/room/${room.roomId}`,
-						},
-					]);
-
-				// set the room
+				// set the room (breadcrumbs are driven reactively via useGlobalBreadcrumbs above)
 				setRoom(room);
 			} catch (e) {
 				// if it doesn't load successfully, go back to home
@@ -109,14 +105,7 @@ export const RoomPage = observer(() => {
 		};
 
 		loadRoom();
-	}, [
-		roomId,
-		navigate,
-		chat.loadRoom,
-		chat.setSelectedModel,
-		setBreadcrumbs,
-		t,
-	]);
+	}, [roomId, navigate, chat.loadRoom, chat.setSelectedModel]);
 
 	const navbarActions = useMemo<React.ReactNode>(() => {
 		if (room?.options) {

--- a/packages/playground/src/stores/room/room.store.ts
+++ b/packages/playground/src/stores/room/room.store.ts
@@ -596,6 +596,12 @@ export class RoomStore {
 				const workspaceOutput = workspaceResponse.pixelReturn[0]
 					.output as Workspace;
 
+				// Populate the workspace name on options so the UI (e.g. breadcrumbs)
+				// can show a human-readable label instead of the workspace_id
+				if (workspaceOutput?.name && newOptions.workspace) {
+					newOptions.workspace.name = workspaceOutput.name;
+				}
+
 				// Merge workspace MCPs into the mcp array with fromWorkspace flag
 				if (
 					workspaceOutput?.mcp &&


### PR DESCRIPTION
## Summary

Respect the existing `showPlatformLinks` theme flag on the room page's agent breadcrumbs, and fix two pre-existing issues surfaced while wiring it up:

1. **Agent / agent-name breadcrumbs were being overwritten** by a race between the imperative `setBreadcrumbs` inside `loadRoom` and the reactive default set by `useGlobalBreadcrumbs`. `setRoom(room)` triggered a re-render that clobbered the workspace crumbs with the 2-crumb fallback (`Home > <room name>`).
2. **Agent breadcrumb showed the workspace UUID** instead of a name, because `room.options.workspace.name` was never populated from the `GetWorkspace` pixel response even though the field existed on the `Workspace` interface.

## Behavior

| `showPlatformLinks` | Breadcrumbs on `/room/:id` (room linked to an agent) |
| --- | --- |
| `true` / unset (default) | `Home > Agent > <Agent name> > <Room name>` — all clickable |
| `false` | `Home > Agent > <Agent name> > <Room name>` — `Agent` and `<Agent name>` rendered as non-clickable muted spans; `Home` and `<Room name>` remain clickable |

Rooms with no associated workspace still render the 2-crumb `Home > <Room name>` fallback.

## Changes

- **`packages/playground/src/stores/room/room.store.ts`** — after the `GetWorkspace` call during room load, copy `workspaceOutput.name` onto `newOptions.workspace.name` so the UI has a human-readable label.
- **`packages/playground/src/pages/room-page.tsx`** — made breadcrumbs reactive by computing the full array (including the agent crumbs when `room.options.workspace` is present) inside the `useGlobalBreadcrumbs({ breadcrumbs })` call. Removed the imperative `setBreadcrumbs` inside `loadRoom` that was being clobbered on re-render. `Agent` and agent-name crumbs use an empty `path` when `root.theme.showPlatformLinks === false`.
- **`packages/playground/src/pages/main-layout.tsx`** — breadcrumb renderer: when `crumb.path` is empty, render a non-clickable `<span>` (muted for non-last, foreground for last) instead of a `<Link>`. Updated the fragment `key` to `${index}-${crumb.path}` to avoid duplicate-key warnings when multiple crumbs have empty paths.

## Test plan

- [ ] Open a room linked to an agent with `showPlatformLinks` unset → see `Home > Agent > <Agent name> > <Room name>`, all clickable, navigating correctly.
- [ ] Set `"showPlatformLinks": false` in `theme.local.json`, restart dev server, reopen the same room → `Agent` and `<Agent name>` render as muted non-clickable text; `Home` and `<Room name>` still navigate.
- [ ] Open a room **not** associated with an agent → breadcrumbs show `Home > <Room name>` (no agent crumbs).
- [ ] Navigate between rooms (agent-linked ↔ standalone) without reloading → breadcrumbs update correctly each time (no stale 4-crumb state leaking into a 2-crumb room or vice-versa).
- [ ] Confirm the agent name displayed matches the workspace name on the Agents page (not the UUID).
