### PR TITLE
feat(playground): Allow users to scroll md tables

### DIFF
--- a/libs/ui/src/next/scroll-area.tsx
+++ b/libs/ui/src/next/scroll-area.tsx
@@ -6,9 +6,11 @@ function ScrollArea({
 	className,
 	children,
 	viewportRef,
+	scrollOrientation = "vertical",
 	...props
 }: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
 	viewportRef?: (ele: HTMLDivElement) => void;
+	scrollOrientation?: "vertical" | "horizontal" | "both";
 }) {
 	return (
 		<ScrollAreaPrimitive.Root
@@ -23,7 +25,12 @@ function ScrollArea({
 			>
 				{children}
 			</ScrollAreaPrimitive.Viewport>
-			<ScrollBar />
+			{(scrollOrientation === "vertical" ||
+				scrollOrientation === "both") && <ScrollBar />}
+			{(scrollOrientation === "horizontal" ||
+				scrollOrientation === "both") && (
+				<ScrollBar orientation="horizontal" />
+			)}
 			<ScrollAreaPrimitive.Corner />
 		</ScrollAreaPrimitive.Root>
 	);

--- a/libs/ui/src/next/table.tsx
+++ b/libs/ui/src/next/table.tsx
@@ -71,7 +71,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
 		<th
 			data-slot="table-head"
 			className={cn(
-				"h-10 whitespace-nowrap px-2 text-left align-middle font-medium text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+				"h-10 whitespace-nowrap px-2 text-left align-middle font-medium text-foreground [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5",
 				className,
 			)}
 			{...props}
@@ -84,7 +84,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
 		<td
 			data-slot="table-cell"
 			className={cn(
-				"whitespace-nowrap p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+				"whitespace-nowrap p-2 align-middle [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5",
 				className,
 			)}
 			{...props}

--- a/packages/playground/src/components/message/response-message-text/create-markdown-components.tsx
+++ b/packages/playground/src/components/message/response-message-text/create-markdown-components.tsx
@@ -9,8 +9,6 @@ import {
 	type Markdown,
 	P,
 	ScrollArea,
-	ScrollBar,
-	Table,
 } from "@semoss/ui/next";
 import type { RoomStore } from "@/stores";
 import { CodePreviewBlock } from "./code-preview-block";
@@ -258,10 +256,13 @@ export const createMarkdownComponents = (
 			/>
 		);
 	},
-	table: ({ ...props }) => (
-		<ScrollArea className="w-full">
-			<ScrollBar orientation="horizontal"></ScrollBar>
-			<Table {...props} />
+	table: ({ className, ...props }) => (
+		<ScrollArea className="w-full" scrollOrientation="horizontal">
+			<table
+				data-slot="table"
+				className={`min-w-full caption-bottom text-sm${className ? ` ${className}` : ""}`}
+				{...props}
+			/>
 		</ScrollArea>
 	),
 });


### PR DESCRIPTION
## Description
Previously, horiz scroll on md tables couldn't be dragged with mouse

**Claude says:**
Two issues: the table renderer wrapped Table (which already has overflow-x-auto) in a ScrollArea, creating a double scroll container. The ScrollBar was also passed as a child of ScrollArea, landing it inside the Viewport as content instead of as a sibling — so Radix's thumb had no connection to the actual scroll container.

## Changes Made
- libs/ui/src/next/scroll-area.tsx: added scrollOrientation prop ("vertical" | "horizontal" | "both", defaults "vertical"). Renders the appropriate ScrollBar as a Viewport sibling. No breaking change.
- create-markdown-components.tsx: rewrote table renderer to use scrollOrientation="horizontal" and place <table> directly inside the Viewport, making it the sole scroll container the Radix thumb controls.
- hi

## How to Test

1. Prompt for a wide table (e.g. "compare 10 languages across 8 attributes")
2. Confirm horizontal scrollbar appears and the thumb is draggable
3. Verify trackpad/wheel scroll still works
4. Check a few other <ScrollArea> usages (sidebars, member lists) — vertical scroll should be unchanged
