### PR TITLE
Upload thinking placeholder

### DIFF
--- a/packages/playground/src/stores/message/response-message.store.ts
+++ b/packages/playground/src/stores/message/response-message.store.ts
@@ -163,45 +163,54 @@ export class ResponseMessageStore extends AbstractMessageStore {
 	 * initiates tool execution if the response contains tool calls.
 	 *
 	 * @param inputMessage - The user input message to send to the AI model
+	 * @param existingResponse - Optional pre-created response placeholder already wired into the message tree. When provided, skips creating a new ResponseMessageStore and skips the addChild setup calls, streaming directly into the existing placeholder instead.
 	 * @returns Promise resolving to the pixel response containing input and output messages
 	 */
-	runMessage = async (inputMessage: InputMessageStore) => {
+	runMessage = async (
+		inputMessage: InputMessageStore,
+		existingResponse?: ResponseMessageStore,
+	) => {
 		const room = this.room;
 
 		// Create a placeholder response message to show streaming content
-		const responseMessage = new ResponseMessageStore(room, {
-			io: "OUTPUT",
-			messageId: STREAMING_PLACEHOLDER_ID,
-			visible: true,
-			platform_generated: true,
-			modelId: room.model.engine_id,
-			dateCreated: new Date().toISOString(),
-			parts: [
-				{
-					type: "THINKING",
-					thinking: "",
+		const responseMessage =
+			existingResponse ??
+			new ResponseMessageStore(room, {
+				io: "OUTPUT",
+				messageId: STREAMING_PLACEHOLDER_ID,
+				visible: true,
+				platform_generated: true,
+				modelId: room.model.engine_id,
+				dateCreated: new Date().toISOString(),
+				parts: [
+					{
+						type: "THINKING",
+						thinking: "",
+					},
+				],
+				tokens: 0,
+				ornaments: {
+					modelName:
+						room.model.engine_display_name ||
+						room.model.engine_name ||
+						"",
 				},
-			],
-			tokens: 0,
-			ornaments: {
-				modelName:
-					room.model.engine_display_name ||
-					room.model.engine_name ||
-					"",
-			},
-		} as ResponsePixelMessage);
+			} as ResponsePixelMessage);
 
 		try {
-			// connect to the parent
-			this.addChild(inputMessage);
-
 			// build the context if it is there
 			let context = "";
 			if (room.options?.instructions) {
 				context = room.options?.instructions;
 			}
-			// Add placeholder as child of input to show streaming text
-			inputMessage.addChild(responseMessage);
+
+			if (!existingResponse) {
+				// connect to the parent
+				this.addChild(inputMessage);
+
+				// Add placeholder as child of input to show streaming text
+				inputMessage.addChild(responseMessage);
+			}
 
 			// turn on thinking
 			responseMessage.isThinking = true;

--- a/packages/playground/src/stores/room/room.store.ts
+++ b/packages/playground/src/stores/room/room.store.ts
@@ -25,8 +25,6 @@ import type {
 	InputPixelMessage,
 	MCPConfig,
 	PixelMessage,
-	PixelMessageMediaPart,
-	PixelMessageTextPart,
 	PixelMessageToolCallPart,
 	PixelMessageToolResultPart,
 	Prompt,
@@ -950,12 +948,55 @@ export class RoomStore {
 
 		this.setIsLoading(true);
 
-		// upload the files
-		let uploaded: {
-			fileName: string;
-			fileLocation: string;
-		}[] = [];
+		// Create the input message immediately so the user's bubble and the
+		// thinking placeholder are visible during the file upload wait
+		const inputMessage = new InputMessageStore(this, {
+			io: "INPUT",
+			type: "INPUT_TEXT",
+			messageId: "ASK_PLACEHOLDER_ID",
+			visible: true,
+			platform_generated: true,
+			modelId: this.model?.engine_id,
+			modelType: this.model?.engine_type,
+			dateCreated: new Date().toISOString(),
+			parts: [{ type: "TEXT", text: prompt, uiText: prompt }],
+			tokens: 0,
+			ornaments: {
+				modelName:
+					this.model.engine_display_name || this.model.engine_name,
+			},
+			pruneToolsAbove: false,
+		});
 
+		const parentMessage = this.tail;
+		if (parentMessage instanceof InputMessageStore) {
+			throw new Error("Cannot respond to input messages");
+		}
+
+		const uploadPlaceholder = new ResponseMessageStore(this, {
+			io: "OUTPUT",
+			messageId: STREAMING_PLACEHOLDER_ID,
+			visible: true,
+			platform_generated: true,
+			modelId: this.model.engine_id,
+			dateCreated: new Date().toISOString(),
+			parts: [{ type: "THINKING", thinking: "" }],
+			tokens: 0,
+			ornaments: {
+				modelName:
+					this.model.engine_display_name ||
+					this.model.engine_name ||
+					"",
+			},
+		} as ResponsePixelMessage);
+
+		parentMessage.addChild(inputMessage);
+		inputMessage.addChild(uploadPlaceholder);
+		runInAction(() => {
+			uploadPlaceholder.isThinking = true;
+		});
+
+		// upload the files
 		let mediaInputs: {
 			fileName: string;
 			fileLocation: string;
@@ -969,8 +1010,7 @@ export class RoomStore {
 				files,
 			);
 
-			// set the new files
-			uploaded = response.data;
+			const uploaded = response.data;
 
 			const normalizeExt = (value: string) =>
 				value.trim().toLowerCase().replace(/^\./, "");
@@ -991,57 +1031,28 @@ export class RoomStore {
 
 				return allowedSet.has(ext);
 			});
-		}
 
-		const parts: (PixelMessageTextPart | PixelMessageMediaPart)[] = [
-			{
-				type: "TEXT",
-				text: prompt,
-				uiText: prompt,
-			},
-		];
-		for (const file of mediaInputs) {
-			parts.push({
-				type: "MEDIA",
-				mediaInfo: {
-					base64Data: "",
-					fileFormat: "",
-					fileName: file.fileName,
-					fileLocation: file.fileLocation,
-					mediaInputType: "FILE",
-					mimeType: "",
-				},
+			// Append media parts to the already-visible input message
+			runInAction(() => {
+				for (const file of mediaInputs) {
+					inputMessage.parts.push({
+						type: "MEDIA",
+						mediaInfo: {
+							base64Data: "",
+							fileFormat: "",
+							fileName: file.fileName,
+							fileLocation: file.fileLocation,
+							mediaInputType: "FILE",
+							mimeType: "",
+						},
+					});
+				}
 			});
 		}
 
-		// create the input message
-		const inputMessage = new InputMessageStore(this, {
-			io: "INPUT",
-			type: "INPUT_TEXT",
-			messageId: "ASK_PLACEHOLDER_ID",
-			visible: true,
-			platform_generated: true,
-			modelId: this.model?.engine_id,
-			modelType: this.model?.engine_type,
-			dateCreated: new Date().toISOString(),
-			parts: parts,
-			tokens: 0,
-			ornaments: {
-				modelName:
-					this.model.engine_display_name || this.model.engine_name,
-			},
-			pruneToolsAbove: false,
-		});
-
-		// get the parent message
-		const parentMessage = this.tail;
-		if (parentMessage instanceof InputMessageStore) {
-			throw new Error("Cannot respond to input messages");
-		}
-
-		// run the message
+		// run the message, reusing the upload placeholder as the streaming response
 		try {
-			await parentMessage.runMessage(inputMessage);
+			await parentMessage.runMessage(inputMessage, uploadPlaceholder);
 		} catch (e) {
 			this.plan?.failStepExecution();
 

--- a/packages/playground/src/stores/room/room.store.ts
+++ b/packages/playground/src/stores/room/room.store.ts
@@ -1002,52 +1002,61 @@ export class RoomStore {
 			fileLocation: string;
 		}[] = [];
 
-		// upload the files if there are any
-		if (files.length > 0) {
-			const response = await uploadInsight(
-				this._store.insightId,
-				"",
-				files,
-			);
+		try {
+			// upload the files if there are any
+			if (files.length > 0) {
+				const response = await uploadInsight(
+					this._store.insightId,
+					"",
+					files,
+				);
 
-			const uploaded = response.data;
+				const uploaded = response.data;
 
-			const normalizeExt = (value: string) =>
-				value.trim().toLowerCase().replace(/^\./, "");
+				const normalizeExt = (value: string) =>
+					value.trim().toLowerCase().replace(/^\./, "");
 
-			mediaInputs = uploaded.filter((f) => {
-				const allowed = this._theme.allowedFileTypes;
+				mediaInputs = uploaded.filter((f) => {
+					const allowed = this._theme.allowedFileTypes;
 
-				// If not configured (or empty), allow all
-				if (!allowed || allowed.length === 0) return true;
+					// If not configured (or empty), allow all
+					if (!allowed || allowed.length === 0) return true;
 
-				const allowedSet = new Set(allowed.map(normalizeExt));
+					const allowedSet = new Set(allowed.map(normalizeExt));
 
-				const rawExt = f.fileName.split(".").pop() ?? "";
-				const ext = normalizeExt(rawExt);
+					const rawExt = f.fileName.split(".").pop() ?? "";
+					const ext = normalizeExt(rawExt);
 
-				// If there's no extension, it's not allowed (when allow-list is configured)
-				if (!ext) return false;
+					// If there's no extension, it's not allowed (when allow-list is configured)
+					if (!ext) return false;
 
-				return allowedSet.has(ext);
-			});
+					return allowedSet.has(ext);
+				});
 
-			// Append media parts to the already-visible input message
+				// Append media parts to the already-visible input message
+				runInAction(() => {
+					for (const file of mediaInputs) {
+						inputMessage.parts.push({
+							type: "MEDIA",
+							mediaInfo: {
+								base64Data: "",
+								fileFormat: "",
+								fileName: file.fileName,
+								fileLocation: file.fileLocation,
+								mediaInputType: "FILE",
+								mimeType: "",
+							},
+						});
+					}
+				});
+			}
+		} catch (e) {
+			// remove the placeholder messages if the upload fails
 			runInAction(() => {
-				for (const file of mediaInputs) {
-					inputMessage.parts.push({
-						type: "MEDIA",
-						mediaInfo: {
-							base64Data: "",
-							fileFormat: "",
-							fileName: file.fileName,
-							fileLocation: file.fileLocation,
-							mediaInputType: "FILE",
-							mimeType: "",
-						},
-					});
-				}
+				uploadPlaceholder.isThinking = false;
 			});
+			parentMessage.removeChild(inputMessage);
+			throw e;
 		}
 
 		// run the message, reusing the upload placeholder as the streaming response


### PR DESCRIPTION
## Description
When a user attaches images to a message, the thinking placeholder box wasn't appearing until after the file upload completed. The input message and streaming placeholder weren't wired into the message tree until `runMessage` was called — which only happens post-upload — so `isLoading` would be true with nothing visible in the chat.

## Changes Made
- **room.store.ts:** Creates the `InputMessageStore` and a `ResponseMessageStore` placeholder immediately on submit, before the upload begins, and connects them to the message tree so the user's bubble and thinking box appear right away. After upload completes, media parts are pushed into the input message's observable `parts` array so they appear in the bubble and are included in the pixel call. Upload errors tear down both placeholder messages and rethrow.
- **response-message.store.ts:** `runMessage` accepts an optional `existingResponse` param. When provided, skips creating a new placeholder and skips the `addChild` wiring since both have already been done, streaming directly into the existing instance instead.

## How to Test
1. Open a chat room and attach an image to a message — the user bubble and thinking box should appear immediately, before the upload resolves.
2. Once the upload completes, the attached image should appear in the user bubble and the AI should respond with awareness of it.

## Notes
To get a longer window to inspect the loading state, add this line in `room.store.ts` inside `askMessage` just before the `uploadInsight` call:
```ts
if (files.length > 0) await new Promise((resolve) => setTimeout(resolve, 20000));