### PR TITLE
fix(playground): saftey on theme

### DIFF
--- a/libs/sdk/src/stores/insight/insight.store.ts
+++ b/libs/sdk/src/stores/insight/insight.store.ts
@@ -48,8 +48,11 @@ interface InsightStoreInterface {
 			 * Theme of the app
 			 */
 			theme: {
-				playground: Record<string, unknown>;
 				[key: string]: unknown;
+				THEME_MAP?: string;
+				THEME_NAME?: string;
+				ID?: string;
+				IS_ACTIVE?: boolean;
 			};
 			/**
 			 * System Date

--- a/packages/playground/src/pages/root-layout.tsx
+++ b/packages/playground/src/pages/root-layout.tsx
@@ -1,11 +1,11 @@
-import { useMemo } from "react";
+import { type PropsWithChildren, useMemo } from "react";
 import { useInsight } from "@semoss/sdk/react";
 import type { ThemeMap } from "@semoss/shared";
 import { Spinner } from "@semoss/ui/next";
 import { RootContext } from "@/contexts";
 import { RootStore } from "@/stores";
 
-export const RootLayout = ({ children }) => {
+export const RootLayout = ({ children }: PropsWithChildren) => {
 	const { system } = useInsight();
 
 	// set up the store
@@ -16,16 +16,15 @@ export const RootLayout = ({ children }) => {
 			// parse the theme
 			let theme: Partial<ThemeMap["playground"]> = {};
 			try {
-				theme = JSON.parse(
-					String(system?.config?.theme?.THEME_MAP) || "{}",
-				)?.playground;
+				theme =
+					JSON.parse(String(system?.config?.theme?.THEME_MAP) || "{}")
+						?.playground ?? {};
 			} catch (_e) {}
 
 			store.initialize(theme);
-			return store;
 		}
 
-		return null;
+		return store;
 	}, [system.config.theme]);
 
 	if (!rootStore.isInitialized) {

--- a/packages/playground/src/pages/root-layout.tsx
+++ b/packages/playground/src/pages/root-layout.tsx
@@ -12,13 +12,16 @@ export const RootLayout = ({ children }: PropsWithChildren) => {
 	const rootStore = useMemo(() => {
 		const store = new RootStore();
 
-		if (system.config.theme) {
+		if (system?.config?.theme) {
 			// parse the theme
 			let theme: Partial<ThemeMap["playground"]> = {};
+
+			const rawTheme = system.config.theme.THEME_MAP || null || "{}";
 			try {
-				theme =
-					JSON.parse(String(system?.config?.theme?.THEME_MAP) || "{}")
-						?.playground ?? {};
+				if (rawTheme) {
+					const parsedTheme = JSON.parse(String(rawTheme));
+					theme = parsedTheme?.playground || {};
+				}
 			} catch (_e) {}
 
 			store.initialize(theme);

--- a/packages/playground/src/stores/root/root.store.ts
+++ b/packages/playground/src/stores/root/root.store.ts
@@ -210,7 +210,7 @@ export class RootStore {
 	 * Update the theme
 	 * @param theme Theme
 	 */
-	private updateTheme = (theme: Partial<ThemeMap["playground"]>) => {
+	private updateTheme = (theme: Partial<ThemeMap["playground"]> = {}) => {
 		// Resolve featureFlags before building the merged theme. Several flags
 		// were historically stored as top-level keys on the theme object; new
 		// themes should put them inside featureFlags instead. Top-level values
@@ -219,7 +219,7 @@ export class RootStore {
 		//
 		// The cast to `legacy` suppresses @deprecated hints: reading these fields
 		// here is intentional — it's the one place responsible for the migration.
-		const legacy = theme as Record<string, unknown>;
+		const legacy = (theme ?? {}) as Record<string, unknown>;
 		const resolvedFeatureFlags = {
 			...this._store.theme.featureFlags,
 			// Migrate top-level booleans for old stored themes


### PR DESCRIPTION
## Description
Theme maps without the playground key were breaking dev

## Changes Made
- In the SDK, correct the theme keys
- When parsing theme in root-layout, make sure that playground is a valid key
- When merging theme in root.store, make sure that the merge is valid

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->