### PR TITLE
feat(metamodel): fix Create Connection modal

### DIFF
--- a/packages/client/src/components/import/database/database-form.tsx
+++ b/packages/client/src/components/import/database/database-form.tsx
@@ -5,6 +5,7 @@ import { ChevronDown, ChevronUp, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { console as getPixelConsole } from "@semoss/sdk/react";
+import { PairedFileUpload, type PairedFileUploadRow } from "@semoss/shared";
 import {
 	Button,
 	Checkbox,
@@ -32,7 +33,6 @@ import {
 	toast,
 } from "@semoss/ui/next";
 import { uploadFile } from "@/api";
-import { PairedFileUpload, type PairedFileUploadRow } from "@semoss/shared";
 import { useRootStore } from "@/hooks";
 import { useNavigate } from "@/hooks/useNavigate";
 import DataSelection from "./flat-table-column-editor";
@@ -139,7 +139,8 @@ export const DatabaseForm = ({
 		const isPropFile = metamodelType === "fromPropFile";
 		setResolvedFields((prev) =>
 			prev.map((f) => {
-				if (f.key === "FILE_UPLOAD") return { ...f, hidden: isPropFile };
+				if (f.key === "FILE_UPLOAD")
+					return { ...f, hidden: isPropFile };
 				if (f.key === "PROP_FILE_UPLOAD") return { ...f, hidden: true };
 				return f;
 			}),
@@ -314,11 +315,15 @@ export const DatabaseForm = ({
 			const uploadedFilesResponse =
 				formData.METAMODEL_TYPE === "fromPropFile"
 					? []
-					: await uploadFile(formData.FILE_UPLOAD, configStore.store.insightID);
+					: await uploadFile(
+							formData.FILE_UPLOAD,
+							configStore.store.insightID,
+						);
 
 			if (
 				formData.METAMODEL_TYPE !== "fromPropFile" &&
-				(!uploadedFilesResponse || !Array.isArray(uploadedFilesResponse))
+				(!uploadedFilesResponse ||
+					!Array.isArray(uploadedFilesResponse))
 			) {
 				toast.error("Upload failed or returned invalid response.");
 				setValue("DATABASE_TYPE", formData.DATABASE_TYPE);
@@ -393,13 +398,21 @@ export const DatabaseForm = ({
 
 					for (const pair of validPairs) {
 						const [csvUpload, propUpload] = await Promise.all([
-							uploadFile([pair.dataFile as File], configStore.store.insightID),
+							uploadFile(
+								[pair.dataFile as File],
+								configStore.store.insightID,
+							),
 							pair.propFile
-								? uploadFile([pair.propFile as File], configStore.store.insightID)
+								? uploadFile(
+										[pair.propFile as File],
+										configStore.store.insightID,
+									)
 								: Promise.resolve(null),
 						]);
 						if (!csvUpload?.length) {
-							toast.error(`Failed to upload ${(pair.dataFile as File).name}.`);
+							toast.error(
+								`Failed to upload ${(pair.dataFile as File).name}.`,
+							);
 							setLoading(false);
 							return;
 						}
@@ -416,7 +429,9 @@ export const DatabaseForm = ({
 							setLoading(false);
 							return;
 						}
-						parsedResults.push(response?.pixelReturn?.[0]?.output as ParsedResult);
+						parsedResults.push(
+							response?.pixelReturn?.[0]?.output as ParsedResult,
+						);
 						const name = csvPath.split(/[/\\]/).pop() || "";
 						names.push(name);
 					}
@@ -427,7 +442,9 @@ export const DatabaseForm = ({
 					setParsedData(parsedResults);
 					setStep("metaModel");
 				} catch {
-					toast.error("An error occurred while processing the files.");
+					toast.error(
+						"An error occurred while processing the files.",
+					);
 				} finally {
 					setLoading(false);
 				}
@@ -1301,7 +1318,7 @@ export const DatabaseForm = ({
 					case "zip-upload":
 						return (
 							<div
-								className={`flex flex-col gap-2${val.hidden ? " hidden" : ""}`}
+								className={`flex flex-col gap-2${val.hidden ? "hidden" : ""}`}
 								data-testid={`database-form-field-${val.key}`}
 							>
 								<P>
@@ -1647,7 +1664,13 @@ export const DatabaseForm = ({
 			dataTypes: Record<string, string>;
 			physicalTypes: Record<string, string>;
 			cleanHeaders: string[];
-			relation: { relName: string; fromTable: string; fromCol?: string; toTable: string; toCol?: string; }[];
+			relation: {
+				relName: string;
+				fromTable: string;
+				fromCol?: string;
+				toTable: string;
+				toCol?: string;
+			}[];
 			nodeProp: Record<string, string[]>;
 			positions: Record<string, { left: number; top: number }>;
 		} = {
@@ -1786,7 +1809,17 @@ export const DatabaseForm = ({
 													{
 														key: "dataFile",
 														label: "Data File",
-														extensions: resolvedFields.find((f: { key: string }) => f.key === "FILE_UPLOAD")?.options?.extensions ?? [".csv"],
+														extensions:
+															resolvedFields.find(
+																(f: {
+																	key: string;
+																}) =>
+																	f.key ===
+																	"FILE_UPLOAD",
+															)?.options
+																?.extensions ?? [
+																".csv",
+															],
 														required: true,
 													},
 													{
@@ -1901,6 +1934,10 @@ export const DatabaseForm = ({
 						submitMetamodelPixel(payload, formValues)
 					}
 					onCancel={handleCancel}
+					isRdf={
+						(formValues as { DATABASE_TYPE?: string })
+							.DATABASE_TYPE === "rdf"
+					}
 				/>
 			)}
 

--- a/packages/client/src/components/import/database/metamodel-editor-csv.tsx
+++ b/packages/client/src/components/import/database/metamodel-editor-csv.tsx
@@ -64,7 +64,7 @@ import {
 import { PortalModal } from "./portal";
 
 export const MetaModelType = observer(
-	({ parsedData, onImport, onCancel }: MetaModelTypeProps) => {
+	({ parsedData, onImport, onCancel, isRdf = false }: MetaModelTypeProps) => {
 		// State
 		const [selectedDataIndex, setSelectedDataIndex] = useState<number>(0);
 		const [flowStates, setFlowStates] = useState<Record<number, FlowData>>(
@@ -814,6 +814,7 @@ export const MetaModelType = observer(
 							)}
 							onEditConnection={handleEditConnection}
 							onDeleteConnection={handleDeleteConnection}
+							isRdf={isRdf}
 						/>
 					</div>
 				</div>

--- a/packages/client/src/components/import/database/metamodel-types.ts
+++ b/packages/client/src/components/import/database/metamodel-types.ts
@@ -56,6 +56,7 @@ export interface MetaModelTypeProps {
 	onImport?: (parsed: unknown) => void | Promise<void>;
 	onCancel: () => void;
 	onImportConnections?: (connections: unknown) => void | Promise<void>;
+	isRdf?: boolean;
 }
 
 export type MetamodelNode = {

--- a/packages/client/src/components/metamodel/create-connection.tsx
+++ b/packages/client/src/components/metamodel/create-connection.tsx
@@ -1,6 +1,6 @@
-import { ArrowRight, Edit, Eye, Trash2} from "lucide-react";
+import { ArrowRight, Edit, Eye, Trash2 } from "lucide-react";
 import type React from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
 	Button,
 	Dialog,
@@ -46,6 +46,7 @@ interface ConnectionProps {
 	initialConnections?: Conn[];
 	onEditConnection?: (updated: Conn) => void;
 	onDeleteConnection?: (id: string) => void;
+	isRdf?: boolean;
 }
 
 export const CreateConnection: React.FC<ConnectionProps> = ({
@@ -56,6 +57,7 @@ export const CreateConnection: React.FC<ConnectionProps> = ({
 	initialConnections = [],
 	onEditConnection,
 	onDeleteConnection,
+	isRdf = false,
 }) => {
 	const tableOptions = useMemo(() => nodes.map((n) => n.data.name), [nodes]);
 
@@ -65,6 +67,9 @@ export const CreateConnection: React.FC<ConnectionProps> = ({
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [error, setError] = useState<string>("");
 	const [save, setSave] = useState(true);
+
+	// Snapshot of connections at dialog open — used to diff on Save
+	const snapshotRef = useRef<Conn[]>([]);
 
 	const makeId = (c: Conn) =>
 		`${c.parentTable}_${c.childTable}`.replace(/\s+/g, "_");
@@ -76,6 +81,7 @@ export const CreateConnection: React.FC<ConnectionProps> = ({
 				if (!copy.id) copy.id = makeId(copy);
 				return copy;
 			});
+			snapshotRef.current = normalized;
 			setConnections(normalized);
 			setEditingId(null);
 			setParentTable("");
@@ -179,11 +185,9 @@ export const CreateConnection: React.FC<ConnectionProps> = ({
 			setConnections((prev) =>
 				prev.map((p) => (p.id === editingId ? newConn : p)),
 			);
-			onEditConnection?.(newConn);
 			setEditingId(null);
 		} else {
 			setConnections((prev) => [...prev, newConn]);
-			onCreateConnection?.(newConn);
 		}
 
 		setParentTable("");
@@ -197,7 +201,6 @@ export const CreateConnection: React.FC<ConnectionProps> = ({
 		setConnections((prev) =>
 			prev.filter((c) => (c.id ?? makeId(c)) !== id),
 		);
-		if (id && onDeleteConnection) onDeleteConnection(id);
 
 		if (editingId === id) {
 			setEditingId(null);
@@ -205,6 +208,48 @@ export const CreateConnection: React.FC<ConnectionProps> = ({
 			setChildTable("");
 		}
 		setError("");
+		setSave(false);
+	};
+
+	const handleSave = () => {
+		const snapshot = snapshotRef.current;
+		const snapshotIds = new Set(snapshot.map((c) => c.id ?? makeId(c)));
+		const currentIds = new Set(connections.map((c) => c.id ?? makeId(c)));
+
+		// Deleted: in snapshot but not in current
+		for (const c of snapshot) {
+			const id = c.id ?? makeId(c);
+			if (!currentIds.has(id)) {
+				onDeleteConnection?.(id);
+			}
+		}
+
+		// Added: in current but not in snapshot
+		for (const c of connections) {
+			const id = c.id ?? makeId(c);
+			if (!snapshotIds.has(id)) {
+				onCreateConnection?.(c);
+			}
+		}
+
+		// Edited: same id but different tables
+		for (const c of connections) {
+			const id = c.id ?? makeId(c);
+			if (snapshotIds.has(id)) {
+				const orig = snapshot.find(
+					(ic) => (ic.id ?? makeId(ic)) === id,
+				);
+				if (
+					orig &&
+					(orig.parentTable !== c.parentTable ||
+						orig.childTable !== c.childTable)
+				) {
+					onEditConnection?.(c);
+				}
+			}
+		}
+
+		onClose();
 	};
 
 	useEffect(() => {
@@ -223,7 +268,7 @@ export const CreateConnection: React.FC<ConnectionProps> = ({
 				<div className="flex flex-col gap-4 pb-2">
 					<Field>
 						<FieldLabel className="mb-1.5 block text-xs">
-							Parent Table{" "}
+							{isRdf ? "Start Node" : "Parent Table"}{" "}
 							<span className="text-destructive">*</span>
 						</FieldLabel>
 						<Select
@@ -231,7 +276,13 @@ export const CreateConnection: React.FC<ConnectionProps> = ({
 							onValueChange={(value) => setParentTable(value)}
 						>
 							<SelectTrigger className="w-full">
-								<SelectValue placeholder="Select or type parent table" />
+								<SelectValue
+									placeholder={
+										isRdf
+											? "Select start node"
+											: "Select parent table"
+									}
+								/>
 							</SelectTrigger>
 							<SelectContent>
 								{tableOptions.map((table) => (
@@ -245,7 +296,7 @@ export const CreateConnection: React.FC<ConnectionProps> = ({
 
 					<Field>
 						<FieldLabel className="mb-1.5 block text-xs">
-							Child Table{" "}
+							{isRdf ? "Child Node" : "Child Table"}{" "}
 							<span className="text-destructive">*</span>
 						</FieldLabel>
 						<Select
@@ -253,7 +304,13 @@ export const CreateConnection: React.FC<ConnectionProps> = ({
 							onValueChange={(value) => setChildTable(value)}
 						>
 							<SelectTrigger className="w-full">
-								<SelectValue placeholder="Select or type child table" />
+								<SelectValue
+									placeholder={
+										isRdf
+											? "Select child node"
+											: "Select child table"
+									}
+								/>
 							</SelectTrigger>
 							<SelectContent>
 								{tableOptions.map((table) => (
@@ -265,12 +322,31 @@ export const CreateConnection: React.FC<ConnectionProps> = ({
 						</Select>
 					</Field>
 
-					{/* Relationship Preview Box */}
-					<div className="flex h-11 w-full cursor-pointer items-center gap-2 rounded-md border border-primary/30 bg-primary/10 px-2.5 py-1.5">
-						<Eye className="mr-1 size-[18px] text-primary" />
-						<P className="font-medium text-primary">
-							Relationship Preview
-						</P>
+					{/* Live Relationship Preview */}
+					<div className="flex h-11 w-full items-center gap-2 rounded-md border border-border bg-muted/40 px-3">
+						<Eye className="size-4 shrink-0 text-muted-foreground" />
+						{parentTable || childTable ? (
+							<div className="flex min-w-0 flex-1 items-center gap-1.5 text-sm">
+								<span
+									className={`truncate font-medium ${parentTable ? "text-foreground" : "text-muted-foreground italic"}`}
+								>
+									{parentTable ||
+										(isRdf ? "Start Node" : "Parent Table")}
+								</span>
+								<ArrowRight className="size-3.5 shrink-0 text-muted-foreground" />
+								<span
+									className={`truncate font-medium ${childTable ? "text-foreground" : "text-muted-foreground italic"}`}
+								>
+									{childTable ||
+										(isRdf ? "Child Node" : "Child Table")}
+								</span>
+							</div>
+						) : (
+							<span className="text-muted-foreground text-sm">
+								Select {isRdf ? "nodes" : "tables"} above to
+								preview
+							</span>
+						)}
 					</div>
 
 					{/* Error Message */}
@@ -287,13 +363,15 @@ export const CreateConnection: React.FC<ConnectionProps> = ({
 									key={id}
 									className="mb-1 flex items-center"
 								>
-									<P className="mr-4 font-normal text-foreground">
-										{c.parentTable}
-									</P>
-									<ArrowRight className="size-5 text-muted-foreground" />
-									<P className="ml-4 font-normal text-foreground">
-										{c.childTable}
-									</P>
+									<div className="flex min-w-0 flex-1 items-center gap-1.5 text-sm">
+										<span className="truncate font-medium text-foreground">
+											{c.parentTable}
+										</span>
+										<ArrowRight className="size-3.5 shrink-0 text-muted-foreground" />
+										<span className="truncate font-medium text-foreground">
+											{c.childTable}
+										</span>
+									</div>
 
 									<div className="ml-auto flex gap-1">
 										<Button
@@ -337,9 +415,7 @@ export const CreateConnection: React.FC<ConnectionProps> = ({
 					</Button>
 					<Button
 						variant="default"
-						onClick={() => {
-							onClose();
-						}}
+						onClick={handleSave}
 						disabled={error !== "" || save}
 						data-testid="save-connection"
 					>


### PR DESCRIPTION
## Summary
- **Live relationship preview**: the preview box now reactively shows the selected parent→child as you pick from the dropdowns, instead of being a static label
- **Cancel safety**: delete and add operations no longer immediately mutate the parent's edge state; all changes are batched and only emitted to the parent on Save, so Cancel truly discards changes
- **RDF terminology**: when `isRdf` is true, labels and placeholders read "Start Node" / "Child Node" instead of "Parent Table" / "Child Table"; the `isRdf` prop is threaded from `database-form.tsx` → `MetaModelType` → `CreateConnection`
- **Connection list typography**: replaced `<P>` with spacer margins with a flex row using `gap-1.5` and a compact `size-3.5` arrow icon; long names truncate cleanly

## Test plan
- [ ] Open CSV import → Define Metamodel → Create Relationship
- [ ] Select a parent and child table — confirm the preview box updates live
- [ ] Add a connection, then click Cancel — confirm the connection does NOT appear in the metamodel
- [ ] Delete an existing connection, then click Cancel — confirm the connection is still present in the metamodel
- [ ] Delete a connection, click Save — confirm the connection is removed
- [ ] Open Create Relationship for an RDF database — confirm labels read "Start Node" / "Child Node"