### PR TITLE
fix(playground): refresh pinned rooms after rename and delete

### DIFF
--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -341,6 +341,7 @@ export const GlobalNav = observer(() => {
 
 			// Refetch rooms after renaming
 			getRooms.reset();
+			getPinnedRooms.reset();
 		} catch {
 			toast.error(t("toasts.failedToRename"));
 		}
@@ -676,6 +677,7 @@ export const GlobalNav = observer(() => {
 
 																			// Refetch rooms after deletion
 																			getRooms.reset();
+																			getPinnedRooms.reset();
 																		} catch (e) {
 																			if (
 																				e instanceof


### PR DESCRIPTION
## Description
This fixes two bugs introduced by earlier changes from 1014 feature branch where pinned rooms don't refresh after rename/delete

## Changes Made
getPinnedRooms.reset() added twice to global-nav.tsx

## How to Test
<!-- Explain how reviewers can test your changes -->
1. On a favorited room, rename it and push enter and your changes should reflect
2. On a favorited room, click delete, and your changes should reflect

## Notes
<!-- Any further notes regarding changes -->