### PR TITLE
feat(playground): use shared insight session and META prefix for pixel calls

### DIFF
--- a/libs/sdk/src/js-frameworks/react/hooks/use-iterator-pixel.ts
+++ b/libs/sdk/src/js-frameworks/react/hooks/use-iterator-pixel.ts
@@ -5,6 +5,9 @@ export interface UseIteratorPixelOptions<T> {
 	/** Number of items to fetch per page */
 	limit?: number;
 
+	/** Insight ID to use for pixel calls; defaults to the app's shared insight */
+	insightId?: string;
+
 	/** Callback when data is successfully loaded */
 	onSuccess?: (data: T[], isLoadingMore: boolean) => void;
 
@@ -65,7 +68,7 @@ export function useIteratorPixel<TResponse, TItem>(
 	options: UseIteratorPixelOptions<TItem> = {},
 	dependencies: React.DependencyList = [],
 ): UseIteratorPixelReturn<TItem> {
-	const { limit = 25, onSuccess, onError } = options;
+	const { limit = 25, insightId, onSuccess, onError } = options;
 
 	const [offset, setOffset] = useState(0);
 	const [allData, setAllData] = useState<TItem[]>([]);
@@ -76,35 +79,39 @@ export function useIteratorPixel<TResponse, TItem>(
 	const query = pixelQuery(limit, offset);
 
 	// Use the standard usePixel hook
-	const pixel = usePixel<TResponse>(query, {
-		data: null as TResponse,
-		onSuccess: (response) => {
-			const newData = getData(response);
-			const count = getTotalCount(response);
+	const pixel = usePixel<TResponse>(
+		query,
+		{
+			data: null as TResponse,
+			onSuccess: (response) => {
+				const newData = getData(response);
+				const count = getTotalCount(response);
 
-			setTotalCount(count);
+				setTotalCount(count);
 
-			if (offset === 0) {
-				// First load or reset - replace all data
-				setAllData(newData);
-			} else {
-				// Loading more - append data
-				setAllData((prev) => [...prev, ...newData]);
-			}
+				if (offset === 0) {
+					// First load or reset - replace all data
+					setAllData(newData);
+				} else {
+					// Loading more - append data
+					setAllData((prev) => [...prev, ...newData]);
+				}
 
-			if (onSuccess) {
-				onSuccess(newData, offset > 0);
-			}
+				if (onSuccess) {
+					onSuccess(newData, offset > 0);
+				}
+			},
+			onError: (_data, error) => {
+				if (onError && error instanceof Error) {
+					onError(error);
+				}
+			},
+			onFinal: () => {
+				isLoadingMoreRef.current = false;
+			},
 		},
-		onError: (_data, error) => {
-			if (onError && error instanceof Error) {
-				onError(error);
-			}
-		},
-		onFinal: () => {
-			isLoadingMoreRef.current = false;
-		},
-	});
+		insightId,
+	);
 
 	/**
 	 * Get the next set of items

--- a/libs/sdk/src/js-frameworks/react/hooks/usePixel.ts
+++ b/libs/sdk/src/js-frameworks/react/hooks/usePixel.ts
@@ -1,5 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { runPixel } from "../../../api";
+import { InsightContext } from "../contexts";
 
 interface PixelState<D> {
 	/** Status of the pixel call */
@@ -43,6 +51,9 @@ export function usePixel<D>(
 	config?: Partial<PixelConfig<D>>,
 	insightId?: string,
 ): usePixel<D> {
+	const context = useContext(InsightContext);
+	const resolvedInsightId = insightId ?? context?.insightId;
+
 	// Memoize the initial data
 	// biome-ignore lint/correctness/useExhaustiveDependencies: config?.data is handled by deep check
 	const initialData = useMemo(() => {
@@ -113,7 +124,7 @@ export function usePixel<D>(
 			data: initialData,
 		});
 
-		runPixel<[D]>(pixel, insightId)
+		runPixel<[D]>(pixel, resolvedInsightId)
 			.then((response) => {
 				// ignore if its cancelled
 				if (isCancelled) {
@@ -163,7 +174,7 @@ export function usePixel<D>(
 		return () => {
 			isCancelled = true;
 		};
-	}, [count, pixel, insightId, initialData]);
+	}, [count, pixel, resolvedInsightId, initialData]);
 
 	return {
 		...state,

--- a/libs/sdk/src/stores/insight/insight.store.ts
+++ b/libs/sdk/src/stores/insight/insight.store.ts
@@ -439,7 +439,7 @@ LoadPyFromFile(alias="${alias}", filePath="temp.py");
 
 		// default if there is no command to preload
 		if (!pixel) {
-			pixel = "1+1;";
+			pixel = "META | init";
 		}
 
 		// create the new insight

--- a/libs/shared/src/components/engine/engine-select.tsx
+++ b/libs/shared/src/components/engine/engine-select.tsx
@@ -117,7 +117,7 @@ export const EngineSelect = ({
 	const getEngines = useIteratorPixel<Engine[], Engine>(
 		(limit, offset) =>
 			open
-				? `MyEngines(${
+				? `META | MyEngines(${
 						debouncedSearch
 							? `filterWord=["<encode>${debouncedSearch}</encode>"], `
 							: ""

--- a/libs/shared/src/components/members/members-table.tsx
+++ b/libs/shared/src/components/members/members-table.tsx
@@ -1,6 +1,7 @@
 import { Plus, Search } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Env, get, post, runPixel } from "@semoss/sdk";
+import { Env, get, post } from "@semoss/sdk";
+import { useInsight } from "@semoss/sdk/react";
 import {
 	Avatar,
 	Button,
@@ -67,21 +68,21 @@ export const MembersTable = ({
 	const debouncedValue = useDebouncedValue(searchKey, 300);
 
 	// Self-fetch current user's ID and permission
+	const { actions } = useInsight();
 	const [myUserId, setMyUserId] = useState<string>("");
 	const [myPermission, setMyPermission] = useState<string>("");
 	const effectiveIsOwner = isOwner || myPermission === "OWNER";
 	const effectiveCurrentUserId = currentUserId ?? myUserId;
 
 	useEffect(() => {
-		runPixel<[Record<string, { id: string; name: string; email: string }>]>(
-			"GetUserInfo();",
-		)
-			.then(({ pixelReturn }) => {
-				const output = pixelReturn[0]?.output ?? {};
-				const providerData =
-					output.SAML ??
-					output.NATIVE ??
-					output[Object.keys(output)[0]];
+		actions
+			.run<[Record<string, { id: string; name: string; email: string }>]>(
+				"META | GetUserInfo()",
+			)
+			.then((result) => {
+				if (!result) return;
+				const output = result.pixelReturn[0]?.output ?? {};
+				const providerData = output[Object.keys(output)[0]];
 				if (providerData?.id) setMyUserId(providerData.id);
 			})
 			.catch(() => undefined);

--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -131,7 +131,7 @@ export const GlobalNav = observer(() => {
 	>(
 		(_limit, offset) =>
 			open
-				? `GetPlaygroundRooms(pinned=[true], offset=${offset}, sort=["DESC"]);`
+				? `META | GetPlaygroundRooms(pinned=[true], offset=${offset}, sort=["DESC"])`
 				: "",
 		() => -1,
 		(response) => response,
@@ -157,7 +157,7 @@ export const GlobalNav = observer(() => {
 	>(
 		(limit, offset) =>
 			open
-				? `GetPlaygroundRooms ( ${debouncedSearch ? `search = "<encode>${debouncedSearch}</encode>", ` : ""} limit = ${limit} , offset = ${offset} , sort = [ "DESC" ] ) ;`
+				? `META | GetPlaygroundRooms ( ${debouncedSearch ? `search = "<encode>${debouncedSearch}</encode>", ` : ""} limit = ${limit} , offset = ${offset} , sort = [ "DESC" ] )`
 				: "",
 
 		(response) => {

--- a/packages/playground/src/components/mcp/mcp-selector.tsx
+++ b/packages/playground/src/components/mcp/mcp-selector.tsx
@@ -66,7 +66,7 @@ export const MCPSelector = observer(
 		 */
 		const getMCP = useIteratorPixel<(Engine | App)[], MCP>(
 			(limit, offset) =>
-				`MyEngineProject (metaKeys = ["tag", "description"], ${useMCPFilter ? `metaFilters=[{"tag":["MCP"]}], ` : ""}type=${type === "TOOLBOX" ? `["PROJECT", "STORAGE", "DATABASE", "FUNCTION", "MODEL"]` : `["VECTOR"]`}, ${debouncedSearch ? `filterWord=${JSON.stringify(debouncedSearch)}, ` : ""}limit=[${limit}], offset=[${offset}])`,
+				`META | MyEngineProject (metaKeys = ["tag", "description"], ${useMCPFilter ? `metaFilters=[{"tag":["MCP"]}], ` : ""}type=${type === "TOOLBOX" ? `["PROJECT", "STORAGE", "DATABASE", "FUNCTION", "MODEL"]` : `["VECTOR"]`}, ${debouncedSearch ? `filterWord=${JSON.stringify(debouncedSearch)}, ` : ""}limit=[${limit}], offset=[${offset}])`,
 			(response) => {
 				// if its less than the limit, we know its the end
 				if (response.length < 25) {

--- a/packages/playground/src/components/plan/tool-call-details.tsx
+++ b/packages/playground/src/components/plan/tool-call-details.tsx
@@ -39,7 +39,7 @@ export const ToolCallDetails: React.FC<ToolCallDetailsProps> = (props) => {
 	 * Get all of the groups
 	 */
 	const getApps = usePixel<(Engine | App)[]>(
-		`MyEngineProject (metaKeys = ["tag", "description"], metaFilters=[{"tag":["MCP"]}], type=["PROJECT", "STORAGE", "DATABASE", "FUNCTION", "MODEL", "VECTOR"])`,
+		`META | MyEngineProject (metaKeys = ["tag", "description"], metaFilters=[{"tag":["MCP"]}], type=["PROJECT", "STORAGE", "DATABASE", "FUNCTION", "MODEL", "VECTOR"])`,
 		{
 			data: [],
 		},

--- a/packages/playground/src/components/prompts/prompt-selector.tsx
+++ b/packages/playground/src/components/prompts/prompt-selector.tsx
@@ -60,7 +60,7 @@ const PromptSelectorInner: React.FC<PromptSelectorProps> = ({
 	 */
 	const getPrompts = useIteratorPixel<Prompt[], Prompt>(
 		(limit, offset) =>
-			`ListPrompt(${debouncedSearch ? `filters=[Filter( (PROMPT__TITLE ?like "${debouncedSearch}") )], ` : ""}limit=[${limit}], offset=[${offset}]);`,
+			`META | ListPrompt(${debouncedSearch ? `filters=[Filter( (PROMPT__TITLE ?like "${debouncedSearch}") )], ` : ""}limit=[${limit}], offset=[${offset}])`,
 		(response) => {
 			if (response.length < 25) {
 				return -1;

--- a/packages/playground/src/components/room/room-input-menu-slash.tsx
+++ b/packages/playground/src/components/room/room-input-menu-slash.tsx
@@ -53,7 +53,7 @@ const RoomInputMenuSlashInner: React.FC<RoomInputMenuSlashProps> = ({
 	 */
 	const getMCPs = useIteratorPixel<(App | Engine)[], MCPConfig>(
 		(limit, offset) =>
-			`MyEngineProject (metaKeys = ["tag", "description"], ${enableKnowledgeMCP ? `metaFilters=[{"tag":["MCP"]}], ` : ""}${debouncedSearch ? `filterWord=${JSON.stringify(debouncedSearch)}, ` : ""}limit=[${limit}], offset=[${offset}])`,
+			`META | MyEngineProject (metaKeys = ["tag", "description"], ${enableKnowledgeMCP ? `metaFilters=[{"tag":["MCP"]}], ` : ""}${debouncedSearch ? `filterWord=${JSON.stringify(debouncedSearch)}, ` : ""}limit=[${limit}], offset=[${offset}])`,
 		(response) => {
 			// if its less than the limit, we know its the end
 			if (response.length < 15) {

--- a/packages/playground/src/components/room/room-input-menu-workspace.tsx
+++ b/packages/playground/src/components/room/room-input-menu-workspace.tsx
@@ -58,7 +58,7 @@ export const RoomInputMenuWorkspace: React.FC<RoomInputMenuWorkspaceProps> = ({
 	const getWorkspaces = useIteratorPixel<App[], App>(
 		(limit, offset) =>
 			isOpen
-				? `MyProjects(${debouncedSearch ? `filterWord=["<encode>${debouncedSearch}</encode>"], ` : ""} type = "WORKSPACE", limit=[${limit}], offset=[${offset}]);`
+				? `META | MyProjects(${debouncedSearch ? `filterWord=["<encode>${debouncedSearch}</encode>"], ` : ""} type = "WORKSPACE", limit=[${limit}], offset=[${offset}])`
 				: "",
 		(response) => {
 			// if its less than the limit, we know its the end

--- a/packages/playground/src/pages/main-layout.tsx
+++ b/packages/playground/src/pages/main-layout.tsx
@@ -30,7 +30,7 @@ import { ChatStore } from "@/stores";
 import { setFavicon } from "@/utility/utils";
 
 export const MainLayout = observer(() => {
-	const { actions, system } = useInsight();
+	const { actions } = useInsight();
 	const { root } = useRoot();
 	const theme = root.theme;
 	const [navbarActions, setNavbarActions] = useState<ReactNode | null>(null);
@@ -45,17 +45,13 @@ export const MainLayout = observer(() => {
 
 	// set up the chat store
 	const chatStore = useMemo(() => {
-		const store = new ChatStore(
-			root.theme,
-			actions,
-			Object.values(system.config.loginDetails ?? {})?.[0],
-		);
+		const store = new ChatStore(root.theme, actions);
 
 		// initialize it
 		store.initialize();
 
 		return store;
-	}, [root.theme, actions, system.config.loginDetails]);
+	}, [root.theme, actions]);
 
 	// Refs for embed iframe sync
 	const iframeRefs = useRef<Record<string, HTMLIFrameElement | null>>({});

--- a/packages/playground/src/pages/new-room-page.tsx
+++ b/packages/playground/src/pages/new-room-page.tsx
@@ -128,7 +128,7 @@ export const NewRoomPage = observer(() => {
 
 	const getPrompts = usePixel<Prompt[]>(
 		mode === "workspace" && selectedWorkspaceId && prompts.length > 0
-			? `ListPrompt(filters=[Filter( (PROMPT__ID == [${prompts.map((p) => `"${p}"`).join(", ")}]) )]);`
+			? `META | ListPrompt(filters=[Filter( (PROMPT__ID == [${prompts.map((p) => `"${p}"`).join(", ")}]) )])`
 			: "",
 		{
 			data: [],

--- a/packages/playground/src/pages/workspace-page.tsx
+++ b/packages/playground/src/pages/workspace-page.tsx
@@ -53,7 +53,7 @@ export const WorkspacePage = observer(() => {
 	 */
 	const getWorkspaces = useIteratorPixel<App[], App>(
 		(limit, offset) =>
-			`MyProjects(${debouncedSearch ? `filterWord=["<encode>${debouncedSearch}</encode>"], ` : ""} type = "WORKSPACE", limit=[${limit}], offset=[${offset}]);`,
+			`META | MyProjects(${debouncedSearch ? `filterWord=["<encode>${debouncedSearch}</encode>"], ` : ""} type = "WORKSPACE", limit=[${limit}], offset=[${offset}])`,
 		(response) => {
 			// if its less than the limit, we know its the end
 			if (response.length < 25) {

--- a/packages/playground/src/stores/chat/chat.store.ts
+++ b/packages/playground/src/stores/chat/chat.store.ts
@@ -85,19 +85,9 @@ export class ChatStore {
 		embeddedPageMap: {},
 	};
 
-	constructor(
-		theme: ThemeMap["playground"],
-		actions: Insight["actions"],
-		user?: {
-			id: string;
-			name: string;
-		},
-	) {
+	constructor(theme: ThemeMap["playground"], actions: Insight["actions"]) {
 		this._theme = theme;
 		this._actions = actions;
-		if (user) {
-			this._store.user = user;
-		}
 		this._store.embeddedPageMap = [
 			...theme.sidebar.headerItems,
 			...theme.sidebar.footerItems,
@@ -162,15 +152,33 @@ export class ChatStore {
 	 */
 	initialize = async (): Promise<void> => {
 		try {
-			// set as initialized
-			Promise.all([
-				// get the default model info
-				this.getDefaultModel(),
-			]).finally(() => {
+			Promise.all([this.getDefaultModel(), this.getUser()]).finally(
+				() => {
+					runInAction(() => {
+						this._store.isInitialized = true;
+					});
+				},
+			);
+		} catch (e) {
+			console.error(e);
+		}
+	};
+
+	getUser = async (): Promise<void> => {
+		try {
+			const result =
+				await this._actions.run<
+					[Record<string, { id: string; name: string }>]
+				>(`META | GetUserInfo()`);
+
+			if (!result) return;
+
+			const user = Object.values(result.pixelReturn[0].output)[0];
+			if (user) {
 				runInAction(() => {
-					this._store.isInitialized = true;
+					this._store.user = { id: user.id, name: user.name };
 				});
-			});
+			}
 		} catch (e) {
 			console.error(e);
 		}
@@ -340,7 +348,7 @@ export class ChatStore {
 		});
 
 		const { pixelReturn } = await this._actions.run<[number | undefined]>(
-			`GetContextWindow(${JSON.stringify(engineId)});`,
+			`META | GetContextWindow(${JSON.stringify(engineId)})`,
 		);
 
 		if (this.models.selected?.engine_id === engineId) {
@@ -440,7 +448,7 @@ export class ChatStore {
 
 		// initially limit to 10 models
 		const { pixelReturn } = await this._actions.run<[Engine[]]>(
-			` MyEngines ( metaKeys = [] , metaFilters = [{ "tag" : "text-generation" }] , engineTypes = [ 'MODEL' ] )`,
+			`META | MyEngines ( metaKeys = [] , metaFilters = [{ "tag" : "text-generation" }] , engineTypes = [ 'MODEL' ] )`,
 		);
 
 		runInAction(() => {

--- a/packages/playground/src/stores/room/room.store.ts
+++ b/packages/playground/src/stores/room/room.store.ts
@@ -640,7 +640,7 @@ export class RoomStore {
 			// set the model based on the history
 			if (activeModelId) {
 				const { pixelReturn } = await this.runRoomPixel<[Engine[]]>(
-					` MyEngines ( metaKeys = [] , metaFilters = [{ "tag" : "text-generation" }] , engineTypes = [ 'MODEL' ], filterWord=${JSON.stringify(activeModelId)})`,
+					`META | MyEngines ( metaKeys = [] , metaFilters = [{ "tag" : "text-generation" }] , engineTypes = [ 'MODEL' ], filterWord=${JSON.stringify(activeModelId)})`,
 				);
 
 				runInAction(() => {


### PR DESCRIPTION
## Summary

- **Fix user name not showing on login**: `GetUserInfo()` now runs via `_actions.run` (shared insight) instead of creating a throwaway `"new"` insight, so the name is populated on first load without requiring a page refresh
- **Use shared insight for all read-only pixel calls**: `MyEngines`, `GetContextWindow`, `GetPlaygroundRooms`, `MyProjects`, `MyEngineProject`, `ListPrompt`, `GetUserInfo` in `members-table` all now reuse the insight established by `init` instead of spinning up a new server session per call
- **Add `META |` prefix** to all of the above pixel expressions
- **SDK: default `usePixel` / `useIteratorPixel` to shared insight**: both hooks now read `InsightContext` and automatically use the app's insight ID — no call sites need to change; callers can still pass an explicit `insightId` via the third param / options to override
- **Replace `1+1` init expression with `"init"`** in `insight.store.ts`

## Test plan

- [ ] Log in — user name should appear in the bottom-left sidebar immediately without refreshing
- [ ] Open the Agents/Workspace tab — workspaces load correctly
- [ ] Open the MCP selector (Toolbox + Knowledge tabs) — items load
- [ ] Open the model dropdown in a chat room — models load
- [ ] Open the pinned rooms and room list in the sidebar — rooms load
- [ ] Open the Prompts selector — prompts load
- [ ] Open the Members table on an engine/project — current user ID resolves correctly
- [ ] Log out and log back in — name and all lists load correctly without refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)