### PR TITLE
Fix mobile issue 1038

### DIFF
--- a/packages/playground/src/components/mcp/mcp-selector.tsx
+++ b/packages/playground/src/components/mcp/mcp-selector.tsx
@@ -18,6 +18,7 @@ import {
 	TooltipTrigger,
 	useDebouncedValue,
 	useInfiniteScroll,
+	useIsMobile,
 } from "@semoss/ui/next";
 import { engineProjectToMCP, MCPCard, NewKnowledgeOverlay } from "@/components";
 import { useRoot } from "@/hooks";
@@ -44,6 +45,7 @@ export const MCPSelector = observer(
 	({ type, values, disabled, onChange }: MCPSelectorProps) => {
 		const { t } = useTranslation("mcp");
 		const { root } = useRoot();
+		const isMobile = useIsMobile();
 		const [search, setSearch] = useState<string>("");
 		const [isKnowledgeOverlayOpen, setIsKnowledgeOverlayOpen] =
 			useState(false);
@@ -187,7 +189,35 @@ export const MCPSelector = observer(
 						</div>
 					)}
 				</ScrollArea>
-				{values.length > 0 && (
+				{values.length > 0 && isMobile && (
+					<div className="flex flex-wrap gap-2 p-4">
+						{values.map((t) => (
+							<Badge
+								key={t.id}
+								variant="secondary"
+								className="text-sm"
+								title={t.name}
+							>
+								<div className="max-w-32 truncate">
+									{t.name}
+								</div>
+								<Button
+									className="ml-1"
+									type="button"
+									variant="ghost"
+									size="icon-sm"
+									disabled={disabled || t.fromWorkspace}
+									onClick={() => {
+										onSelect(t);
+									}}
+								>
+									<XIcon />
+								</Button>
+							</Badge>
+						))}
+					</div>
+				)}
+				{values.length > 0 && !isMobile && (
 					<ScrollArea className="w-full whitespace-nowrap">
 						<ScrollBar orientation="horizontal"></ScrollBar>
 						<div className="flex space-x-2 p-4">

--- a/packages/playground/src/components/mcp/mcp-selector.tsx
+++ b/packages/playground/src/components/mcp/mcp-selector.tsx
@@ -190,7 +190,7 @@ export const MCPSelector = observer(
 					)}
 				</ScrollArea>
 				{values.length > 0 && isMobile && (
-					<div className="flex flex-wrap gap-2 p-4">
+					<div className="flex max-h-20 flex-wrap gap-2 overflow-y-auto p-4">
 						{values.map((t) => (
 							<Badge
 								key={t.id}


### PR DESCRIPTION
## Description

Fix the selected badges display behavior in Configure Knowledge and Configure Toolbox dialogs on mobile viewports. On small screens, the horizontal scrolling badge list makes it difficult to see all selected items and requires unintuitive horizontal swiping. This PR switches to a wrapping layout on mobile so all selected badges are visible at a glance.

## Changes Made

- **mcp-selector.tsx**: Conditionally render the selected badges section using `useIsMobile()`. On mobile, badges display in a `flex-wrap` layout instead of a horizontal `ScrollArea`, making all selections visible without horizontal scrolling. On desktop, the original horizontal scrolling behavior is preserved unchanged.

## How to Test

1. Open the playground using Chrome extension `Mobile simulator`
2. In /home and click the plus icon on the chat box to open menu
3. Click the "Add Knowledge" or "Add Toolboxes" option to open the configure dialog
4. The badges should **wrap** to multiple lines, not overflow horizontally
5. On a desktop-width viewport, verify the badges still scroll horizontally as before

## Notes

- This change does not affect the desktop UI's appearance or the desktop user experience
- Screenshot
<img width="224" height="458" alt="image" src="https://github.com/user-attachments/assets/0a3b3bf4-1d8a-4a0d-917b-94ca760c280a" />

