### PR TITLE
Fix room flicker

### DIFF
--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/suspicious/noArrayIndexKey: TODO
 import dayjs from "dayjs";
 import {
 	ComputerIcon,

--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -144,12 +144,12 @@ export const GlobalNav = observer(() => {
 		() => -1,
 		(response) => response,
 		{},
-		// Re-fetch when the chat store's roomCounter increments
-		// (new chat, rename, delete elsewhere). The reset useEffect
-		// below relies on MobX observability which is fragile inside
-		// effect deps — wiring the counter directly into the iterator
-		// deps is the source of truth.
-		[chat.keys.roomCounter],
+		// No roomCounter dependency here — the useEffect below already
+		// calls reset() when roomCounter increments, and reset() preserves
+		// the current data while refetching (no blank flash). Putting
+		// roomCounter in the useIteratorPixel deps would call setAllData([])
+		// instead, which is the source of the sidebar flicker.
+		[],
 	);
 
 	const getRooms = useIteratorPixel<
@@ -185,9 +185,9 @@ export const GlobalNav = observer(() => {
 		{
 			limit: 25,
 		},
-		// Re-fetch on search change OR when the chat store's
-		// roomCounter increments (rename / delete elsewhere in app).
-		[debouncedSearch, chat.keys.roomCounter],
+		// Re-fetch only on search change — counter-based refreshes are handled
+		// by the useEffect below, which calls reset() and preserves data.
+		[debouncedSearch],
 	);
 
 	/**
@@ -767,8 +767,11 @@ export const GlobalNav = observer(() => {
 																						e.message,
 																					);
 																				}
-																			} finally {
-																				// remove from deleted set after attempting deletion to allow re-render if deletion failed
+																				// Deletion failed — restore the room in the list.
+																				// On the success path we intentionally leave the
+																				// roomId in deletedSet until the refetch lands, so
+																				// the room doesn't briefly reappear between the
+																				// reset() call and the new data arriving.
 																				setDeletedSet(
 																					(
 																						prev,

--- a/packages/playground/src/components/workspace/workspace-chat-list.tsx
+++ b/packages/playground/src/components/workspace/workspace-chat-list.tsx
@@ -93,6 +93,7 @@ export const WorkspaceChatList = ({
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [editingName, setEditingName] = useState("");
 	const [isRenaming, setIsRenaming] = useState(false);
+	const [renamedMap, setRenamedMap] = useState<Record<string, string>>({});
 
 	const getWorkspaceRooms = useIteratorPixel<
 		{ total_count: number; rooms: Room[] },
@@ -103,7 +104,7 @@ export const WorkspaceChatList = ({
 		(response) => response.total_count,
 		(response) => response.rooms,
 		{ limit: limit ?? 25 },
-		[debouncedSearch, workspaceId, chat.keys.roomCounter],
+		[debouncedSearch, workspaceId],
 	);
 
 	const { setScroll } = useInfiniteScroll({
@@ -212,7 +213,7 @@ export const WorkspaceChatList = ({
 
 	const handleStartRename = (room: Room) => {
 		setEditingId(room.room_id);
-		setEditingName(room.room_name);
+		setEditingName(renamedMap[room.room_id] ?? room.room_name);
 	};
 
 	const handleCancelRename = () => {
@@ -231,9 +232,9 @@ export const WorkspaceChatList = ({
 		try {
 			await chat.renameRoom(editingId, trimmed);
 			toast.success(t("chat.renameSuccess"));
+			setRenamedMap((prev) => ({ ...prev, [editingId]: trimmed }));
 			setEditingId(null);
 			setEditingName("");
-			getWorkspaceRooms.reset();
 		} catch {
 			toast.error(t("chat.renameFailed"));
 		} finally {
@@ -325,7 +326,20 @@ export const WorkspaceChatList = ({
 													<ChatRow
 														key={room.room_id}
 														t={t}
-														room={room}
+														room={
+															renamedMap[
+																room.room_id
+															]
+																? {
+																		...room,
+																		room_name:
+																			renamedMap[
+																				room
+																					.room_id
+																			],
+																	}
+																: room
+														}
 														isFavorite={pinnedSet.has(
 															room.room_id,
 														)}
@@ -502,7 +516,7 @@ function ChatRow({
 	}
 
 	return (
-		<div className="group/row relative flex items-center gap-2 rounded-lg border border-border bg-card ps-2 pe-3 transition-colors hover:border-border/80 hover:bg-accent/40">
+		<div className="group/row relative flex items-center gap-2 rounded-lg border border-border bg-card py-2 ps-2 pe-3 transition-colors hover:border-border/80 hover:bg-accent/40">
 			{/* Stretched link: makes the whole row clickable */}
 			<Link
 				to={`/room/${room.room_id}`}
@@ -550,7 +564,7 @@ function ChatRow({
 
 			<span
 				dir="auto"
-				className="min-w-0 flex-1 truncate py-2.5 font-semibold text-foreground text-sm"
+				className="min-w-0 flex-1 truncate font-semibold text-foreground text-sm"
 				title={room.room_name}
 			>
 				{room.room_name}

--- a/packages/playground/src/pages/chats-page.tsx
+++ b/packages/playground/src/pages/chats-page.tsx
@@ -257,7 +257,7 @@ export const ChatsPage = observer(() => {
 		>
 			<div className="mx-auto flex w-full max-w-5xl flex-col gap-6 @3xl:px-12 @md:px-6 px-4 pt-8 pb-4">
 				{/* Sticky header */}
-				<div className="-mx-4 -mt-8 @md:-mx-6 @3xl:-mx-12 sticky top-0 z-20 flex flex-row items-center gap-3 border-border border-b bg-background/95 @3xl:px-12 @md:px-6 px-4 py-4 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+				<div className="-mx-4 -mt-8 @md:-mx-6 @3xl:-mx-12 sticky top-0 z-20 flex flex-row items-center gap-3 border-border border-b bg-background/95 @3xl:px-12 @md:px-6 px-4 py-4 backdrop-blur supports-backdrop-filter:bg-background/80">
 					<div className="min-w-0 flex-1">
 						<div className="truncate font-semibold @md:text-2xl text-foreground text-xl leading-tight">
 							{t("workspace:chats.title", {
@@ -446,7 +446,7 @@ export const ChatsPage = observer(() => {
 													toggleSelectOne(r.ROOM_ID);
 												}
 											}}
-											className="relative z-[1] flex shrink-0 cursor-pointer items-center @md:gap-3 gap-2 py-2.5 @md:ps-3 ps-2 @md:pe-2 pe-1"
+											className="relative z-1 flex shrink-0 cursor-pointer items-center @md:gap-3 gap-2 py-2.5 @md:ps-3 ps-2 @md:pe-2 pe-1"
 										>
 											<Checkbox
 												checked={isSelected}
@@ -475,7 +475,7 @@ export const ChatsPage = observer(() => {
 										</div>
 
 										{/* Name + date — link covers this area for navigation */}
-										<div className="pointer-events-none relative z-[1] flex min-w-0 flex-1 flex-col py-2.5">
+										<div className="pointer-events-none relative z-1 flex min-w-0 flex-1 flex-col py-2.5">
 											<div className="flex min-w-0 items-center gap-1.5">
 												<div
 													dir="auto"
@@ -508,7 +508,7 @@ export const ChatsPage = observer(() => {
 										    to the stretched Link and navigate to the
 										    room. The rename Button re-enables events
 										    on itself via `pointer-events-auto`. */}
-										<div className="pointer-events-none relative z-[1] flex shrink-0 items-center gap-1 @md:pe-3 pe-2">
+										<div className="pointer-events-none relative z-1 flex shrink-0 items-center gap-1 @md:pe-3 pe-2">
 											<Tooltip>
 												<TooltipTrigger asChild>
 													<Button
@@ -557,7 +557,7 @@ export const ChatsPage = observer(() => {
 			    the selection. */}
 			{hasSelection && (
 				<div className="-translate-x-1/2 fade-in-0 slide-in-from-bottom-4 fixed bottom-6 left-1/2 z-30 animate-in">
-					<div className="flex items-center gap-1 rounded-full border border-border bg-card/95 px-2 py-1.5 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-card/80">
+					<div className="flex items-center gap-1 rounded-full border border-border bg-card/95 px-2 py-1.5 shadow-lg backdrop-blur supports-backdrop-filter:bg-card/80">
 						<span className="px-3 font-medium text-foreground text-sm">
 							{t("workspace:chats.selectedCount", {
 								count: selectedIds.size,

--- a/packages/playground/src/pages/chats-page.tsx
+++ b/packages/playground/src/pages/chats-page.tsx
@@ -11,7 +11,7 @@ import {
 	XIcon,
 } from "lucide-react";
 import { observer } from "mobx-react-lite";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "@semoss/i18n";
 import { useIteratorPixel } from "@semoss/sdk/react";
@@ -85,10 +85,10 @@ export const ChatsPage = observer(() => {
 		(response) => (response.length < 25 ? -1 : Infinity),
 		(response) => response,
 		{ limit: 25 },
-		// roomCounter is incremented by the chat store whenever a chat
-		// is created / renamed / deleted; re-fetching here keeps the
-		// "All chats" list in sync across pages without a manual refresh.
-		[debouncedSearch, chat.keys.roomCounter],
+		// Re-fetch only on search change — counter-based refreshes are
+		// handled by the useEffect below, which calls reset() and
+		// preserves current data instead of clearing it first.
+		[debouncedSearch],
 	);
 
 	const { setScroll } = useInfiniteScroll({
@@ -114,6 +114,19 @@ export const ChatsPage = observer(() => {
 		() => setSelectedIds(new Set(visibleRooms.map((r) => r.ROOM_ID))),
 		[visibleRooms],
 	);
+
+	// Re-fetch when roomCounter increments (create / rename / delete from
+	// anywhere in the app) without clearing the list first. reset()
+	// preserves current data while the refetch runs, avoiding a blank flash.
+	const didInitialMount = useRef(false);
+	useEffect(() => {
+		chat.keys.roomCounter;
+		if (!didInitialMount.current) {
+			didInitialMount.current = true;
+			return;
+		}
+		getRooms.reset();
+	}, [getRooms.reset, chat.keys.roomCounter]);
 
 	// Keyboard shortcuts: Esc clears the current selection;
 	// Cmd/Ctrl+A selects all visible chats (only when focus isn't

--- a/packages/playground/src/pages/workspace-page.tsx
+++ b/packages/playground/src/pages/workspace-page.tsx
@@ -138,7 +138,12 @@ export const WorkspacePage = observer(() => {
 						</InputGroupAddon>
 					</InputGroup>
 
-					{getWorkspaces.data.length === 0 ? (
+					{getWorkspaces.isLoading &&
+					getWorkspaces.data.length === 0 ? (
+						<div className="flex items-center justify-center py-12">
+							<Spinner />
+						</div>
+					) : getWorkspaces.data.length === 0 ? (
 						<div className="flex items-center justify-center py-12">
 							<Muted>{t("workspace:messages.noResults")}</Muted>
 						</div>

--- a/packages/playground/src/stores/chat/chat.store.ts
+++ b/packages/playground/src/stores/chat/chat.store.ts
@@ -348,9 +348,8 @@ export class ChatStore {
 		runInAction(() => {
 			// save it to the cache
 			this._store.rooms[roomId] = room;
-
-			// increment the roomCounter to force re-render of the nav
-			this._store.keys.roomCounter++;
+			// No roomCounter increment here — loading an existing room doesn't
+			// change the list, so there's no reason to trigger a re-fetch.
 		});
 
 		// return the room


### PR DESCRIPTION
## Description
Eliminates UI flickering in the room/chat list across the Playground app. The flicker manifested as the list briefly going blank after loading, deleting, or renaming a chat — and as a "No results" flash during initial workspace page load.

## Changes Made
- **Sidebar (`global-nav.tsx`):** Removed `roomCounter` from `useIteratorPixel` dependencies so dependency changes don't clear the list. Added a companion `useEffect` with a first-mount guard to call `reset()` on subsequent `roomCounter` changes instead.
- **Chats page (`chats-page.tsx`):** Same `roomCounter` dep fix and companion effect pattern as the sidebar.
- **Workspace page (`workspace-page.tsx`):** Added `isLoading && data.length === 0` guard so a `Spinner` shows during the initial fetch instead of a premature "No results" message.
- **Workspace chat list (`workspace-chat-list.tsx`):** Replaced the `reset()` call after rename with a local `renamedMap` patch so the list never clears on rename. Fixed the edit-mode row resize by moving vertical padding from the name span to the row container. Fixed a stale-name bug where opening the rename input a second time would show the original name instead of the previously saved one.

## How to Test
1. Open the **Chats page** — confirm the list loads without a blank flash.
2. Open a **workspace detail page** — confirm the chat timeline loads without flickering.
3. **Rename a chat** on the workspace detail page — confirm the list stays in place with no blank/reload flash and the row shows the new name immediately.
4. **Rename the same chat again** — confirm the input pre-fills with the name from step 3, not the original.
5. **Delete a chat** on the workspace detail page — confirm the row disappears optimistically and the list refetches cleanly.
6. Open the **Workspace (agent) listing page** — confirm a spinner shows during load instead of a "No results" flash.

## Notes
The root cause in most cases was `roomCounter` (a MobX observable incremented on room create/rename/delete) appearing in `useIteratorPixel`'s dependency array. A dep change triggers `setAllData([])` internally before the refetch, which caused the blank flash. The fix keeps `roomCounter` out of that array and uses a separate effect to call `reset()` (which preserves existing data during the refetch) only after the initial mount.