### PR TITLE
Use display name in mcp modal on playground

### DIFF
--- a/packages/playground/src/components/mcp/utility.ts
+++ b/packages/playground/src/components/mcp/utility.ts
@@ -74,7 +74,7 @@ export const engineProjectToMCP = (tool: Engine | App): MCP => {
 		return {
 			type: tool.engine_type,
 			id: tool.engine_id,
-			name: tool.engine_name,
+			name: tool.engine_display_name || tool.engine_name,
 			subtype: tool.engine_subtype,
 			description: tool.description || "",
 			tags: [], // Tags are not provided in the current response


### PR DESCRIPTION
## Description
Knowledge sources in the chat MCP selector were displaying their raw internal engine name instead of the user-facing display name.

## Changes Made
- `engineProjectToMCP` (`mcp/utility.ts`): use `engine_display_name || engine_name` for engine-type MCPs, consistent with how app-type MCPs already use `project_display_name || project_name`

## How to Test
1. Open a chat room and open the resource/knowledge selector — knowledge sources with a display name set should now show that name instead of the raw engine name.