### PR TITLE
Mcp menu fix

### DIFF
--- a/packages/playground/src/components/mcp/mcp-overlay.tsx
+++ b/packages/playground/src/components/mcp/mcp-overlay.tsx
@@ -1,4 +1,3 @@
-import type { LexicalEditor } from "lexical";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "@semoss/i18n";
@@ -27,13 +26,10 @@ interface MCPOverlayProps {
 
 	/** Callback triggered when the tool model is closed */
 	onClose: (mcp?: MCPConfig[]) => void;
-
-	/** Optional ref to editor to focus when closing */
-	editorRef?: React.RefObject<LexicalEditor>;
 }
 
 export const MCPOverlay: React.FC<MCPOverlayProps> = (props) => {
-	const { open, type, values, onClose, editorRef } = props;
+	const { open, type, values, onClose } = props;
 	const { t } = useTranslation("mcp");
 
 	const [updated, setUpdated] = useState<MCPConfig[]>(values);
@@ -53,14 +49,7 @@ export const MCPOverlay: React.FC<MCPOverlayProps> = (props) => {
 						: t("overlay.editKnowledge")
 				}
 				onOpenAutoFocus={(e) => e.preventDefault()}
-				onCloseAutoFocus={(e) => {
-					// Prevent focus from returning to the trigger element
-					e.preventDefault();
-					// Focus editor after dialog closes
-					if (editorRef?.current) {
-						setTimeout(() => editorRef.current?.focus(), 0);
-					}
-				}}
+				onCloseAutoFocus={(e) => e.preventDefault()}
 			>
 				<DialogHeader>
 					<DialogTitle>

--- a/packages/playground/src/components/mcp/mcp-selector.tsx
+++ b/packages/playground/src/components/mcp/mcp-selector.tsx
@@ -50,11 +50,7 @@ export const MCPSelector = observer(
 		const searchContainerRef = useRef<HTMLDivElement>(null);
 
 		const focusSearch = () => {
-			const input = searchContainerRef.current?.querySelector("input");
-			if (!input) return;
-			input.focus();
-			// Restore cursor to end — some browsers select-all on programmatic focus
-			input.setSelectionRange(input.value.length, input.value.length);
+			searchContainerRef.current?.querySelector("input")?.focus();
 		};
 
 		const debouncedSearch = useDebouncedValue(search);

--- a/packages/playground/src/components/mcp/mcp-selector.tsx
+++ b/packages/playground/src/components/mcp/mcp-selector.tsx
@@ -1,6 +1,6 @@
 import { PlusIcon, SearchIcon, XIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "@semoss/i18n";
 import { useIteratorPixel } from "@semoss/sdk/react";
 import {
@@ -47,11 +47,6 @@ export const MCPSelector = observer(
 		const [search, setSearch] = useState<string>("");
 		const [isKnowledgeOverlayOpen, setIsKnowledgeOverlayOpen] =
 			useState(false);
-		const searchContainerRef = useRef<HTMLDivElement>(null);
-
-		const focusSearch = () => {
-			searchContainerRef.current?.querySelector("input")?.focus();
-		};
 
 		const debouncedSearch = useDebouncedValue(search);
 		const useMCPFilter =
@@ -89,12 +84,6 @@ export const MCPSelector = observer(
 			[debouncedSearch, useMCPFilter],
 		);
 
-		useEffect(() => {
-			if (!getMCP.isLoading) {
-				focusSearch();
-			}
-		}, [getMCP.isLoading]);
-
 		/**
 		 * Setup infinite scroll for the command list
 		 */
@@ -128,7 +117,7 @@ export const MCPSelector = observer(
 		return (
 			<div className="w-full overflow-hidden rounded-xl border-border bg-card shadow-sm">
 				<div className="flex w-full flex-row gap-2 border-border bg-primary-foreground p-4">
-					<div ref={searchContainerRef} className="flex-1">
+					<div className="flex-1">
 						<InputGroup className="bg-background">
 							<InputGroupInput
 								autoFocus

--- a/packages/playground/src/components/mcp/mcp-selector.tsx
+++ b/packages/playground/src/components/mcp/mcp-selector.tsx
@@ -50,7 +50,11 @@ export const MCPSelector = observer(
 		const searchContainerRef = useRef<HTMLDivElement>(null);
 
 		const focusSearch = () => {
-			searchContainerRef.current?.querySelector("input")?.focus();
+			const input = searchContainerRef.current?.querySelector("input");
+			if (!input) return;
+			input.focus();
+			// Restore cursor to end — some browsers select-all on programmatic focus
+			input.setSelectionRange(input.value.length, input.value.length);
 		};
 
 		const debouncedSearch = useDebouncedValue(search);
@@ -134,7 +138,7 @@ export const MCPSelector = observer(
 								autoFocus
 								placeholder={t("selector.search")}
 								value={search}
-								disabled={disabled || getMCP.isLoading}
+								disabled={disabled}
 								onChange={(e) => setSearch(e.target.value)}
 							/>
 							<InputGroupAddon>

--- a/packages/playground/src/components/room/room-content.tsx
+++ b/packages/playground/src/components/room/room-content.tsx
@@ -35,7 +35,7 @@ import {
 	RoomInputMenuMCP,
 	RoomInputMenuUpload,
 } from "@/components";
-import { useChat, useGracefulErrors, useRoot } from "@/hooks";
+import { useChat, useGracefulErrors } from "@/hooks";
 import type { RoomStore } from "@/stores";
 import type { MCPConfig } from "@/types";
 import { RoomSuggestions } from "./room-suggestions";
@@ -55,10 +55,8 @@ export const RoomContent: React.FC<RoomContentProps> = observer(({ room }) => {
 	const { chat } = useChat();
 	const { t } = useTranslation("room");
 	const { getGracefulErrorMessage } = useGracefulErrors();
-	const { root } = useRoot();
 	const [scrollEle, setScrollEle] = useState<HTMLDivElement | null>(null);
 	const [contentEle, setContentEle] = useState<HTMLDivElement | null>(null);
-
 	const [contentHeight, setContentHeight] = useState(0);
 	const [showScrollup, setShowScrollup] = useState(false);
 	const [showScrolldown, setShowScrolldown] = useState(false);
@@ -463,8 +461,16 @@ export const RoomContent: React.FC<RoomContentProps> = observer(({ room }) => {
 					}}
 					options={room.options}
 					onMcpSelect={handleToolAdd}
+					onMcpToggle={handleToolSelect}
 					MenuComponent={observer(
-						({ onOpenChange, fileRef, editorRef }) => (
+						({
+							onOpenChange,
+							fileRef,
+							knowledgeOverlayOpen,
+							onKnowledgeOverlayChange,
+							toolboxOverlayOpen,
+							onToolboxOverlayChange,
+						}) => (
 							<>
 								<RoomInputMenuUpload
 									fileRef={fileRef}
@@ -474,16 +480,14 @@ export const RoomContent: React.FC<RoomContentProps> = observer(({ room }) => {
 								<RoomInputMenuMCP
 									type="KNOWLEDGE"
 									options={room.options}
-									onSelect={handleToolSelect}
-									editorRef={editorRef}
-									onOverlayClose={() => onOpenChange(false)}
+									open={knowledgeOverlayOpen}
+									onOpenChange={onKnowledgeOverlayChange}
 								/>
 								<RoomInputMenuMCP
 									type="TOOLBOX"
 									options={room.options}
-									onSelect={handleToolSelect}
-									editorRef={editorRef}
-									onOverlayClose={() => onOpenChange(false)}
+									open={toolboxOverlayOpen}
+									onOpenChange={onToolboxOverlayChange}
 								/>
 								<DropdownMenuSeparator />
 								<RoomInputMenuFileExplorer

--- a/packages/playground/src/components/room/room-input-menu-mcp.tsx
+++ b/packages/playground/src/components/room/room-input-menu-mcp.tsx
@@ -1,47 +1,28 @@
-import type { LexicalEditor } from "lexical";
 import { BookOpenIcon, HammerIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
-import { useState } from "react";
 import { useTranslation } from "@semoss/i18n";
 import { Badge, DropdownMenuItem } from "@semoss/ui/next";
-import { MCPOverlay } from "@/components";
 import type { RoomStore } from "@/stores";
-import type { MCPConfig } from "@/types";
 
 interface RoomInputMenuMCPProps {
-	/** Type of MCP to manage */
 	type: "KNOWLEDGE" | "TOOLBOX";
-
-	/** Options */
 	options: RoomStore["options"];
-
-	/** Callback when an MCP is selected/deselected */
-	onSelect: (mcp: MCPConfig) => void;
-
-	/** Callback when the overlay closes */
-	onOverlayClose?: () => void;
-
-	/** Optional ref to editor to focus when closing */
-	editorRef?: React.RefObject<LexicalEditor>;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
 }
 
 const RoomInputMenuMCPInner: React.FC<RoomInputMenuMCPProps> = ({
 	type,
 	options,
-	onSelect,
-	onOverlayClose,
-	editorRef,
+	onOpenChange,
 }) => {
-	const [isOpen, setIsOpen] = useState(false);
 	const { t } = useTranslation("room");
 
-	// Filter MCPs based on type
 	const items =
 		type === "KNOWLEDGE"
 			? options.mcp.filter((mcp) => mcp.type === "VECTOR")
 			: options.mcp.filter((mcp) => mcp.type !== "VECTOR");
 
-	// Select icon and labels based on type
 	const Icon = type === "KNOWLEDGE" ? BookOpenIcon : HammerIcon;
 	const labelKey =
 		type === "KNOWLEDGE"
@@ -49,50 +30,11 @@ const RoomInputMenuMCPInner: React.FC<RoomInputMenuMCPProps> = ({
 			: "menuToolbox.addToolbox";
 
 	return (
-		<>
-			<DropdownMenuItem
-				onSelect={(e) => {
-					e.preventDefault();
-					setIsOpen(true);
-				}}
-			>
-				<Icon />
-				<span className="flex-1">{t(labelKey)}</span>
-				<Badge variant="outline">{items.length}</Badge>
-			</DropdownMenuItem>
-
-			<MCPOverlay
-				open={isOpen}
-				type={type}
-				values={items}
-				editorRef={editorRef}
-				onClose={(updatedMcp) => {
-					setIsOpen(false);
-					onOverlayClose?.();
-					if (updatedMcp) {
-						// Calculate changes and call onSelect for each
-						const oldIds = new Set(items.map((item) => item.id));
-						const newIds = new Set(
-							updatedMcp.map((item) => item.id),
-						);
-
-						// Add new items
-						for (const mcp of updatedMcp) {
-							if (!oldIds.has(mcp.id)) {
-								onSelect(mcp);
-							}
-						}
-
-						// Remove deleted items
-						for (const mcp of items) {
-							if (!newIds.has(mcp.id)) {
-								onSelect(mcp);
-							}
-						}
-					}
-				}}
-			/>
-		</>
+		<DropdownMenuItem onSelect={() => onOpenChange(true)}>
+			<Icon />
+			<span className="flex-1">{t(labelKey)}</span>
+			<Badge variant="outline">{items.length}</Badge>
+		</DropdownMenuItem>
 	);
 };
 

--- a/packages/playground/src/components/room/room-input.tsx
+++ b/packages/playground/src/components/room/room-input.tsx
@@ -55,6 +55,7 @@ import {
 import {
 	EnterPlugin,
 	FocusPlugin,
+	MCPOverlay,
 	MentionPlugin,
 	PromptLibraryDialog,
 	type PromptLibraryItem,
@@ -65,6 +66,21 @@ import { useGracefulErrors, useRoot } from "@/hooks";
 import type { RoomStore } from "@/stores";
 import type { Engine, MCPConfig } from "@/types";
 import { PromptOptimizer } from "../../components/prompt/PromptOptimizer";
+
+function applyMCPDiff(
+	items: MCPConfig[],
+	updated: MCPConfig[],
+	onSelect: (mcp: MCPConfig) => void,
+) {
+	const oldIds = new Set(items.map((m) => m.id));
+	const newIds = new Set(updated.map((m) => m.id));
+	for (const mcp of updated) {
+		if (!oldIds.has(mcp.id)) onSelect(mcp);
+	}
+	for (const mcp of items) {
+		if (!newIds.has(mcp.id)) onSelect(mcp);
+	}
+}
 
 let isIframed = false;
 try {
@@ -180,8 +196,14 @@ interface RoomInputProps {
 		isOpen: boolean;
 		onOpenChange: (isOpen: boolean) => void;
 		fileRef: React.RefObject<HTMLInputElement>;
-		editorRef?: React.RefObject<LexicalEditor>;
+		knowledgeOverlayOpen: boolean;
+		onKnowledgeOverlayChange: (open: boolean) => void;
+		toolboxOverlayOpen: boolean;
+		onToolboxOverlayChange: (open: boolean) => void;
 	}>;
+
+	/** Callback when an MCP is toggled via the plus menu */
+	onMcpToggle?: (mcp: MCPConfig) => void;
 
 	/** Room options containing MCP configurations for slash menu */
 	options: RoomStore["options"];
@@ -247,6 +269,7 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 		options,
 		onPrompt = () => null,
 		onMcpSelect,
+		onMcpToggle,
 		hasOutstandingTools = false,
 		hasToolsPaused = false,
 		toggleToolsPaused,
@@ -271,6 +294,10 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 		const [isScrollable, setIsScrollable] = useState(false);
 		const [inputText, setInputText] = useState("");
 		const { root } = useRoot();
+
+		// MCP overlay state — managed here so overlays render outside the DropdownMenu's React subtree
+		const [knowledgeOverlayOpen, setKnowledgeOverlayOpen] = useState(false);
+		const [toolboxOverlayOpen, setToolboxOverlayOpen] = useState(false);
 
 		// Refs for DOM elements and Lexical editor
 		const ref = useRef<HTMLDivElement>(null);
@@ -826,7 +853,18 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 												isOpen={menuOpen}
 												onOpenChange={setMenuOpen}
 												fileRef={fileRef}
-												editorRef={editorRef}
+												knowledgeOverlayOpen={
+													knowledgeOverlayOpen
+												}
+												onKnowledgeOverlayChange={
+													setKnowledgeOverlayOpen
+												}
+												toolboxOverlayOpen={
+													toolboxOverlayOpen
+												}
+												onToolboxOverlayChange={
+													setToolboxOverlayOpen
+												}
 											/>
 										</DropdownMenuContent>
 									</DropdownMenu>
@@ -1084,6 +1122,46 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 						}
 					/>
 				</LexicalComposer>
+				{onMcpToggle && (
+					<>
+						<MCPOverlay
+							type="KNOWLEDGE"
+							open={knowledgeOverlayOpen}
+							values={options.mcp.filter(
+								(m) => m.type === "VECTOR",
+							)}
+							onClose={(updated) => {
+								setKnowledgeOverlayOpen(false);
+								if (updated)
+									applyMCPDiff(
+										options.mcp.filter(
+											(m) => m.type === "VECTOR",
+										),
+										updated,
+										onMcpToggle,
+									);
+							}}
+						/>
+						<MCPOverlay
+							type="TOOLBOX"
+							open={toolboxOverlayOpen}
+							values={options.mcp.filter(
+								(m) => m.type !== "VECTOR",
+							)}
+							onClose={(updated) => {
+								setToolboxOverlayOpen(false);
+								if (updated)
+									applyMCPDiff(
+										options.mcp.filter(
+											(m) => m.type !== "VECTOR",
+										),
+										updated,
+										onMcpToggle,
+									);
+							}}
+						/>
+					</>
+				)}
 			</div>
 		);
 	},

--- a/packages/playground/src/components/room/room-input.tsx
+++ b/packages/playground/src/components/room/room-input.tsx
@@ -67,11 +67,11 @@ import type { RoomStore } from "@/stores";
 import type { Engine, MCPConfig } from "@/types";
 import { PromptOptimizer } from "../../components/prompt/PromptOptimizer";
 
-function applyMCPDiff(
+const applyMCPDiff = (
 	items: MCPConfig[],
 	updated: MCPConfig[],
 	onSelect: (mcp: MCPConfig) => void,
-) {
+) => {
 	const oldIds = new Set(items.map((m) => m.id));
 	const newIds = new Set(updated.map((m) => m.id));
 	for (const mcp of updated) {
@@ -80,7 +80,7 @@ function applyMCPDiff(
 	for (const mcp of items) {
 		if (!newIds.has(mcp.id)) onSelect(mcp);
 	}
-}
+};
 
 let isIframed = false;
 try {

--- a/packages/playground/src/pages/new-room-page.tsx
+++ b/packages/playground/src/pages/new-room-page.tsx
@@ -98,7 +98,6 @@ export const NewRoomPage = observer(() => {
 	const [mode, setMode] = useState<"chat" | "plan" | "workspace">("chat");
 	const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>("");
 	const [prompts, setPrompts] = useState<string[]>([]);
-
 	const previewPrompts = useMemo(
 		() => tempRoomStore.options.predefinedPrompts.slice(0, 5),
 		[tempRoomStore.options.predefinedPrompts],
@@ -462,6 +461,7 @@ export const NewRoomPage = observer(() => {
 							}}
 							options={tempRoomStore.options}
 							onMcpSelect={handleToolAdd}
+							onMcpToggle={handleToolSelect}
 							onPrompt={async (prompt, files) => {
 								await createRoom(prompt, files);
 
@@ -469,7 +469,14 @@ export const NewRoomPage = observer(() => {
 							}}
 							hidePauseButton
 							MenuComponent={observer(
-								({ onOpenChange, fileRef, editorRef }) => (
+								({
+									onOpenChange,
+									fileRef,
+									knowledgeOverlayOpen,
+									onKnowledgeOverlayChange,
+									toolboxOverlayOpen,
+									onToolboxOverlayChange,
+								}) => (
 									<>
 										<RoomInputMenuUpload
 											fileRef={fileRef}
@@ -549,19 +556,17 @@ export const NewRoomPage = observer(() => {
 										<RoomInputMenuMCP
 											type="KNOWLEDGE"
 											options={tempRoomStore.options}
-											onSelect={handleToolSelect}
-											editorRef={editorRef}
-											onOverlayClose={() =>
-												onOpenChange(false)
+											open={knowledgeOverlayOpen}
+											onOpenChange={
+												onKnowledgeOverlayChange
 											}
 										/>
 										<RoomInputMenuMCP
 											type="TOOLBOX"
 											options={tempRoomStore.options}
-											onSelect={handleToolSelect}
-											editorRef={editorRef}
-											onOverlayClose={() =>
-												onOpenChange(false)
+											open={toolboxOverlayOpen}
+											onOpenChange={
+												onToolboxOverlayChange
 											}
 										/>
 										<DropdownMenuSeparator />


### PR DESCRIPTION
## Description
The MCP selection modal was having issues with being nested inside a dropdown menu. Refactor the related components so that it's rendered outside of the menu.

## Changes Made
- Render the MCP selection modal outside of the dropdown menu
- Control the modal state in the room input
- Also remove the "focus editor on close" feature which was confusing and not too valuable
- Remove un-needed ref tracking and focus logic now that the modal is clean

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Open the MCP selection menu from both the plus menu and the side configuration panel
2. Verify that both work as expected

## Notes
<!-- Any further notes regarding changes -->