### PR TITLE
feat(database): add SPARQL query page with syntax highlighting and raw toggle

### DIFF
--- a/packages/client/src/components/database/index.ts
+++ b/packages/client/src/components/database/index.ts
@@ -2,5 +2,6 @@ export * from "./database-statistics";
 export * from "./database-structure-browser";
 export * from "./query-actions";
 export * from "./query-results-panel";
+export * from "./sparql-query-editor";
 export * from "./sql-query-editor";
 export * from "./sync-external-database-overlay";

--- a/packages/client/src/components/database/query-results-panel.tsx
+++ b/packages/client/src/components/database/query-results-panel.tsx
@@ -12,12 +12,12 @@ import {
 	TooltipTrigger,
 	toast,
 } from "@semoss/ui/next";
-import { useQueryResults } from "@/hooks/use-database-query-results";
 import {
 	getErrorMessage,
 	isErrorResponse,
 	type QueryResult,
-} from "@/hooks/useDatabaseQueryExecution";
+} from "@/hooks/use-database-query-execution";
+import { useQueryResults } from "@/hooks/use-database-query-results";
 
 interface QueryResultsPanelProps {
 	previewData: QueryResult | null;

--- a/packages/client/src/components/database/sparql-query-editor.tsx
+++ b/packages/client/src/components/database/sparql-query-editor.tsx
@@ -1,0 +1,376 @@
+import { Check, Copy, RotateCcw } from "lucide-react";
+import type React from "react";
+import { Suspense, useState } from "react";
+import { MonacoEditor } from "@semoss/shared";
+import { Button, cn, P } from "@semoss/ui/next";
+
+interface SPARQLQueryEditorProps {
+	query: string;
+	setQuery: (query: string) => void;
+	clearQuery: () => void;
+	handleEditorMount: (editor, monaco) => void;
+	executeQuery: () => void;
+	previewLoading: boolean;
+	onUserQueryInput?: (query: string) => void;
+	raw: boolean;
+	onRawChange: (raw: boolean) => void;
+}
+
+const SPARQL_KEYWORDS = [
+	"SELECT",
+	"CONSTRUCT",
+	"DESCRIBE",
+	"ASK",
+	"WHERE",
+	"PREFIX",
+	"BASE",
+	"FROM",
+	"NAMED",
+	"OPTIONAL",
+	"GRAPH",
+	"UNION",
+	"FILTER",
+	"ORDER",
+	"BY",
+	"GROUP",
+	"HAVING",
+	"LIMIT",
+	"OFFSET",
+	"DISTINCT",
+	"REDUCED",
+	"AS",
+	"BIND",
+	"VALUES",
+	"SERVICE",
+	"MINUS",
+	"INSERT",
+	"DELETE",
+	"LOAD",
+	"CLEAR",
+	"DROP",
+	"CREATE",
+	"ADD",
+	"MOVE",
+	"COPY",
+	"WITH",
+	"USING",
+	"NOT",
+	"EXISTS",
+	"IN",
+	"true",
+	"false",
+	"a",
+];
+
+const SPARQL_FUNCTIONS = [
+	"STR",
+	"LANG",
+	"DATATYPE",
+	"IRI",
+	"URI",
+	"BNODE",
+	"RAND",
+	"ABS",
+	"CEIL",
+	"FLOOR",
+	"ROUND",
+	"STRLEN",
+	"LCASE",
+	"UCASE",
+	"ENCODE_FOR_URI",
+	"CONTAINS",
+	"STRSTARTS",
+	"STRENDS",
+	"STRBEFORE",
+	"STRAFTER",
+	"SUBSTR",
+	"REPLACE",
+	"REGEX",
+	"YEAR",
+	"MONTH",
+	"DAY",
+	"HOURS",
+	"MINUTES",
+	"SECONDS",
+	"TIMEZONE",
+	"TZ",
+	"NOW",
+	"UUID",
+	"STRUUID",
+	"MD5",
+	"SHA1",
+	"SHA256",
+	"SHA384",
+	"SHA512",
+	"COALESCE",
+	"IF",
+	"STRLANG",
+	"STRDT",
+	"SAMETERM",
+	"ISIRI",
+	"ISURI",
+	"ISBLANK",
+	"ISLITERAL",
+	"ISNUMERIC",
+	"BOUND",
+	"CONCAT",
+	"COUNT",
+	"SUM",
+	"MIN",
+	"MAX",
+	"AVG",
+	"SAMPLE",
+	"GROUP_CONCAT",
+];
+
+function registerSparqlLanguage(monaco) {
+	const languages = monaco.languages.getLanguages();
+	if (languages.some((l) => l.id === "sparql")) return;
+
+	monaco.languages.register({ id: "sparql" });
+
+	monaco.languages.setMonarchTokensProvider("sparql", {
+		keywords: SPARQL_KEYWORDS.map((k) => k.toUpperCase()),
+		builtins: SPARQL_FUNCTIONS,
+		tokenizer: {
+			root: [
+				// Comments
+				[/#.*$/, "comment"],
+				// IRIs
+				[/<[^>]*>/, "type.identifier"],
+				// Prefixed names (prefix:localName)
+				[/[a-zA-Z_][\w-]*:[a-zA-Z_][\w-]*/, "type"],
+				// Variables
+				[/[?$][a-zA-Z_]\w*/, "variable"],
+				// String literals (double-quoted)
+				[/"([^"\\]|\\.)*"/, "string"],
+				// String literals (single-quoted)
+				[/'([^'\\]|\\.)*'/, "string"],
+				// Numeric literals
+				[/[+-]?\d+(\.\d+)?([eE][+-]?\d+)?/, "number"],
+				// Keywords and identifiers
+				[
+					/[a-zA-Z_]\w*/,
+					{
+						cases: {
+							"@keywords": "keyword",
+							"@builtins": "predefined",
+							"@default": "identifier",
+						},
+					},
+				],
+				// Operators and punctuation
+				[/[{}()[\]]/, "delimiter"],
+				[/[,;.]/, "delimiter"],
+				[/[=!<>|+\-*/&^~]+/, "operator"],
+			],
+		},
+	});
+
+	monaco.languages.registerCompletionItemProvider("sparql", {
+		provideCompletionItems: (model, position) => {
+			const word = model.getWordUntilPosition(position);
+			const range = {
+				startLineNumber: position.lineNumber,
+				endLineNumber: position.lineNumber,
+				startColumn: word.startColumn,
+				endColumn: word.endColumn,
+			};
+			const keywordSuggestions = SPARQL_KEYWORDS.map((kw) => ({
+				label: kw,
+				kind: monaco.languages.CompletionItemKind.Keyword,
+				insertText: kw,
+				range,
+			}));
+			const functionSuggestions = SPARQL_FUNCTIONS.map((fn) => ({
+				label: fn,
+				kind: monaco.languages.CompletionItemKind.Function,
+				insertText: `${fn}()`,
+				insertTextRules:
+					monaco.languages.CompletionItemInsertTextRule
+						.InsertAsSnippet,
+				range,
+			}));
+			return {
+				suggestions: [...keywordSuggestions, ...functionSuggestions],
+			};
+		},
+	});
+
+	monaco.editor.defineTheme("sparql-theme-dark", {
+		base: "vs-dark",
+		inherit: true,
+		rules: [
+			{ token: "keyword", foreground: "569cd6", fontStyle: "bold" },
+			{ token: "predefined", foreground: "dcdcaa" },
+			{ token: "type.identifier", foreground: "4ec9b0" },
+			{ token: "type", foreground: "4ec9b0" },
+			{ token: "variable", foreground: "9cdcfe" },
+			{ token: "comment", foreground: "6a9955", fontStyle: "italic" },
+			{ token: "string", foreground: "ce9178" },
+			{ token: "number", foreground: "b5cea8" },
+		],
+		colors: {},
+	});
+}
+
+export const SPARQLQueryEditor: React.FC<SPARQLQueryEditorProps> = ({
+	query,
+	setQuery,
+	clearQuery,
+	handleEditorMount,
+	executeQuery,
+	previewLoading,
+	onUserQueryInput,
+	raw,
+	onRawChange,
+}) => {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopyQuery = async () => {
+		if (query && navigator.clipboard) {
+			try {
+				await navigator.clipboard.writeText(query);
+				setCopied(true);
+				setTimeout(() => setCopied(false), 2000);
+			} catch (err) {
+				console.error("Failed to copy query:", err);
+			}
+		}
+	};
+
+	const handleMount = (editor, monaco) => {
+		registerSparqlLanguage(monaco);
+		monaco.editor.setTheme("sparql-theme-dark");
+		handleEditorMount(editor, monaco);
+	};
+
+	return (
+		<div
+			className="flex h-full flex-col overflow-hidden"
+			data-testid="sparql-query-editor"
+		>
+			{/* Header */}
+			<div className="flex flex-shrink-0 items-center justify-between border-border/50 border-b bg-gradient-to-r from-accent/50 via-accent/40 to-accent/30 px-4 py-2.5">
+				<h3
+					className="font-semibold text-foreground text-sm"
+					data-testid="query-editor-title"
+				>
+					Enter Query
+				</h3>
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={clearQuery}
+					className="h-8 gap-1.5 font-medium text-primary text-xs hover:bg-primary/10 hover:text-primary"
+					data-testid="query-reset-btn"
+				>
+					<RotateCcw className="size-3.5" />
+					Reset
+				</Button>
+			</div>
+
+			{/* Editor Container */}
+			<div className="group/query-editor relative m-2 flex flex-1 flex-col overflow-hidden rounded-2xl border-2 border-primary/40 bg-muted/30 shadow-lg transition-all duration-300 hover:border-primary/60 hover:shadow-xl">
+				{/* Copy Button */}
+				{query && (
+					<div className="pointer-events-none absolute top-3 right-3 z-10 opacity-0 transition-opacity group-focus-within/query-editor:pointer-events-auto group-focus-within/query-editor:opacity-100 group-hover/query-editor:pointer-events-auto group-hover/query-editor:opacity-100">
+						<Button
+							variant="secondary"
+							size="icon"
+							onClick={handleCopyQuery}
+							title={copied ? "Copied!" : "Copy query"}
+							className={cn(
+								"size-8 bg-background/80 shadow-md backdrop-blur-sm transition-all duration-200 hover:scale-105",
+							)}
+							data-testid="query-copy-btn"
+						>
+							{copied ? (
+								<Check className="size-4" />
+							) : (
+								<Copy className="size-4" />
+							)}
+						</Button>
+					</div>
+				)}
+
+				{/* Monaco Editor */}
+				<div className="relative h-full min-h-[200px] overflow-hidden bg-gradient-to-br from-card to-muted/50">
+					<Suspense
+						fallback={
+							<div className="flex h-full items-center justify-center p-4">
+								<div className="flex items-center gap-2">
+									<div className="size-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+									<P className="text-muted-foreground text-sm">
+										Loading editor...
+									</P>
+								</div>
+							</div>
+						}
+					>
+						<MonacoEditor
+							value={query}
+							defaultValue=""
+							language="sparql"
+							options={{
+								scrollbar: {
+									horizontal: "hidden",
+									horizontalScrollbarSize: 0,
+									alwaysConsumeMouseWheel: false,
+								},
+								readOnly: false,
+								minimap: { enabled: false },
+								automaticLayout: true,
+								scrollBeyondLastLine: false,
+								lineHeight: 20,
+								fontSize: 14,
+								overviewRulerBorder: false,
+								lineNumbers: "on",
+								glyphMargin: false,
+								folding: false,
+								lineNumbersMinChars: 3,
+								wordWrap: "on",
+								wrappingStrategy: "advanced",
+								tabSize: 4,
+								quickSuggestions: true,
+								suggestOnTriggerCharacters: true,
+								wordBasedSuggestions: false,
+								colorDecorators: true,
+								padding: { top: 12, bottom: 12 },
+								renderLineHighlight: "all",
+								cursorBlinking: "smooth",
+								smoothScrolling: true,
+							}}
+							onChange={(value) => {
+								const nextQuery = value || "";
+								setQuery(nextQuery);
+								onUserQueryInput?.(nextQuery);
+							}}
+							onMount={handleMount}
+						/>
+					</Suspense>
+				</div>
+			</div>
+
+			{/* Query Actions */}
+			<div className="flex flex-shrink-0 items-center justify-between border-border/50 border-t px-4 py-2">
+				<Button
+					variant={raw ? "default" : "outline"}
+					size="sm"
+					onClick={() => onRawChange(!raw)}
+					data-testid="sparql-raw-toggle-btn"
+				>
+					{raw ? "Raw: On" : "Raw: Off"}
+				</Button>
+				<Button
+					variant="default"
+					onClick={executeQuery}
+					disabled={previewLoading || !query.trim()}
+					data-testid="query-run-btn"
+				>
+					{previewLoading ? "Running..." : "Run Query"}
+				</Button>
+			</div>
+		</div>
+	);
+};

--- a/packages/client/src/hooks/index.ts
+++ b/packages/client/src/hooks/index.ts
@@ -1,10 +1,11 @@
 import { useQueryResults } from "./use-database-query-results";
 import { usePixel } from "./use-pixel";
+import { useSparqlQueryExecution } from "./use-sparql-query-execution";
+import { useSqlQueryExecution } from "./use-sql-query-execution";
 import { useTabBarScroll } from "./use-tab-bar-scroll";
 import { useAPI } from "./useAPI";
 import { useCacheState } from "./useCacheState";
 import { useQueryEditor } from "./useDatabaseQueryEditor";
-import { useQueryExecution } from "./useDatabaseQueryExecution";
 import { useDatabaseStructure } from "./useDatabaseStructure";
 import { useDesigner } from "./useDesigner";
 import { useEngine } from "./useEngine";
@@ -32,7 +33,8 @@ export {
 	usePage,
 	usePixel,
 	useQueryEditor,
-	useQueryExecution,
+	useSqlQueryExecution,
+	useSparqlQueryExecution,
 	useQueryResults,
 	useRootStore,
 	useServerPagination,

--- a/packages/client/src/hooks/use-database-query-execution.ts
+++ b/packages/client/src/hooks/use-database-query-execution.ts
@@ -66,18 +66,17 @@ export const hasTabularData = (response: unknown): boolean => {
 
 interface QueryExecutionOptions {
 	onSchemaChange?: () => void;
-	buildPixel?: (engineId: string, query: string) => string;
 }
 
-export function useQueryExecution(
+export function useDatabaseQueryExecution(
 	engineId: string,
+	buildPixel: (engineId: string, query: string) => string,
 	options: QueryExecutionOptions = {},
 ) {
 	const [query, setQuery] = useState("");
 	const [previewData, setPreviewData] = useState<QueryResult | null>(null);
 	const [previewLoading, setPreviewLoading] = useState(false);
 	const [pixelQuery, setPixelQuery] = useState<string | null>(null);
-	// const [limit, setLimit] = useState(500);
 
 	const clearQuery = () => {
 		setQuery("");
@@ -102,25 +101,19 @@ export function useQueryExecution(
 		setPreviewLoading(true);
 
 		try {
-			const pixel = options.buildPixel
-				? options.buildPixel(engineId, queryToRun.replaceAll("`", ""))
-				: `SqlQuery(database=["${engineId}"], query=["<encode>${queryToRun.replaceAll("`", "")}</encode>"], commit = [true]);`;
+			const pixel = buildPixel(engineId, queryToRun.replaceAll("`", ""));
 			setPixelQuery(pixel);
 
 			const response = await runPixel(pixel);
-			console.log("Full response:", response);
 
 			let resultToStore: QueryResult;
 			if (response?.pixelReturn && response.pixelReturn.length > 0) {
-				const firstResult = response.pixelReturn[0];
-				console.log("Setting data to:", firstResult);
 				resultToStore = {
-					...firstResult,
+					...response.pixelReturn[0],
 					queryType: "OTHER",
 					queryText: queryToRun,
 				};
 			} else {
-				console.log("No pixelReturn found, using full response");
 				resultToStore = {
 					output: response,
 					queryType: "OTHER",
@@ -140,15 +133,11 @@ export function useQueryExecution(
 				!isErrorResponse(resultToStore) &&
 				!hasTabularData(resultToStore)
 			) {
-				console.log(
-					"Non-tabular response detected. Refreshing schema.",
-				);
 				setTimeout(() => options.onSchemaChange?.(), 100);
 			}
 		} catch (error: unknown) {
 			const message =
 				error instanceof Error ? error.message : "Unknown error";
-			console.error("Query execution error:", error);
 			setPreviewData({
 				error: true,
 				output: `Error: ${message}`,
@@ -170,7 +159,5 @@ export function useQueryExecution(
 		clearResults,
 		executeQuery,
 		pixelQuery,
-		// limit,
-		// setLimit
 	};
 }

--- a/packages/client/src/hooks/use-database-query-results.tsx
+++ b/packages/client/src/hooks/use-database-query-results.tsx
@@ -4,7 +4,7 @@ import {
 	hasTabularData,
 	isErrorResponse,
 	type QueryResult,
-} from "./useDatabaseQueryExecution";
+} from "./use-database-query-execution";
 
 export function useQueryResults() {
 	const renderResults = (

--- a/packages/client/src/hooks/use-sparql-query-execution.ts
+++ b/packages/client/src/hooks/use-sparql-query-execution.ts
@@ -1,0 +1,18 @@
+import { useDatabaseQueryExecution } from "./use-database-query-execution";
+
+interface SparqlQueryExecutionOptions {
+	onSchemaChange?: () => void;
+}
+
+export function useSparqlQueryExecution(
+	engineId: string,
+	raw: boolean,
+	options: SparqlQueryExecutionOptions = {},
+) {
+	return useDatabaseQueryExecution(
+		engineId,
+		(id, query) =>
+			`SparqlQuery(database=["${id}"], query=["<encode>${query}</encode>"], raw=[${raw}], commit=[true]);`,
+		options,
+	);
+}

--- a/packages/client/src/hooks/use-sql-query-execution.ts
+++ b/packages/client/src/hooks/use-sql-query-execution.ts
@@ -1,0 +1,17 @@
+import { useDatabaseQueryExecution } from "./use-database-query-execution";
+
+interface SqlQueryExecutionOptions {
+	onSchemaChange?: () => void;
+}
+
+export function useSqlQueryExecution(
+	engineId: string,
+	options: SqlQueryExecutionOptions = {},
+) {
+	return useDatabaseQueryExecution(
+		engineId,
+		(id, query) =>
+			`SqlQuery(database=["${id}"], query=["<encode>${query}</encode>"], commit=[true]);`,
+		options,
+	);
+}

--- a/packages/client/src/hooks/useDatabaseQueryExecution.ts
+++ b/packages/client/src/hooks/useDatabaseQueryExecution.ts
@@ -66,6 +66,7 @@ export const hasTabularData = (response: unknown): boolean => {
 
 interface QueryExecutionOptions {
 	onSchemaChange?: () => void;
+	buildPixel?: (engineId: string, query: string) => string;
 }
 
 export function useQueryExecution(
@@ -101,7 +102,9 @@ export function useQueryExecution(
 		setPreviewLoading(true);
 
 		try {
-			const pixel = `SqlQuery(database=["${engineId}"], query=["<encode>${queryToRun.replaceAll("`", "")}</encode>"], commit = [true]);`;
+			const pixel = options.buildPixel
+				? options.buildPixel(engineId, queryToRun.replaceAll("`", ""))
+				: `SqlQuery(database=["${engineId}"], query=["<encode>${queryToRun.replaceAll("`", "")}</encode>"], commit = [true]);`;
 			setPixelQuery(pixel);
 
 			const response = await runPixel(pixel);

--- a/packages/client/src/pages/engine/engine-layout.tsx
+++ b/packages/client/src/pages/engine/engine-layout.tsx
@@ -178,13 +178,15 @@ export const EngineLayout: React.FC<EngineLayoutProps> = ({ route }) => {
 			t.restrict ? t.restrict.indexOf(permission) > -1 : true,
 		);
 
-		// additional filtering for DATABASE type engines - hide Query tab unless database is SQL
+		// additional filtering for DATABASE type engines - hide Query/SPARQL tabs based on category
 		if (route.type === "DATABASE") {
 			const databaseCategory = getDatabaseCategory.data;
 			filteredTabs = filteredTabs.filter((t) => {
-				// if it's the Query tab (path === 'query'), only show it if database is SQL
 				if (t.path === "query") {
 					return databaseCategory === "SQL";
+				}
+				if (t.path === "sparql-query") {
+					return databaseCategory === "RDF";
 				}
 				return true;
 			});

--- a/packages/client/src/pages/engine/engine-sparql-query-page.tsx
+++ b/packages/client/src/pages/engine/engine-sparql-query-page.tsx
@@ -4,7 +4,7 @@ import { Card, cn } from "@semoss/ui/next";
 import {
 	DatabaseStructureBrowser,
 	QueryResultsPanel,
-	SQLQueryEditor,
+	SPARQLQueryEditor,
 } from "@/components/database";
 import {
 	useDatabaseStructure,
@@ -14,11 +14,11 @@ import {
 } from "@/hooks";
 import { hasTabularData } from "@/hooks/useDatabaseQueryExecution";
 
-export const EngineQueryDataPage = observer(() => {
+export const EngineSparqlQueryPage = observer(() => {
 	const { active } = useEngine();
 	const [refreshMessage, setRefreshMessage] = useState<string | null>(null);
 	const [isQueryResultsExpanded, setIsQueryResultsExpanded] = useState(false);
-	const [isUserModifiedQuery, setIsUserModifiedQuery] = useState(false);
+	const [raw, setRaw] = useState(true);
 
 	// Resize states
 	const [bottomPanelHeight, setBottomPanelHeight] = useState(300); // pixels
@@ -58,7 +58,6 @@ export const EngineQueryDataPage = observer(() => {
 		activeTable,
 		toggleColumnSelection,
 		clearColumnSelection,
-		generateSelectedColumnsQuery,
 	} = useDatabaseStructure(active.id || "");
 
 	const {
@@ -74,6 +73,8 @@ export const EngineQueryDataPage = observer(() => {
 		onSchemaChange: () => {
 			refreshDatabaseStructure();
 		},
+		buildPixel: (engineId, sparqlQuery) =>
+			`SparqlQuery(database=["${engineId}"], query=["<encode>${sparqlQuery}</encode>"], raw=[${raw}], commit=[true]);`,
 	});
 
 	const executeQuery = async (queryOverride?: string) => {
@@ -90,7 +91,6 @@ export const EngineQueryDataPage = observer(() => {
 	const clearQuery = () => {
 		clearQueryInternal();
 		setValue("");
-		setIsUserModifiedQuery(false);
 	};
 
 	const setQueryProgrammatically = useCallback(
@@ -100,14 +100,6 @@ export const EngineQueryDataPage = observer(() => {
 			setValue(nextQuery);
 		},
 		[setQuery, setValue],
-	);
-
-	const setGeneratedQuery = useCallback(
-		(nextQuery: string) => {
-			setQueryProgrammatically(nextQuery);
-			setIsUserModifiedQuery(false);
-		},
-		[setQueryProgrammatically],
 	);
 
 	const appendQueryToken = useCallback(
@@ -126,17 +118,6 @@ export const EngineQueryDataPage = observer(() => {
 		},
 		[query, setQueryProgrammatically],
 	);
-
-	const generateTableQuery = (tableName: string) => {
-		if (!query.trim() || !isUserModifiedQuery) {
-			const sql = `SELECT * FROM ${tableName}`;
-			setGeneratedQuery(sql);
-			clearColumnSelection();
-			return;
-		}
-
-		appendQueryToken(tableName);
-	};
 
 	const handleToggleColumnSelection = (
 		tableName: string,
@@ -158,7 +139,6 @@ export const EngineQueryDataPage = observer(() => {
 			}
 
 			ignoreProgrammaticQueryValueRef.current = null;
-			setIsUserModifiedQuery(true);
 
 			if (
 				activeTable &&
@@ -177,15 +157,6 @@ export const EngineQueryDataPage = observer(() => {
 		},
 		[appendQueryToken],
 	);
-
-	const handleGenerateQuery = useCallback(
-		(generatedQuery: string) => {
-			setGeneratedQuery(generatedQuery);
-		},
-		[setGeneratedQuery],
-	);
-
-	const canAutoGenerateQuery = !query.trim() || !isUserModifiedQuery;
 
 	// Vertical resize handlers
 	const handleVerticalResizeStart = useCallback((e: React.MouseEvent) => {
@@ -317,7 +288,6 @@ export const EngineQueryDataPage = observer(() => {
 							error={error}
 							refreshDatabaseStructure={handleRefresh}
 							refreshMessage={refreshMessage}
-							onTableClick={generateTableQuery}
 							selectedColumns={selectedColumns}
 							activeTable={activeTable}
 							onToggleColumnSelection={
@@ -325,16 +295,11 @@ export const EngineQueryDataPage = observer(() => {
 							}
 							onClearColumnSelection={handleClearColumnSelection}
 							onColumnNameInsert={handleColumnNameInsert}
-							onGenerateQuery={handleGenerateQuery}
-							generateSelectedColumnsQuery={
-								generateSelectedColumnsQuery
-							}
-							canAutoGenerateQuery={canAutoGenerateQuery}
 						/>
 					</Card>
 				</div>
 
-				{/* Right Panel - SQL Query Editor */}
+				{/* Right Panel - SPARQL Query Editor */}
 				<div
 					className="flex flex-col transition-all duration-200"
 					style={
@@ -344,7 +309,7 @@ export const EngineQueryDataPage = observer(() => {
 					}
 				>
 					<Card className="group flex h-[calc(100%-2rem)] flex-col overflow-hidden rounded-2xl p-0">
-						<SQLQueryEditor
+						<SPARQLQueryEditor
 							query={query}
 							setQuery={setQuery}
 							clearQuery={clearQuery}
@@ -352,6 +317,8 @@ export const EngineQueryDataPage = observer(() => {
 							executeQuery={executeQuery}
 							previewLoading={previewLoading}
 							onUserQueryInput={handleUserQueryInput}
+							raw={raw}
+							onRawChange={setRaw}
 						/>
 					</Card>
 				</div>

--- a/packages/client/src/pages/engine/engine-sparql-query-page.tsx
+++ b/packages/client/src/pages/engine/engine-sparql-query-page.tsx
@@ -10,9 +10,9 @@ import {
 	useDatabaseStructure,
 	useEngine,
 	useQueryEditor,
-	useQueryExecution,
+	useSparqlQueryExecution,
 } from "@/hooks";
-import { hasTabularData } from "@/hooks/useDatabaseQueryExecution";
+import { hasTabularData } from "@/hooks/use-database-query-execution";
 
 export const EngineSparqlQueryPage = observer(() => {
 	const { active } = useEngine();
@@ -69,12 +69,10 @@ export const EngineSparqlQueryPage = observer(() => {
 		clearResults,
 		executeQuery: executeQueryInternal,
 		pixelQuery,
-	} = useQueryExecution(active.id || "", {
+	} = useSparqlQueryExecution(active.id || "", raw, {
 		onSchemaChange: () => {
 			refreshDatabaseStructure();
 		},
-		buildPixel: (engineId, sparqlQuery) =>
-			`SparqlQuery(database=["${engineId}"], query=["<encode>${sparqlQuery}</encode>"], raw=[${raw}], commit=[true]);`,
 	});
 
 	const executeQuery = async (queryOverride?: string) => {
@@ -371,7 +369,7 @@ export const EngineSparqlQueryPage = observer(() => {
 							previewLoading={previewLoading}
 							clearResults={clearResults}
 							onExpandChange={setIsQueryResultsExpanded}
-							pixelQuery={pixelQuery}
+							pixelQuery={pixelQuery ?? undefined}
 						/>
 					</div>
 				</div>

--- a/packages/client/src/pages/engine/engine-sql-query-page.tsx
+++ b/packages/client/src/pages/engine/engine-sql-query-page.tsx
@@ -10,9 +10,9 @@ import {
 	useDatabaseStructure,
 	useEngine,
 	useQueryEditor,
-	useQueryExecution,
+	useSqlQueryExecution,
 } from "@/hooks";
-import { hasTabularData } from "@/hooks/useDatabaseQueryExecution";
+import { hasTabularData } from "@/hooks/use-database-query-execution";
 
 export const EngineSqlQueryPage = observer(() => {
 	const { active } = useEngine();
@@ -70,7 +70,7 @@ export const EngineSqlQueryPage = observer(() => {
 		clearResults,
 		executeQuery: executeQueryInternal,
 		pixelQuery,
-	} = useQueryExecution(active.id || "", {
+	} = useSqlQueryExecution(active.id || "", {
 		onSchemaChange: () => {
 			refreshDatabaseStructure();
 		},
@@ -404,7 +404,7 @@ export const EngineSqlQueryPage = observer(() => {
 							previewLoading={previewLoading}
 							clearResults={clearResults}
 							onExpandChange={setIsQueryResultsExpanded}
-							pixelQuery={pixelQuery}
+							pixelQuery={pixelQuery ?? undefined}
 						/>
 					</div>
 				</div>

--- a/packages/client/src/pages/engine/engine-sql-query-page.tsx
+++ b/packages/client/src/pages/engine/engine-sql-query-page.tsx
@@ -1,0 +1,429 @@
+import { observer } from "mobx-react-lite";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Card, cn } from "@semoss/ui/next";
+import {
+	DatabaseStructureBrowser,
+	QueryResultsPanel,
+	SQLQueryEditor,
+} from "@/components/database";
+import {
+	useDatabaseStructure,
+	useEngine,
+	useQueryEditor,
+	useQueryExecution,
+} from "@/hooks";
+import { hasTabularData } from "@/hooks/useDatabaseQueryExecution";
+
+export const EngineSqlQueryPage = observer(() => {
+	const { active } = useEngine();
+	const [refreshMessage, setRefreshMessage] = useState<string | null>(null);
+	const [isQueryResultsExpanded, setIsQueryResultsExpanded] = useState(false);
+	const [isUserModifiedQuery, setIsUserModifiedQuery] = useState(false);
+
+	// Resize states
+	const [bottomPanelHeight, setBottomPanelHeight] = useState(300); // pixels
+	const [isResizingVertical, setIsResizingVertical] = useState(false);
+
+	const [isMobile, setIsMobile] = useState(
+		() => typeof window !== "undefined" && window.innerWidth < 768,
+	);
+
+	const containerRef = useRef<HTMLDivElement>(null);
+	const ignoreProgrammaticQueryValueRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		const handleResize = () => setIsMobile(window.innerWidth < 768);
+		window.addEventListener("resize", handleResize);
+		return () => window.removeEventListener("resize", handleResize);
+	}, []);
+
+	const handleRefresh = () => {
+		setRefreshMessage("Refreshing database structure...");
+		refreshDatabaseStructure();
+		setTimeout(() => setRefreshMessage(null), 3000);
+	};
+
+	const {
+		structure,
+		searchTerm,
+		setSearchTerm,
+		searchedStructure,
+		expandedTables,
+		toggleTable,
+		toggleAllTables,
+		isLoading,
+		error,
+		refreshDatabaseStructure,
+		selectedColumns,
+		activeTable,
+		toggleColumnSelection,
+		clearColumnSelection,
+		generateSelectedColumnsQuery,
+	} = useDatabaseStructure(active.id || "");
+
+	const {
+		query,
+		setQuery,
+		previewData,
+		previewLoading,
+		clearQuery: clearQueryInternal,
+		clearResults,
+		executeQuery: executeQueryInternal,
+		pixelQuery,
+	} = useQueryExecution(active.id || "", {
+		onSchemaChange: () => {
+			refreshDatabaseStructure();
+		},
+	});
+
+	const executeQuery = async (queryOverride?: string) => {
+		await executeQueryInternal(queryOverride);
+	};
+
+	const { handleEditorMount, setValue } = useQueryEditor({
+		onRun: (value) => {
+			executeQuery(value);
+		},
+		tables: structure.tables,
+	});
+
+	const clearQuery = () => {
+		clearQueryInternal();
+		setValue("");
+		setIsUserModifiedQuery(false);
+	};
+
+	const setQueryProgrammatically = useCallback(
+		(nextQuery: string) => {
+			ignoreProgrammaticQueryValueRef.current = nextQuery;
+			setQuery(nextQuery);
+			setValue(nextQuery);
+		},
+		[setQuery, setValue],
+	);
+
+	const setGeneratedQuery = useCallback(
+		(nextQuery: string) => {
+			setQueryProgrammatically(nextQuery);
+			setIsUserModifiedQuery(false);
+		},
+		[setQueryProgrammatically],
+	);
+
+	const appendQueryToken = useCallback(
+		(token: string) => {
+			const trimmedToken = token.trim();
+			if (!trimmedToken) {
+				return;
+			}
+
+			const shouldAddSpace = query.length > 0 && !/[\s(,]$/.test(query);
+			const nextQuery = shouldAddSpace
+				? `${query} ${trimmedToken}`
+				: `${query}${trimmedToken}`;
+
+			setQueryProgrammatically(nextQuery);
+		},
+		[query, setQueryProgrammatically],
+	);
+
+	const generateTableQuery = (tableName: string) => {
+		if (!query.trim() || !isUserModifiedQuery) {
+			const sql = `SELECT * FROM ${tableName}`;
+			setGeneratedQuery(sql);
+			clearColumnSelection();
+			return;
+		}
+
+		appendQueryToken(tableName);
+	};
+
+	const handleToggleColumnSelection = (
+		tableName: string,
+		columnName: string,
+	) => {
+		toggleColumnSelection(tableName, columnName);
+	};
+
+	const handleClearColumnSelection = () => {
+		clearColumnSelection();
+		clearQuery();
+	};
+
+	const handleUserQueryInput = useCallback(
+		(nextQuery: string) => {
+			if (ignoreProgrammaticQueryValueRef.current === nextQuery) {
+				ignoreProgrammaticQueryValueRef.current = null;
+				return;
+			}
+
+			ignoreProgrammaticQueryValueRef.current = null;
+			setIsUserModifiedQuery(true);
+
+			if (
+				activeTable &&
+				selectedColumns[activeTable] &&
+				selectedColumns[activeTable].length > 0
+			) {
+				clearColumnSelection();
+			}
+		},
+		[activeTable, selectedColumns, clearColumnSelection],
+	);
+
+	const handleColumnNameInsert = useCallback(
+		(_tableName: string, columnName: string) => {
+			appendQueryToken(columnName);
+		},
+		[appendQueryToken],
+	);
+
+	const handleGenerateQuery = useCallback(
+		(generatedQuery: string) => {
+			setGeneratedQuery(generatedQuery);
+		},
+		[setGeneratedQuery],
+	);
+
+	const canAutoGenerateQuery = !query.trim() || !isUserModifiedQuery;
+
+	// Vertical resize handlers
+	const handleVerticalResizeStart = useCallback((e: React.MouseEvent) => {
+		e.preventDefault();
+		setIsResizingVertical(true);
+	}, []);
+
+	const handleVerticalResize = useCallback(
+		(e: MouseEvent) => {
+			if (!isResizingVertical || !containerRef.current) return;
+
+			const container = containerRef.current;
+			const containerRect = container.getBoundingClientRect();
+			const containerHeight = containerRect.height;
+
+			// Calculate new bottom panel height from bottom
+			const newHeight = containerRect.bottom - e.clientY;
+
+			// Constrain between 200px and 80% of container height
+			const constrainedHeight = Math.max(
+				200,
+				Math.min(containerHeight * 0.8, newHeight),
+			);
+
+			setBottomPanelHeight(constrainedHeight);
+		},
+		[isResizingVertical],
+	);
+
+	const handleVerticalResizeEnd = useCallback(() => {
+		setIsResizingVertical(false);
+	}, []);
+
+	useEffect(() => {
+		if (
+			isMobile ||
+			isQueryResultsExpanded ||
+			isResizingVertical ||
+			previewLoading ||
+			!previewData ||
+			!hasTabularData(previewData)
+		) {
+			return;
+		}
+
+		const containerHeight =
+			containerRef.current?.getBoundingClientRect().height ??
+			window.innerHeight;
+		const targetHeight = Math.max(
+			320,
+			Math.min(520, containerHeight * 0.45),
+		);
+
+		if (bottomPanelHeight < targetHeight) {
+			setBottomPanelHeight(targetHeight);
+		}
+	}, [
+		isMobile,
+		isQueryResultsExpanded,
+		isResizingVertical,
+		previewLoading,
+		previewData,
+		bottomPanelHeight,
+	]);
+
+	useEffect(() => {
+		if (isResizingVertical) {
+			document.addEventListener("mousemove", handleVerticalResize);
+			document.addEventListener("mouseup", handleVerticalResizeEnd);
+			document.body.style.cursor = "row-resize";
+			document.body.style.userSelect = "none";
+
+			return () => {
+				document.removeEventListener("mousemove", handleVerticalResize);
+				document.removeEventListener(
+					"mouseup",
+					handleVerticalResizeEnd,
+				);
+				document.body.style.cursor = "";
+				document.body.style.userSelect = "";
+			};
+		}
+	}, [isResizingVertical, handleVerticalResize, handleVerticalResizeEnd]);
+
+	return (
+		<div
+			ref={containerRef}
+			className="relative flex h-screen w-full flex-col overflow-hidden bg-gradient-to-br from-background via-background to-muted/20"
+			data-testid="queryDataPage-container"
+		>
+			{/* Main Content Area */}
+			<div
+				className={cn(
+					"min-h-0 w-full flex-1 transition-opacity duration-500 ease-out",
+					isMobile ? "flex flex-col overflow-y-auto" : "flex",
+					isQueryResultsExpanded
+						? "pointer-events-none opacity-0"
+						: "opacity-100",
+				)}
+				style={
+					isMobile
+						? undefined
+						: {
+								height: isQueryResultsExpanded
+									? 0
+									: `calc(100% - ${bottomPanelHeight}px)`,
+							}
+				}
+				data-testid="engine-queryDataPage-content"
+			>
+				{/* Left Panel - Database Structure Browser */}
+				<div
+					className="flex flex-col transition-all duration-200"
+					style={
+						isMobile
+							? { width: "100%", height: "280px", flexShrink: 0 }
+							: { width: "32%", minWidth: "280px" }
+					}
+				>
+					<Card className="group flex h-[calc(100%-2rem)] flex-col overflow-hidden rounded-2xl border border-border/50 bg-card/95 p-0 shadow-lg backdrop-blur-sm transition-all duration-300 hover:border-primary/20 hover:shadow-xl">
+						<DatabaseStructureBrowser
+							searchTerm={searchTerm}
+							setSearchTerm={setSearchTerm}
+							searchedStructure={searchedStructure}
+							expandedTables={expandedTables}
+							toggleTable={toggleTable}
+							toggleAllTables={toggleAllTables}
+							isLoading={isLoading}
+							error={error}
+							refreshDatabaseStructure={handleRefresh}
+							refreshMessage={refreshMessage}
+							onTableClick={generateTableQuery}
+							selectedColumns={selectedColumns}
+							activeTable={activeTable}
+							onToggleColumnSelection={
+								handleToggleColumnSelection
+							}
+							onClearColumnSelection={handleClearColumnSelection}
+							onColumnNameInsert={handleColumnNameInsert}
+							onGenerateQuery={handleGenerateQuery}
+							generateSelectedColumnsQuery={
+								generateSelectedColumnsQuery
+							}
+							canAutoGenerateQuery={canAutoGenerateQuery}
+						/>
+					</Card>
+				</div>
+
+				{/* Right Panel - SQL Query Editor */}
+				<div
+					className="flex flex-col transition-all duration-200"
+					style={
+						isMobile
+							? { width: "100%", height: "300px", flexShrink: 0 }
+							: { flex: 1, minWidth: "400px" }
+					}
+				>
+					<Card className="group flex h-[calc(100%-2rem)] flex-col overflow-hidden rounded-2xl p-0">
+						<SQLQueryEditor
+							query={query}
+							setQuery={setQuery}
+							clearQuery={clearQuery}
+							handleEditorMount={handleEditorMount}
+							executeQuery={executeQuery}
+							previewLoading={previewLoading}
+							onUserQueryInput={handleUserQueryInput}
+						/>
+					</Card>
+				</div>
+			</div>
+
+			{/* Query Results Panel - Expandable Full Screen */}
+			<div
+				className={cn(
+					"flex flex-col transition-all duration-500 ease-out",
+					isQueryResultsExpanded
+						? "absolute inset-0 z-50 size-full"
+						: "relative w-full flex-shrink-0",
+				)}
+				style={{
+					height: isQueryResultsExpanded
+						? "100%"
+						: isMobile
+							? "400px"
+							: `${bottomPanelHeight}px`,
+				}}
+				data-testid="query-results-wrapper"
+			>
+				{/* Vertical Resize Handle - Desktop only */}
+				{!isQueryResultsExpanded && !isMobile && (
+					<button
+						type="button"
+						onMouseDown={handleVerticalResizeStart}
+						className="h-2 w-full flex-shrink-0 cursor-row-resize transition-colors hover:bg-primary/5"
+						data-testid="vertical-resize-handle"
+						aria-label="Resize panels vertically"
+					/>
+				)}
+
+				<div
+					className={cn(
+						"flex flex-col transition-all duration-500",
+						isQueryResultsExpanded
+							? "h-full"
+							: "h-[calc(100%-0.5rem)]",
+					)}
+				>
+					<div
+						className={cn(
+							"h-full",
+							!isQueryResultsExpanded && "pb-4",
+						)}
+					>
+						<QueryResultsPanel
+							previewData={previewData}
+							previewLoading={previewLoading}
+							clearResults={clearResults}
+							onExpandChange={setIsQueryResultsExpanded}
+							pixelQuery={pixelQuery}
+						/>
+					</div>
+				</div>
+			</div>
+
+			{/* Refresh Message Toast */}
+			{refreshMessage && (
+				<div
+					className="slide-in-from-bottom-5 fade-in fixed right-6 bottom-6 z-50 animate-in duration-300"
+					data-testid="refresh-toast"
+				>
+					<div className="flex items-center gap-3 rounded-xl border border-primary/20 bg-primary/10 px-4 py-3 shadow-lg backdrop-blur-md">
+						<div className="size-2 animate-pulse rounded-full bg-primary" />
+						<p className="font-medium text-foreground text-sm">
+							{refreshMessage}
+						</p>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+});

--- a/packages/client/src/pages/engine/engine.constants.ts
+++ b/packages/client/src/pages/engine/engine.constants.ts
@@ -10,9 +10,10 @@ import { EngineMetadataPage } from "./engine-metadata-page";
 import { EngineModelChatPage } from "./engine-model-chat-page";
 import { EngineOverviewPage } from "./engine-overview-page";
 import { EngineQAPage } from "./engine-qa-page";
-import { EngineQueryDataPage } from "./engine-query-data-page";
 import { EngineSettingsPage } from "./engine-settingsPage";
 import { EngineSmssPage } from "./engine-smss-page";
+import { EngineSparqlQueryPage } from "./engine-sparql-query-page";
+import { EngineSqlQueryPage } from "./engine-sql-query-page";
 import { EngineStorageViewerPage } from "./engine-storage-viewer-page";
 import { EngineUsagePage } from "./engine-usage-page";
 
@@ -186,7 +187,13 @@ export const ENGINE_ROUTES: {
 			{
 				name: "Query",
 				path: "query",
-				component: EngineQueryDataPage,
+				component: EngineSqlQueryPage,
+				restrict: ["READ_ONLY", "EDIT", "OWNER"],
+			},
+			{
+				name: "Query",
+				path: "sparql-query",
+				component: EngineSparqlQueryPage,
 				restrict: ["READ_ONLY", "EDIT", "OWNER"],
 			},
 			{

--- a/packages/client/src/pages/settings/admin-query-page.tsx
+++ b/packages/client/src/pages/settings/admin-query-page.tsx
@@ -18,7 +18,7 @@ import {
 	hasTabularData,
 	isErrorResponse,
 	type QueryResult,
-} from "@/hooks/useDatabaseQueryExecution";
+} from "@/hooks/use-database-query-execution";
 
 const DATABASE_OPTIONS = [
 	{ label: "Audit Logs", value: "AuditLogs" },


### PR DESCRIPTION
## Summary
- **Rename** `engine-query-data-page` → `engine-sql-query-page` (component: `EngineSqlQueryPage`) to make the SQL-specific nature explicit
- **New SPARQL query page** (`engine-sparql-query-page.tsx`) — shown only for RDF databases via `GetDatabaseCategory` filtering in `engine-layout.tsx`
- **SPARQL Monaco editor** (`sparql-query-editor.tsx`) — registers a custom `sparql` language with a full Monarch tokenizer (keywords, built-in functions, IRIs, prefixed names, variables, comments) and keyword/function autocomplete
- **Raw toggle** — button next to Run Query defaults to `Raw: On`; passes `raw=[true/false]` into the `SparqlQuery` pixel reactor
- **Pixel format**: `SparqlQuery(database=["<id>"], query=["<encode>...</encode>"], raw=[true/false], commit=[true])`
- **`buildPixel` option** added to `useQueryExecution` hook so the SPARQL page can override pixel construction without touching the SQL path

## Test plan
- [ ] Open an RDF database — confirm "Query" tab appears (SPARQL page) and SQL databases do not show it
- [ ] Open a SQL database — confirm "Query" tab appears (SQL page) and not the SPARQL one
- [ ] Type a SPARQL query — confirm keywords (SELECT, WHERE, PREFIX) highlight in blue, functions (COUNT, REGEX) in yellow, IRIs in teal, variables in light blue
- [ ] Autocomplete triggers on keywords and functions
- [ ] Toggle Raw button — confirm it switches between filled/outline and the pixel includes `raw=[true]` / `raw=[false]`
- [ ] Run a query — confirm pixel sent matches `SparqlQuery(...)` format