### PR TITLE
fix(import): fix FILE_UPLOAD visibility on H2/SQLite forms and simplify category desc

### DIFF
--- a/packages/client/src/components/import/database/database-form.tsx
+++ b/packages/client/src/components/import/database/database-form.tsx
@@ -154,8 +154,14 @@ export const DatabaseForm = ({
 
 	useEffect(() => {
 		const isPropFile = metamodelType === "fromPropFile";
-		setResolvedFields((prev) =>
-			prev.map((f) => {
+		const formHasPropFileOption = fields.some(
+			(f: { key: string; options?: { options?: { value: string }[] } }) =>
+				f.key === "METAMODEL_TYPE" &&
+				f.options?.options?.some((o) => o.value === "fromPropFile"),
+		);
+		if (!formHasPropFileOption) return;
+		setResolvedFields((prev: Record<string, unknown>[]) =>
+			prev.map((f: Record<string, unknown>) => {
 				if (f.key === "FILE_UPLOAD")
 					return { ...f, hidden: isPropFile };
 				if (f.key === "PROP_FILE_UPLOAD") return { ...f, hidden: true };
@@ -163,7 +169,7 @@ export const DatabaseForm = ({
 			}),
 		);
 		if (!isPropFile) setPairedFiles([]);
-	}, [metamodelType]);
+	}, [metamodelType, fields]);
 
 	useEffect(() => {
 		type MetaOpt = { display: string; value: string };

--- a/packages/client/src/components/import/database/database.constants.tsx
+++ b/packages/client/src/components/import/database/database.constants.tsx
@@ -5374,8 +5374,7 @@ export const CATEGORY_DESCRIPTIONS = {
 		"Contains descriptive and organizational details about the database, such as name, description, and tags.",
 	Database:
 		"Select the database engine type and how the data should be imported.",
-	"File Upload":
-		"Upload the data file to import. When using a prop file, pair each data file with its corresponding prop file.",
+	"File Upload": "Upload the file to import.",
 	Settings:
 		"Defines the technical configuration needed to connect to the database, including host, port, schema, and connection parameters.",
 	Credentials:


### PR DESCRIPTION
## Summary

Follow-up to #3166.

- **H2/SQLite FILE_UPLOAD shows on initial render** — the `metamodelType` useEffect was unconditionally setting `FILE_UPLOAD.hidden = isPropFile` (false on mount), which overwrote the `hidden: true` the constants correctly set for H2/SQLite. Fix: bail early if the current form does not offer a `fromPropFile` option, so only CSV/TSV/TXT forms (which actually use `PairedFileUpload`) have their FILE_UPLOAD toggled.
- **Wrong "File Upload" category description on H2/SQLite** — removed the prop-file pairing sentence so the description is generic across all form types.

## Test plan

- [ ] Open H2 import form → default "Create Empty Database" → FILE_UPLOAD section should not appear
- [ ] Switch to "Upload Existing H2 Database" → FILE_UPLOAD appears (controlled by existing displayRules)
- [ ] Open CSV import form → FILE_UPLOAD visible by default; switch to "From Prop File" → FILE_UPLOAD hides, PairedFileUpload shows
- [ ] "File Upload" category description no longer mentions prop files on H2/SQLite forms