### PR TITLE
feat: include YEAR and ALL_TIME usage frequency interval support

### DIFF
--- a/libs/shared/src/components/members/add-members.tsx
+++ b/libs/shared/src/components/members/add-members.tsx
@@ -424,6 +424,12 @@ export const AddMembersOverlay = ({
 										<SelectItem value="MONTH">
 											Monthly
 										</SelectItem>
+										<SelectItem value="YEAR">
+											Yearly
+										</SelectItem>
+										<SelectItem value="ALL_TIME">
+											All time
+										</SelectItem>
 									</SelectContent>
 								</Select>
 							</div>

--- a/libs/shared/src/components/members/members-list.tsx
+++ b/libs/shared/src/components/members/members-list.tsx
@@ -72,6 +72,8 @@ const formatValue = (input?: string) => {
 		DAY: "Daily",
 		WEEK: "Weekly",
 		MONTH: "Monthly",
+		YEAR: "Yearly",
+		ALL_TIME: "All time",
 	};
 	return mappings[input.toUpperCase()] ?? input;
 };

--- a/libs/shared/src/components/members/members-table.tsx
+++ b/libs/shared/src/components/members/members-table.tsx
@@ -368,6 +368,12 @@ export const MembersTable = ({
 													<SelectItem value="MONTH">
 														Monthly
 													</SelectItem>
+													<SelectItem value="YEAR">
+														Yearly
+													</SelectItem>
+													<SelectItem value="ALL_TIME">
+														All time
+													</SelectItem>
 												</SelectContent>
 											</Select>
 										</div>

--- a/packages/client/src/components/settings/members-add-overlay.tsx
+++ b/packages/client/src/components/settings/members-add-overlay.tsx
@@ -171,6 +171,8 @@ export const MembersAddOverlay = (props: MembersAddOverlayProps) => {
 		DAY: "Daily",
 		WEEK: "Weekly",
 		MONTH: "Monthly",
+		YEAR: "Yearly",
+		ALL_TIME: "All time",
 	};
 	const unitTypes: string[] = ["milliseconds"];
 

--- a/packages/client/src/components/settings/members-table.tsx
+++ b/packages/client/src/components/settings/members-table.tsx
@@ -62,6 +62,8 @@ const formatValue = (input: string) => {
 			DAY: "Daily",
 			WEEK: "Weekly",
 			MONTH: "Monthly",
+			YEAR: "Yearly",
+			ALL_TIME: "All time",
 			NULL: "None",
 		};
 		return mappings[input.toUpperCase()] || input;

--- a/packages/client/src/components/settings/user-add-overlay.tsx
+++ b/packages/client/src/components/settings/user-add-overlay.tsx
@@ -190,6 +190,8 @@ export const UserAddOverlay = observer((props: UserAddOverlayProps) => {
 		DAY: "Daily",
 		WEEK: "Weekly",
 		MONTH: "Monthly",
+		YEAR: "Yearly",
+		ALL_TIME: "All time",
 	};
 	const unitTypes: string[] = ["milliseconds"];
 

--- a/packages/client/src/components/settings/user-table.tsx
+++ b/packages/client/src/components/settings/user-table.tsx
@@ -75,6 +75,8 @@ const formatValue = (input: string) => {
 			DAY: "Daily",
 			WEEK: "Weekly",
 			MONTH: "Monthly",
+			YEAR: "Yearly",
+			ALL_TIME: "All time",
 		};
 		return mappings[input.toUpperCase()] || input;
 	}


### PR DESCRIPTION
## Description
Want to expand possible time intervals available for computation of token/compute usage limits.

## Changes Made
Added YEAR and ALL_TIME (since start of epoch) to the existing DAY, WEEK, MONTH intervals

## How to Test
Can use Semoss branch `usage_frequency_intervals` for matching BE support. Usage restriction selection from member settings or engine permissions should update corresponding DB tables smss_user.modelusagefrequency/enginepermission.usagefrequency and calls to GetUserModelUsageRestrictions should pass/fail according to the different sum window
