### PR TITLE
feat: add auto open parameter functionality

### DIFF
--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -139,6 +139,7 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 
 		useEffect(() => {
 			if (
+				!tool.argumentsStreaming &&
 				tool.display !== "hidden" &&
 				tool.json._meta.SMSS_MCP_UI?.autoOpen === true &&
 				!tool.isOpen &&
@@ -146,7 +147,12 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 			) {
 				tool.openTool();
 			}
-		}, [tool, isDisabled]);
+		}, [
+			tool,
+			tool.argumentsStreaming,
+			tool.json._meta.SMSS_MCP_UI?.autoOpen,
+			isDisabled,
+		]);
 
 		// While the tool call is still streaming in, we don't have title/meta/args
 		// yet — delegate to a dedicated placeholder pill that shows a spinner and

--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -1,5 +1,6 @@
 import { CheckIcon, CirclePause, HammerIcon, XCircleIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
+import { useEffect } from "react";
 import { useTranslation } from "@semoss/i18n";
 import { Button, cn, Spinner, useIsMobile } from "@semoss/ui/next";
 import { useLoadingMessage } from "@/hooks";
@@ -128,13 +129,6 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 				: [],
 		);
 
-		// While the tool call is still streaming in, we don't have title/meta/args
-		// yet — delegate to a dedicated placeholder pill that shows a spinner and
-		// optionally expands to preview the accumulating JSON.
-		if (tool.argumentsStreaming) {
-			return <ResponseMessageToolStreaming tool={tool} />;
-		}
-
 		// TODO: if the plan is executing, only the execution step is enabled
 		const isDisabled =
 			room.mode === "executing" &&
@@ -142,6 +136,24 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 				room.plan?.step?.details.tool_name !== tool.json.name ||
 				room.plan?.step?.details._meta.SMSS_PROJECT_ID !==
 					tool.json._meta.SMSS_PROJECT_ID);
+
+		useEffect(() => {
+			if (
+				tool.display !== "hidden" &&
+				tool.json._meta.SMSS_MCP_UI?.autoOpen === true &&
+				!tool.isOpen &&
+				!isDisabled
+			) {
+				tool.openTool();
+			}
+		}, [tool, isDisabled]);
+
+		// While the tool call is still streaming in, we don't have title/meta/args
+		// yet — delegate to a dedicated placeholder pill that shows a spinner and
+		// optionally expands to preview the accumulating JSON.
+		if (tool.argumentsStreaming) {
+			return <ResponseMessageToolStreaming tool={tool} />;
+		}
 
 		const isActive =
 			tool.isOpen &&

--- a/packages/playground/src/types.d.ts
+++ b/packages/playground/src/types.d.ts
@@ -198,6 +198,7 @@ export interface PixelMessageToolCallPart {
 				loadingMessage?: string;
 				displayLocation?: "inline" | "sidebar" | "hidden";
 				resourceURI?: string;
+				autoOpen?: boolean;
 			};
 		};
 	};
@@ -287,6 +288,7 @@ export interface MCPTool {
 			loadingMessage?: string;
 			resourceURI?: string;
 			displayLocation?: "inline" | "sidebar" | "hidden";
+			autoOpen?: boolean;
 		};
 	};
 }


### PR DESCRIPTION
## Description
Adds functionality to auto open mcp tools

## Changes Made
when the mcp tool is set to auto open then the mcp tool should open without needing to click

## How to Test
add:
"SMSS_MCP_UI": {
                    "resourceURI": "/index.html",
                    "displayLocation": "sidebar",
                    "autoOpen": true
                },

and the mcp tool should open up automatically

## Notes
Right now it only matters if autoopen, not sure it makes sense to do it for auto execute so might want to add another condition in there.