### PR TITLE
feat(import): surface raw physical types from ExternalJdbcSchema through metamodel properties

### DIFF
--- a/packages/client/src/components/import/database/database-form.tsx
+++ b/packages/client/src/components/import/database/database-form.tsx
@@ -1642,9 +1642,18 @@ export const DatabaseForm = ({
 	}
 
 	function transformStructure(dbObject) {
-		const result = {
+		const result: {
+			headers: string[];
+			dataTypes: Record<string, string>;
+			physicalTypes: Record<string, string>;
+			cleanHeaders: string[];
+			relation: { relName: string; fromTable: string; fromCol?: string; toTable: string; toCol?: string; }[];
+			nodeProp: Record<string, string[]>;
+			positions: Record<string, { left: number; top: number }>;
+		} = {
 			headers: [],
 			dataTypes: {},
+			physicalTypes: {},
 			cleanHeaders: [],
 			relation: [],
 			nodeProp: {},
@@ -1653,8 +1662,10 @@ export const DatabaseForm = ({
 
 		dbObject.tables.forEach((table) => {
 			table.columns.forEach((col, i) => {
-				result.dataTypes[col] =
-					table.type[i]?.toLowerCase() || "string";
+				result.dataTypes[col] = table.type[i] || "";
+				if (table.raw_type?.[i]) {
+					result.physicalTypes[col] = table.raw_type[i];
+				}
 			});
 
 			result.nodeProp[table.table] = table.columns;
@@ -1663,6 +1674,7 @@ export const DatabaseForm = ({
 
 		if (dbObject.relationships && dbObject.relationships?.length > 0) {
 			result.relation = dbObject.relationships.map((r) => ({
+				relName: `${r.fromCol ?? r.fromTable}.${r.toCol ?? r.toTable}`,
 				fromTable: r.fromTable,
 				fromCol: r.fromCol,
 				toTable: r.toTable,

--- a/packages/client/src/components/import/database/metamodel-editor-jdbc.tsx
+++ b/packages/client/src/components/import/database/metamodel-editor-jdbc.tsx
@@ -83,6 +83,7 @@ export const MetaModelConnections = observer(
 								parsed.dataTypes?.[prop] ??
 								parsed.additionalDataTypes?.[prop] ??
 								"",
+							rawType: parsed.physicalTypes?.[prop],
 							isPrimary: idx === 0,
 						})),
 					},
@@ -638,7 +639,7 @@ export const MetaModelConnections = observer(
 					contentId={portalContentId}
 				/>
 				{!showFullScreenModal && (
-					<div className="mt-4 flex justify-end gap-3 border-border border-t pt-4">
+					<div className="mt-4 flex justify-end gap-3 border-border border-t pt-4 pb-6">
 						<Button variant="outline" onClick={onCancel}>
 							Cancel
 						</Button>

--- a/packages/client/src/components/import/database/metamodel-types.ts
+++ b/packages/client/src/components/import/database/metamodel-types.ts
@@ -37,6 +37,8 @@ export interface ParsedResult {
 	descriptionMap?: Record<string, string>;
 	fileName?: string;
 	fileLocation?: string;
+	raw_type?: string[];
+	physicalTypes?: Record<string, string>;
 }
 
 export interface Property {
@@ -47,6 +49,7 @@ export interface Property {
 	logicalNames?: string[];
 	isPrimary?: boolean;
 	label?: string;
+	rawType?: string;
 }
 export interface MetaModelTypeProps {
 	parsedData?: ParsedResult[];

--- a/packages/client/src/components/import/database/metamodel-utils.ts
+++ b/packages/client/src/components/import/database/metamodel-utils.ts
@@ -84,11 +84,28 @@ export const generateNodesFromParsed = (parsed: {
 	nodeProp?: Record<string, string[]>;
 	dataTypes?: Record<string, string>;
 	additionalDataTypes?: Record<string, string>;
+	raw_type?: string[];
 }): (MetamodelNode | FlowNode)[] => {
-	if (!parsed?.positions) return [];
+	if (!parsed) return [];
 
-	return Object.keys(parsed.positions).map((nodeName) => {
-		const position = parsed.positions[nodeName];
+	const nodeNames = parsed.positions
+		? Object.keys(parsed.positions)
+		: Object.keys(parsed.nodeProp ?? {});
+
+	if (nodeNames.length === 0) return [];
+
+	const autoPositions: Record<string, { left: number; top: number }> = {};
+	if (!parsed.positions) {
+		nodeNames.forEach((name, idx) => {
+			autoPositions[name] = { left: idx * 300, top: 100 };
+		});
+	}
+
+	const positions = parsed.positions ?? autoPositions;
+
+	let rawTypeIdx = 0;
+	return nodeNames.map((nodeName) => {
+		const position = positions[nodeName];
 		const isIndexNode = nodeName.toLowerCase() === "index";
 
 		const extraProps = parsed.nodeProp?.[nodeName] ?? [];
@@ -108,6 +125,7 @@ export const generateNodesFromParsed = (parsed: {
 						parsed.dataTypes?.[prop] ??
 						parsed.additionalDataTypes?.[prop] ??
 						"",
+					rawType: parsed.raw_type?.[rawTypeIdx++],
 					isPrimary: idx === 0,
 					label: prop?.replace(/_/g, " "),
 				})),
@@ -243,11 +261,14 @@ export const rebuildNodesFromParsed = (parsed: {
 	nodeProp?: Record<string, string[]>;
 	dataTypes?: Record<string, string>;
 	additionalDataTypes?: Record<string, string>;
+	raw_type?: string[];
 }): (MetamodelNode | FlowNode)[] => {
 	if (!parsed?.positions) return [];
 
-	return Object.keys(parsed.positions).map((nodeName) => {
-		const position = parsed.positions[nodeName];
+	const positions = parsed.positions as Record<string, { left: number; top: number }>;
+	let rawTypeIdx = 0;
+	return Object.keys(positions).map((nodeName) => {
+		const position = positions[nodeName];
 		const isIndexNode = nodeName.toLowerCase() === "index";
 		const extraProps = parsed.nodeProp?.[nodeName] ?? [];
 		const propertiesList = isIndexNode
@@ -266,6 +287,7 @@ export const rebuildNodesFromParsed = (parsed: {
 						parsed.dataTypes?.[prop] ??
 						parsed.additionalDataTypes?.[prop] ??
 						"",
+					rawType: parsed.raw_type?.[rawTypeIdx++],
 					isPrimary: idx === 0,
 					label: prop?.replace(/_/g, " "),
 				})),


### PR DESCRIPTION
## Summary

- Extends `ParsedResult` with `physicalTypes: Record<string, string>` and `raw_type?: string[]`; extends `Property` with `rawType?: string`
- Updates `transformStructure` in `DatabaseForm` to populate `physicalTypes` from `raw_type` and use the backend-provided `type` values directly (no frontend normalization needed — backend already returns canonical types like `INT`, `STRING`, etc.)
- Updates `generateNodesFromParsed` and `rebuildNodesFromParsed` in metamodel-utils to thread `rawType` through to each property
- In the JDBC metamodel editor, each property now includes `rawType: parsed.physicalTypes?.[prop]` so the edit dialog can display the physical database type alongside the logical type
- Adds `pb-6` bottom padding to the Import/Cancel button row

## Test plan

- [ ] Connect to a Postgres database via JDBC import
- [ ] Open the column editor for a table — confirm the "Physical Data Type" field shows the raw DB type (e.g. `int4`, `text`, `timestamptz`)
- [ ] Confirm the "Logical Data Type" dropdown shows the correct canonical value (`INT`, `STRING`, `TIMESTAMP`) without frontend mapping
- [ ] Confirm the Import/Cancel buttons have visible bottom spacing