### PR TITLE
Follow-up fix for mobile issue 1034

### DIFF
--- a/packages/playground/src/components/message/response-message-tool.tsx
+++ b/packages/playground/src/components/message/response-message-tool.tsx
@@ -145,13 +145,14 @@ export const ResponseMessageTool: React.FC<ResponseMessageToolProps> = observer(
 				!tool.isOpen &&
 				!isDisabled
 			) {
-				tool.openTool();
+				tool.openTool(isMobile ? "inline" : undefined);
 			}
 		}, [
 			tool,
 			tool.argumentsStreaming,
 			tool.json._meta.SMSS_MCP_UI?.autoOpen,
 			isDisabled,
+			isMobile,
 		]);
 
 		// While the tool call is still streaming in, we don't have title/meta/args


### PR DESCRIPTION
## Description
Follow-up to #3126

Most of that fix is still intact, but a later change introduced a new code path that bypassed the mobile handling.

## Change in This Fix
- **response-message-tool.tsx**: In the auto-open `useEffect`, pass `isMobile ? "inline" : undefined` to `tool.openTool()` so `autoOpen` tools open inline on mobile, matching the existing manual-click behavior from #3126. Desktop behavior is unchanged.

## How to Test (unchanged from #3126)
1. Open the playground using Chrome extension ```Mobile simulator```
2. Trigger a response that includes a tool result with `autoOpen: true`
3. The tool should auto-open **inline**, not in a sidebar
4. Click on a tool result manually — it should still open **inline**
5. Open the tool dropdown menu — the "Open in Sidebar" option should **not** appear
6. On a desktop-width viewport, verify auto-open and the sidebar option still work as before

## Notes
- Refer to [#3126](https://github.com/SEMOSS/semoss-ui/pull/3126) for the original mobile fix description 

- screenshot:
<img width="332" height="658" alt="image" src="https://github.com/user-attachments/assets/2cb0e652-7092-4ef6-8c46-172f5afd76eb" />

