### PR TITLE
feat(shared): add ImportEditMetamodel, ColumnMetadataModal, and PairedFileUpload components

### DIFF
--- a/libs/shared/src/components/column-metadata-modal/column-metadata-modal.tsx
+++ b/libs/shared/src/components/column-metadata-modal/column-metadata-modal.tsx
@@ -1,0 +1,103 @@
+import type React from "react";
+import {
+	Badge,
+	Button,
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	P,
+} from "@semoss/ui/next";
+
+export interface ColumnMetadataModalProps {
+	open: boolean;
+	onClose: () => void;
+	tableName?: string;
+	columnName?: string;
+	physicalType?: string;
+	logicalNames?: string[];
+	description?: string;
+}
+
+export const ColumnMetadataModal: React.FC<ColumnMetadataModalProps> = ({
+	open,
+	onClose,
+	tableName,
+	columnName,
+	physicalType,
+	logicalNames,
+	description,
+}) => {
+	return (
+		<Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+			<DialogContent className="max-h-[85vh] overflow-hidden sm:max-w-xl">
+				<DialogHeader>
+					<DialogTitle>Column Metadata</DialogTitle>
+					<DialogDescription>
+						View logical names and description.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4 overflow-y-auto pr-1">
+					<div className="flex flex-wrap items-center gap-2">
+						{tableName && (
+							<Badge variant="outline">Table: {tableName}</Badge>
+						)}
+						{columnName && (
+							<Badge variant="outline">Column: {columnName}</Badge>
+						)}
+						{physicalType && (
+							<Badge variant="outline">Physical Type: {physicalType}</Badge>
+						)}
+					</div>
+
+					<div className="space-y-2 rounded-md border border-border p-3">
+						<div className="space-y-1">
+							<P className="font-medium text-foreground text-sm">
+								Logical Names
+							</P>
+							<div className="flex flex-wrap gap-1">
+								{logicalNames?.length ? (
+									logicalNames.map((name) => (
+										<Badge
+											key={name}
+											variant="default"
+											className="text-xs"
+										>
+											{name}
+										</Badge>
+									))
+								) : (
+									<P className="text-muted-foreground text-sm">
+										No logical names provided.
+									</P>
+								)}
+							</div>
+						</div>
+
+						<div className="space-y-1">
+							<P className="font-medium text-foreground text-sm">
+								Description
+							</P>
+							<P className="text-muted-foreground text-sm">
+								{description || "No description provided."}
+							</P>
+						</div>
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={onClose}
+						data-testid="column-details-close-btn"
+					>
+						Close
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/libs/shared/src/components/column-metadata-modal/index.ts
+++ b/libs/shared/src/components/column-metadata-modal/index.ts
@@ -1,0 +1,1 @@
+export * from "./column-metadata-modal";

--- a/libs/shared/src/components/import-edit-metamodel/import-edit-metamodel.tsx
+++ b/libs/shared/src/components/import-edit-metamodel/import-edit-metamodel.tsx
@@ -1,0 +1,472 @@
+import { Plus, Trash2 } from "lucide-react";
+import type React from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Field,
+	FieldLabel,
+	Input,
+	P,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
+	Textarea,
+} from "@semoss/ui/next";
+
+export type LogicalDataType =
+	| "BOOLEAN"
+	| "INT"
+	| "DOUBLE"
+	| "STRING"
+	| "DATE"
+	| "TIMESTAMP";
+
+export const LOGICAL_DATA_TYPES: LogicalDataType[] = [
+	"BOOLEAN",
+	"INT",
+	"DOUBLE",
+	"STRING",
+	"DATE",
+	"TIMESTAMP",
+];
+
+
+interface ImportEditMetamodelProps {
+	open: boolean;
+	onClose: () => void;
+	initialName?: string;
+	initialType?: string;
+	initialRawType?: string;
+	onSave: (payload: {
+		name: string;
+		type: string;
+		logicalNames?: string[];
+		description?: string;
+	}) => void;
+	types?: string[];
+	isEdit?: boolean;
+	initialDescription?: string;
+	initialLogicalNames?: string[];
+	existingColumnNames?: string[];
+	readOnly?: boolean;
+}
+
+export const ImportEditMetamodel: React.FC<ImportEditMetamodelProps> = ({
+	open,
+	onClose,
+	initialName = "",
+	initialType = "",
+	initialRawType,
+	initialDescription = "",
+	initialLogicalNames = [],
+	existingColumnNames = [],
+	onSave,
+	types,
+	isEdit = true,
+	readOnly = false,
+}) => {
+	const typesList = useMemo(
+		() => types ?? LOGICAL_DATA_TYPES,
+		[types],
+	);
+
+	type LogicalNameItem = { id: string; name: string };
+
+	const resolveType = (raw: string) =>
+		typesList.includes(raw) ? raw : typesList[0];
+
+	const [singleNameVal, setSingleNameVal] = useState<string>(initialName ?? "");
+	const [typeVal, setTypeVal] = useState<string>(
+		resolveType(initialType),
+	);
+	const [activeTab, setActiveTab] = useState<string>("edit");
+	const [logicalNames, setLogicalNames] = useState<LogicalNameItem[]>([]);
+	const [newLogicalName, setNewLogicalName] = useState<string>("");
+	const [description, setDescription] = useState<string>(initialDescription);
+	const [logicalNameError, setLogicalNameError] = useState<string>("");
+	const [columnNameError, setColumnNameError] = useState<string>("");
+
+	const baseId = useId();
+	const idCounterRef = useRef(0);
+	const openPrevRef = useRef<boolean>(false);
+
+	useEffect(() => {
+		if (open && !openPrevRef.current) {
+			setTypeVal(resolveType(initialType));
+			setSingleNameVal(initialName ?? "");
+
+			const initialItems = (initialLogicalNames || [])
+				.filter((name) => name?.trim())
+				.map((name) => {
+					idCounterRef.current += 1;
+					return {
+						id: `${baseId}-${idCounterRef.current}`,
+						name: name.trim(),
+					};
+				});
+			setLogicalNames(initialItems);
+			setDescription(initialDescription || "");
+			setNewLogicalName("");
+			setActiveTab("edit");
+			setLogicalNameError("");
+			setColumnNameError("");
+		}
+		openPrevRef.current = open;
+	}, [
+		open,
+		initialType,
+		initialName,
+		initialLogicalNames,
+		initialDescription,
+		typesList,
+		baseId,
+	]);
+
+	const handleAddLogicalName = () => {
+		const trimmed = (newLogicalName || "").trim();
+		if (!trimmed) return;
+
+		if (
+			logicalNames.some(
+				(item) => item.name.toLowerCase() === trimmed.toLowerCase(),
+			)
+		) {
+			setLogicalNameError("Logical name already exists");
+			return;
+		}
+
+		const id =
+			crypto && typeof crypto.randomUUID === "function"
+				? crypto.randomUUID()
+				: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+
+		setLogicalNames((prev) => [...prev, { id, name: trimmed }]);
+		setNewLogicalName("");
+		setLogicalNameError("");
+	};
+
+	const handleRemoveLogicalName = (id: string) => {
+		setLogicalNames((prev) => prev.filter((it) => it.id !== id));
+		setLogicalNameError("");
+	};
+
+	const handleColumnNameChange = (value: string) => {
+		setSingleNameVal(value);
+
+		const trimmedValue = value.trim();
+		if (!trimmedValue) {
+			setColumnNameError("");
+			return;
+		}
+
+		const isDuplicate = existingColumnNames.some(
+			(existingName) => existingName === trimmedValue.toLowerCase(),
+		);
+
+		if (isDuplicate) {
+			setColumnNameError("The same name already exists");
+		} else {
+			setColumnNameError("");
+		}
+	};
+
+	const handleSave = () => {
+		const type = (typeVal ?? "").trim() || typesList[0];
+		const name = (singleNameVal ?? "").trim();
+
+		if (!name) return;
+
+		const isDuplicate = existingColumnNames.some(
+			(existingName) => existingName === name.toLowerCase(),
+		);
+
+		if (isDuplicate) {
+			setColumnNameError("The same name already exists");
+			return;
+		}
+
+		const namesOnly: string[] = logicalNames.map((item) =>
+			typeof item === "string" ? item : item.name,
+		);
+
+		onSave({
+			name,
+			type,
+			logicalNames: namesOnly,
+			description: description?.trim() || undefined,
+		});
+
+		onClose();
+	};
+
+	const EditForm = (
+		<div className="space-y-4">
+			<Field>
+				<FieldLabel className="mb-1.5 text-sm">Column name</FieldLabel>
+				<Input
+					placeholder="Enter column name"
+					value={singleNameVal}
+					onChange={(e) => handleColumnNameChange(e.target.value)}
+					className="w-full"
+					disabled={readOnly}
+					data-testid="edit-metamodel-column-name"
+				/>
+				{columnNameError && (
+					<P className="mt-1 text-destructive text-xs">
+						{columnNameError}
+					</P>
+				)}
+			</Field>
+
+			<Field>
+				<FieldLabel className="mb-1.5 text-sm">Logical Data Type</FieldLabel>
+				<Select
+					value={typeVal || typesList[0]}
+					onValueChange={(value) => setTypeVal(value)}
+					disabled={readOnly}
+				>
+					<SelectTrigger
+						className="w-full"
+						data-testid="edit-metamodel-column-type"
+					>
+						<SelectValue placeholder="Select type" />
+					</SelectTrigger>
+					<SelectContent>
+						{typesList.map((type) => (
+							<SelectItem key={type} value={type}>
+								{type}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</Field>
+
+			{initialRawType && (
+				<Field>
+					<FieldLabel className="mb-1.5 text-sm">Physical Data Type</FieldLabel>
+					<Input
+						value={initialRawType}
+						readOnly
+						disabled
+						className="w-full cursor-default"
+						data-testid="edit-metamodel-raw-type"
+					/>
+				</Field>
+			)}
+		</div>
+	);
+
+	return (
+		<Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+			<DialogContent
+				className="max-w-[600px]"
+				data-testid="edit-metamodel-modal"
+			>
+				<DialogHeader>
+					<DialogTitle className="font-semibold text-lg">
+						{isEdit
+							? readOnly
+								? `View ${initialName}`
+								: `Edit ${initialName}`
+							: "Add column"}
+					</DialogTitle>
+				</DialogHeader>
+
+				{isEdit ? (
+					<Tabs
+						value={activeTab}
+						onValueChange={setActiveTab}
+						className="w-full"
+					>
+						<TabsList className="grid w-full grid-cols-3">
+							<TabsTrigger
+								value="edit"
+								data-testid="edit-metamodel-tab-edit"
+							>
+								Edit
+							</TabsTrigger>
+							<TabsTrigger
+								value="description"
+								data-testid="edit-metamodel-tab-description"
+							>
+								Description
+							</TabsTrigger>
+							<TabsTrigger
+								value="logical-names"
+								data-testid="edit-metamodel-tab-logical-names"
+							>
+								Logical Names
+							</TabsTrigger>
+						</TabsList>
+
+						<TabsContent value="edit" className="mt-4">
+							{EditForm}
+						</TabsContent>
+
+						<TabsContent value="description" className="mt-4">
+							<Field>
+								<FieldLabel className="mb-1.5 text-sm">
+									Description
+								</FieldLabel>
+								<Textarea
+									value={description}
+									onChange={(e) => setDescription(e.target.value)}
+									placeholder="Enter description"
+									rows={4}
+									className="min-h-[100px] w-full resize-y"
+									disabled={readOnly}
+									data-testid="edit-metamodel-description"
+								/>
+							</Field>
+						</TabsContent>
+
+						<TabsContent value="logical-names" className="mt-4 space-y-3">
+							<div className="max-h-[200px] overflow-auto rounded-md border border-border">
+								<Table>
+									<TableHeader className="sticky top-0 bg-muted/50">
+										<TableRow>
+											<TableHead className="h-10 font-medium">
+												Name
+											</TableHead>
+											{!readOnly && (
+												<TableHead className="h-10 w-16 text-center font-medium">
+													Action
+												</TableHead>
+											)}
+										</TableRow>
+									</TableHeader>
+									<TableBody>
+										{logicalNames.length === 0 ? (
+											<TableRow>
+												<TableCell
+													colSpan={readOnly ? 1 : 2}
+													className="h-20 text-center text-muted-foreground text-sm"
+												>
+													No logical names added
+												</TableCell>
+											</TableRow>
+										) : (
+											logicalNames.map((item) => (
+												<TableRow
+													key={item.id}
+													data-testid={`engineMetadata-logicalname-${item.id}-row`}
+												>
+													<TableCell className="py-2">
+														{item.name}
+													</TableCell>
+													{!readOnly && (
+														<TableCell className="border-border border-l py-1 text-center">
+															<Button
+																variant="ghost"
+																size="icon"
+																className="size-8"
+																onClick={() =>
+																	handleRemoveLogicalName(item.id)
+																}
+																data-testid={`engineMetadata-logicalname-${item.id}-remove`}
+															>
+																<Trash2 className="size-4" />
+															</Button>
+														</TableCell>
+													)}
+												</TableRow>
+											))
+										)}
+									</TableBody>
+								</Table>
+							</div>
+
+							{!readOnly && (
+								<div className="space-y-1">
+									<div className="flex gap-2">
+										<Input
+											placeholder="Add logical name"
+											value={newLogicalName}
+											onChange={(e) => {
+												setNewLogicalName(e.target.value);
+												if (logicalNameError)
+													setLogicalNameError("");
+											}}
+											onKeyDown={(e) => {
+												if (e.key === "Enter" && newLogicalName.trim()) {
+													handleAddLogicalName();
+												}
+											}}
+											className="flex-1"
+											data-testid="edit-metamodel-logical-name-input"
+										/>
+										<Button
+											variant="default"
+											size="icon"
+											onClick={handleAddLogicalName}
+											disabled={!newLogicalName.trim()}
+											className="size-9 shrink-0"
+											data-testid="engineMetadata-logicalname-add"
+										>
+											<Plus className="size-4" />
+										</Button>
+									</div>
+
+									{logicalNameError && (
+										<P className="text-destructive text-xs">
+											{logicalNameError}
+										</P>
+									)}
+								</div>
+							)}
+						</TabsContent>
+					</Tabs>
+				) : (
+					<>{EditForm}</>
+				)}
+
+				<DialogFooter>
+					{readOnly ? (
+						<Button
+							variant="outline"
+							onClick={onClose}
+							data-testid="engineMetadata-close-btn"
+						>
+							Close
+						</Button>
+					) : (
+						<>
+							<Button
+								variant="outline"
+								onClick={onClose}
+								data-testid="engineMetadata-cancel-btn"
+							>
+								Cancel
+							</Button>
+							<Button
+								variant="default"
+								onClick={handleSave}
+								disabled={!singleNameVal.trim() || !!columnNameError}
+								data-testid="engineMetadata-save-btn"
+							>
+								Save
+							</Button>
+						</>
+					)}
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/libs/shared/src/components/import-edit-metamodel/index.ts
+++ b/libs/shared/src/components/import-edit-metamodel/index.ts
@@ -1,0 +1,1 @@
+export * from "./import-edit-metamodel";

--- a/libs/shared/src/components/index.ts
+++ b/libs/shared/src/components/index.ts
@@ -1,4 +1,7 @@
 export * from "./auditlog";
+export * from "./column-metadata-modal";
+export * from "./import-edit-metamodel";
+export * from "./paired-file-upload";
 export * from "./data-type-icon";
 export * from "./engine";
 export * from "./file";

--- a/libs/shared/src/components/paired-file-upload/index.ts
+++ b/libs/shared/src/components/paired-file-upload/index.ts
@@ -1,0 +1,1 @@
+export * from "./paired-file-upload";

--- a/libs/shared/src/components/paired-file-upload/paired-file-upload.tsx
+++ b/libs/shared/src/components/paired-file-upload/paired-file-upload.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useRef } from "react";
+import { Upload, X } from "lucide-react";
+
+export interface PairedFileUploadColumn {
+    key: string;
+    label: string;
+    extensions?: string[];
+    required?: boolean;
+}
+
+export type PairedFileUploadRow = Record<string, File | null>;
+
+interface PairedFileUploadProps {
+    columns: PairedFileUploadColumn[];
+    onChange: (rows: PairedFileUploadRow[]) => void;
+    value?: PairedFileUploadRow[];
+}
+
+function emptyRow(columns: PairedFileUploadColumn[]): PairedFileUploadRow {
+    return Object.fromEntries(columns.map((c) => [c.key, null]));
+}
+
+function isRowEmpty(row: PairedFileUploadRow): boolean {
+    return Object.values(row).every((v) => v === null);
+}
+
+export function PairedFileUpload({
+    columns,
+    onChange,
+    value,
+}: PairedFileUploadProps) {
+    // Always render with a trailing empty row — it is purely presentational
+    // and gets stripped before emitting to the parent via onChange.
+    const rows = useMemo(() => {
+        const base = value && value.length > 0 ? [...value] : [];
+        base.push(emptyRow(columns));
+        return base;
+    }, [value, columns]);
+
+    const inputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+
+    function emit(next: PairedFileUploadRow[]) {
+        const meaningful = [...next];
+        while (meaningful.length > 0 && isRowEmpty(meaningful[meaningful.length - 1])) {
+            meaningful.pop();
+        }
+        onChange(meaningful);
+    }
+
+    function setFile(rowIdx: number, colKey: string, file: File | null) {
+        // Operate on value (without the trailing empty row) so indices stay stable
+        const next = (value ?? []).map((r) => ({ ...r }));
+
+        if (rowIdx < next.length) {
+            next[rowIdx][colKey] = file;
+            // Remove a non-last meaningful row if it becomes fully empty
+            if (isRowEmpty(next[rowIdx]) && next.length > 0) {
+                next.splice(rowIdx, 1);
+            }
+        } else {
+            // rowIdx points to the trailing empty slot — create a new row
+            const row = emptyRow(columns);
+            row[colKey] = file;
+            if (file !== null) next.push(row);
+        }
+
+        emit(next);
+    }
+
+    function removeRow(rowIdx: number) {
+        const next = (value ?? []).filter((_, i) => i !== rowIdx);
+        emit(next);
+    }
+
+    function handleDrop(
+        e: React.DragEvent,
+        rowIdx: number,
+        col: PairedFileUploadColumn,
+    ) {
+        e.preventDefault();
+        const file = e.dataTransfer.files[0];
+        if (!file) return;
+        if (col.extensions && !col.extensions.some((ext) => file.name.endsWith(ext))) return;
+        setFile(rowIdx, col.key, file);
+    }
+
+    const trailingIdx = rows.length - 1;
+
+    return (
+        <div className="flex flex-col gap-1">
+            {/* Header */}
+            <div
+                className="grid gap-2"
+                style={{ gridTemplateColumns: `repeat(${columns.length}, 1fr) 2rem` }}
+            >
+                {columns.map((col) => (
+                    <span key={col.key} className="px-1 text-xs font-medium text-foreground">
+                        {col.label}
+                        {col.required && <span className="ml-0.5 text-destructive">*</span>}
+                    </span>
+                ))}
+                <span />
+            </div>
+
+            {/* Rows */}
+            {rows.map((row, rowIdx) => (
+                <div
+                    key={rowIdx}
+                    className="grid items-center gap-2"
+                    style={{ gridTemplateColumns: `repeat(${columns.length}, 1fr) 2rem` }}
+                >
+                    {columns.map((col) => {
+                        const file = row[col.key];
+                        const refKey = `${rowIdx}-${col.key}`;
+                        return (
+                            <div
+                                key={col.key}
+                                className={`flex h-9 min-w-0 cursor-pointer items-center gap-2 overflow-hidden rounded-lg border-2 px-3 text-sm transition-colors
+                                    ${file ? "border-border bg-muted/40" : "border-dashed border-input bg-secondary hover:border-primary hover:bg-accent"}`}
+                                onClick={() => inputRefs.current[refKey]?.click()}
+                                onDragOver={(e) => e.preventDefault()}
+                                onDrop={(e) => handleDrop(e, rowIdx, col)}
+                            >
+                                <input
+                                    ref={(el) => { inputRefs.current[refKey] = el; }}
+                                    type="file"
+                                    accept={col.extensions?.join(",") ?? "*"}
+                                    className="hidden"
+                                    onChange={(e) => {
+                                        const f = e.target.files?.[0] ?? null;
+                                        if (f) setFile(rowIdx, col.key, f);
+                                        e.target.value = "";
+                                    }}
+                                />
+                                {file ? (
+                                    <>
+                                        <span className="min-w-0 flex-1 truncate text-foreground text-sm">{file.name}</span>
+                                        <button
+                                            type="button"
+                                            className="shrink-0 text-muted-foreground hover:text-destructive"
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                setFile(rowIdx, col.key, null);
+                                            }}
+                                        >
+                                            <X className="h-3 w-3" />
+                                        </button>
+                                    </>
+                                ) : (
+                                    <span className="flex shrink-0 items-center gap-1.5 text-muted-foreground text-sm">
+                                        <Upload className="h-3 w-3 shrink-0" />
+                                        {col.extensions ? `Supports ${col.extensions.join(", ")}` : "All file types supported"}
+                                    </span>
+                                )}
+                            </div>
+                        );
+                    })}
+
+                    {/* Remove button — invisible on the trailing empty row */}
+                    <button
+                        type="button"
+                        className={`flex h-7 w-7 items-center justify-center rounded text-muted-foreground transition-colors hover:text-destructive
+                            ${rowIdx === trailingIdx ? "invisible" : ""}`}
+                        onClick={() => removeRow(rowIdx)}
+                    >
+                        <X className="h-4 w-4" />
+                    </button>
+                </div>
+            ))}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `ImportEditMetamodel` — a reusable column edit dialog with Edit, Description, and Logical Names tabs; supports `readOnly` mode and an optional `initialRawType` field for displaying physical data types
- Adds `ColumnMetadataModal` — a read-only view modal for table column metadata (physical type, logical names, description) used on the engine metadata page
- Adds `PairedFileUpload` — a component for pairing data files (.csv) with optional prop files (.json), used in the database import flow
- Wires all three into `@semoss/shared`'s public export surface via `libs/shared/src/components/index.ts`

All additions are purely additive — no existing code changed. This is a prerequisite for PRs that consume these components.

## Test plan

- [ ] Import from `@semoss/shared` in a consuming file and confirm TypeScript compiles without errors
- [ ] Confirm `ImportEditMetamodel` renders with Edit/Description/Logical Names tabs
- [ ] Confirm `readOnly` prop disables inputs and shows only a Close button
- [ ] Confirm `ColumnMetadataModal` renders table name, column name, physical type, logical names, and description
- [ ] Confirm `PairedFileUpload` renders two file columns and allows pairing data + prop files