### PR TITLE
fix(import): fix prop file toggle, remove dead code, unify field keys

### DIFF
--- a/packages/client/src/components/import/database/database-form.tsx
+++ b/packages/client/src/components/import/database/database-form.tsx
@@ -1340,7 +1340,11 @@ export const DatabaseForm = ({
 					case "zip-upload":
 						return (
 							<div
-								className={`flex flex-col gap-2${val.hidden ? "hidden" : ""}`}
+								className={
+									val.hidden
+										? "flex hidden flex-col gap-2"
+										: "flex flex-col gap-2"
+								}
 								data-testid={`database-form-field-${val.key}`}
 							>
 								<P>

--- a/packages/client/src/components/import/database/database-form.tsx
+++ b/packages/client/src/components/import/database/database-form.tsx
@@ -105,6 +105,7 @@ export const DatabaseForm = ({
 		control,
 		handleSubmit,
 		watch,
+		getValues,
 		setValue,
 		setFocus,
 		formState,
@@ -135,6 +136,22 @@ export const DatabaseForm = ({
 	const databaseType = watch("DATABASE_TYPE");
 	const metamodelType = watch("METAMODEL_TYPE");
 
+	type MetaOpt = { display: string; value: string };
+	const metamodelOptions = useMemo(() => {
+		const type = databaseType?.toLowerCase();
+		const allOpts: MetaOpt[] =
+			(
+				fields.find(
+					(f: { key: string }) => f.key === "METAMODEL_TYPE",
+				) as { options?: { options?: MetaOpt[] } } | undefined
+			)?.options?.options ?? [];
+		if (type === "rdf")
+			return allOpts.filter((o) => o.value !== "asFlatTable");
+		if (type === "r" || type === "h2")
+			return allOpts.filter((o) => o.value === "asFlatTable");
+		return allOpts;
+	}, [databaseType, fields]);
+
 	useEffect(() => {
 		const isPropFile = metamodelType === "fromPropFile";
 		setResolvedFields((prev) =>
@@ -160,12 +177,12 @@ export const DatabaseForm = ({
 			filteredOptions = originalOptions.filter(
 				(opt: MetaOpt) => opt.value !== "asFlatTable",
 			);
-		} else if (type) {
+		} else if (type === "r" || type === "h2") {
 			filteredOptions = originalOptions.filter(
 				(opt: MetaOpt) => opt.value === "asFlatTable",
 			);
 		}
-		const currentValue = watch("METAMODEL_TYPE");
+		const currentValue = getValues("METAMODEL_TYPE");
 		const valueStillValid = filteredOptions.some(
 			(opt: MetaOpt) => opt.value === currentValue,
 		);
@@ -184,6 +201,7 @@ export const DatabaseForm = ({
 				};
 			}),
 		);
+		// biome-ignore lint/correctness/useExhaustiveDependencies: getValues/setValue are stable react-hook-form refs
 	}, [databaseType, fields]);
 
 	const grouped = defaultFields.reduce((acc, f) => {
@@ -231,8 +249,8 @@ export const DatabaseForm = ({
 						...(formData.DATABASE_DESCRIPTION && {
 							description: formData.DATABASE_DESCRIPTION,
 						}),
-						...(formData.DATABASE_TAGS && {
-							tag: formData.DATABASE_TAGS,
+						...(formData.DATABASE_TAG && {
+							tag: formData.DATABASE_TAG,
 						}),
 					};
 					const pixel = `databaseVar = CreateEmptyRdbmsDatabase(database=[${JSON.stringify(formData.NAME)}], rdbmsType=[${JSON.stringify(formData.dbDriver)}], username=[${JSON.stringify(formData.USERNAME ?? "")}], password=[${JSON.stringify(formData.PASSWORD ?? "")}]);SetDatabaseMetadata(database=[databaseVar], meta=[${JSON.stringify(meta)}]);SyncDatabaseWithLocalMaster(database=[databaseVar]);`;
@@ -782,7 +800,7 @@ export const DatabaseForm = ({
 				([key]) =>
 					key !== "NAME" &&
 					key !== "DATABASE_DESCRIPTION" &&
-					key !== "DATABASE_TAGS" &&
+					key !== "DATABASE_TAG" &&
 					key !== "FILE_UPLOAD" &&
 					key !== "relationships" &&
 					key !== "tables" &&
@@ -1247,7 +1265,11 @@ export const DatabaseForm = ({
 										/>
 									</SelectTrigger>
 									<SelectContent>
-										{val?.options?.options?.map((opt) => (
+										{(val.key === "METAMODEL_TYPE"
+											? metamodelOptions
+											: ((val?.options?.options ??
+													[]) as MetaOpt[])
+										).map((opt: MetaOpt) => (
 											<SelectItem
 												key={opt.value}
 												value={opt.value}

--- a/packages/client/src/components/import/database/database-form.tsx
+++ b/packages/client/src/components/import/database/database-form.tsx
@@ -1342,7 +1342,7 @@ export const DatabaseForm = ({
 							<div
 								className={
 									val.hidden
-										? "flex hidden flex-col gap-2"
+										? "hidden"
 										: "flex flex-col gap-2"
 								}
 								data-testid={`database-form-field-${val.key}`}

--- a/packages/client/src/components/import/database/database.constants.tsx
+++ b/packages/client/src/components/import/database/database.constants.tsx
@@ -154,14 +154,6 @@ export const DATABASE_CONNECTION = {
 							},
 						],
 					},
-					displayRules: {
-						hideOtherFields: [
-							{
-								key: "PROP_FILE_UPLOAD",
-								value: ["asFlatTable", "asSuggestedMetaModel"],
-							},
-						],
-					},
 				},
 				{
 					key: "CUSTOM_BASE_URI",
@@ -446,14 +438,6 @@ export const DATABASE_CONNECTION = {
 							},
 						],
 					},
-					displayRules: {
-						hideOtherFields: [
-							{
-								key: "PROP_FILE_UPLOAD",
-								value: ["asFlatTable", "asSuggestedMetaModel"],
-							},
-						],
-					},
 				},
 				{
 					key: "CUSTOM_BASE_URI",
@@ -603,14 +587,6 @@ export const DATABASE_CONNECTION = {
 							},
 						],
 					},
-					displayRules: {
-						hideOtherFields: [
-							{
-								key: "PROP_FILE_UPLOAD",
-								value: ["asFlatTable", "asSuggestedMetaModel"],
-							},
-						],
-					},
 				},
 				{
 					key: "CUSTOM_BASE_URI",
@@ -694,7 +670,7 @@ export const DATABASE_CONNECTION = {
 					required: false,
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					category: "General",
@@ -828,7 +804,7 @@ export const DATABASE_CONNECTION = {
 					required: false,
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					category: "General",
@@ -976,7 +952,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -1141,7 +1117,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -1304,7 +1280,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -1441,7 +1417,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -1603,7 +1579,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -1773,7 +1749,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -1952,7 +1928,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -2053,7 +2029,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -2214,7 +2190,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -2376,7 +2352,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -2495,7 +2471,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -2656,7 +2632,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -2817,7 +2793,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -2978,7 +2954,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -3139,7 +3115,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -3300,7 +3276,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -3419,7 +3395,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -3580,7 +3556,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -3741,7 +3717,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -3911,7 +3887,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -4081,7 +4057,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -4242,7 +4218,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -4439,7 +4415,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -4628,7 +4604,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -4799,7 +4775,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -4951,7 +4927,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -5103,7 +5079,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",
@@ -5265,7 +5241,7 @@ export const DATABASE_CONNECTION = {
 					category: "General",
 				},
 				{
-					key: "DATABASE_TAGS",
+					key: "DATABASE_TAG",
 					label: "Tags",
 					value: "",
 					type: "tags",

--- a/packages/client/src/components/import/database/metamodel-editor-csv.tsx
+++ b/packages/client/src/components/import/database/metamodel-editor-csv.tsx
@@ -193,17 +193,6 @@ export const MetaModelType = observer(
 			[selectedDataIndex],
 		);
 
-		// Handlers
-		// const handleNodesMenuOpen = useCallback(
-		// 	() => setAnchorNodesMenu(true),
-		// 	[],
-		// );
-
-		// const handleNodesMenuClose = useCallback(
-		// 	() => setAnchorNodesMenu(false),
-		// 	[],
-		// );
-
 		const handleSelectAll = useCallback(
 			(isChecked: boolean) => {
 				if (isChecked) {

--- a/packages/client/src/components/import/database/metamodel-editor-jdbc.tsx
+++ b/packages/client/src/components/import/database/metamodel-editor-jdbc.tsx
@@ -34,7 +34,9 @@ import type {
 	ParsedResult,
 } from "./metamodel-types";
 import {
+	attachConnectionsToNodes,
 	createPayloadsFromFlowStates,
+	deepClone,
 	transformMetaToParsed,
 } from "./metamodel-utils";
 import { PortalModal } from "./portal";
@@ -42,7 +44,6 @@ import { PortalModal } from "./portal";
 export const MetaModelConnections = observer(
 	({ parsedData, onCancel, onImportConnections }: MetaModelTypeProps) => {
 		const parsed = parsedData?.[0];
-		console.log("MetaModelType parsedData:", parsedData);
 		const portalContentId = useId();
 		const [selectedNode, setSelectedNode] =
 			useState<React.ComponentProps<typeof Metamodel>["selectedNode"]>(
@@ -171,27 +172,11 @@ export const MetaModelConnections = observer(
 			}
 		}, [flow.nodes]);
 
-		const attachConnectionsToNodes = (
-			nodesInput: (MetamodelNode | FlowNode)[],
-			edgesInput: Edge[],
-		) => {
-			return (nodesInput ?? []).map((n) => {
-				const nodeId = n.id;
-				const nodeConnections = (edgesInput ?? []).filter(
-					(e) => e.source === nodeId || e.target === nodeId,
-				);
-				return {
-					...n,
-					connections: nodeConnections.map((e) => ({ ...e })),
-				} as MetamodelNode & { connections?: Edge[] };
-			});
-		};
-
 		const handleSelectAll = (isChecked: boolean) => {
 			if (isChecked) {
 				setSelectedNodeIds((nodes ?? []).map((n) => n.id));
 				const restored = attachConnectionsToNodes(
-					JSON.parse(JSON.stringify(nodes ?? [])),
+					deepClone(nodes ?? []),
 					edges ?? [],
 				);
 				setFlow({ nodes: restored, edges: edges ?? [] });
@@ -224,7 +209,7 @@ export const MetaModelConnections = observer(
 				if (!exists) {
 					const canonical = initialMap.get(nodeId);
 					const nodeToAdd = canonical
-						? JSON.parse(JSON.stringify(canonical))
+						? deepClone(canonical)
 						: {
 								id: nodeId,
 								type: "metamodel",


### PR DESCRIPTION
## Summary

- **Fix PROP_FILE_UPLOAD always visible** — CSS class bug (`gap-2hidden` instead of `gap-2 hidden`) and conflicting `displayRules.hideOtherFields` on `METAMODEL_TYPE` in CSV/TSV/TXT constants both kept the old single-file field visible instead of the `PairedFileUpload` component
- **Correct METAMODEL_TYPE filter logic** — H2 databases now see all options including `fromPropFile`; only R databases are restricted to `asFlatTable`
- **Remove dead code** — locally-duplicated `attachConnectionsToNodes` removed from `metamodel-editor-jdbc`; debug `console.log` and commented-out handlers removed
- **Unify field key** — `DATABASE_TAGS` renamed to `DATABASE_TAG` across all connection form configs

## Test plan

- [ ] Import a CSV with a paired prop file → both file slots visible, `ParseMetamodel` called with prop file path
- [ ] Select `fromPropFile` for an H2 database → `PairedFileUpload` appears, single `FILE_UPLOAD` hidden
- [ ] Switch away from `fromPropFile` → paired upload disappears, single file upload returns
- [ ] RDF database → `asFlatTable` not in METAMODEL_TYPE options
- [ ] R database → only `asFlatTable` in METAMODEL_TYPE options
- [ ] H2/CSV databases → all METAMODEL_TYPE options available