### PR TITLE
fix(playground): file drop on whole input

### DIFF
--- a/packages/playground/src/components/room/room-input.tsx
+++ b/packages/playground/src/components/room/room-input.tsx
@@ -632,6 +632,26 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 								: "hover:border-primary",
 							className,
 						)}
+						onDrop={(e) => {
+							e.preventDefault();
+							const updated = Array.from(e.dataTransfer.files);
+							setFiles((prev) => [...prev, ...updated]);
+							setIsDragging(false);
+						}}
+						onDragOver={(e) => {
+							e.preventDefault();
+							setIsDragging(true);
+						}}
+						onDragLeave={(e) => {
+							if (
+								!e.currentTarget.contains(
+									e.relatedTarget as Node,
+								)
+							) {
+								setIsDragging(false);
+							}
+						}}
+						role="none"
 					>
 						{/* File attachments preview strip */}
 						{files.length > 0 && (
@@ -735,25 +755,6 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 													: t("input.menuPrompt")}
 											</div>
 										}
-										onDrop={(e) => {
-											e.preventDefault();
-											const updated = Array.from(
-												e.dataTransfer.files,
-											);
-											setFiles((prev) => [
-												...prev,
-												...updated,
-											]);
-											setIsDragging(false);
-										}}
-										onDragOver={(e) => {
-											e.preventDefault();
-											setIsDragging(true);
-										}}
-										onDragLeave={(e) => {
-											e.preventDefault();
-											setIsDragging(false);
-										}}
 										onPaste={(e) => {
 											const clipboardFiles = Array.from(
 												e.clipboardData.files,


### PR DESCRIPTION
## Description
The bug that Henry needs fixed: right now in dev, when you drag a file in, you can only drop it on the lines of text, as opposed to the entire input component. If you only have one line of text, that's a pretty small area

## Changes Made
Move the handlers to the whole div

## How to Test
- Self explanatory

## Notes
<!-- Any further notes regarding changes -->