### PR TITLE
refactor: proj specific reactors on suggestions dropdown

### DIFF
--- a/libs/shared/src/components/cell-output/cell-output-block.tsx
+++ b/libs/shared/src/components/cell-output/cell-output-block.tsx
@@ -225,6 +225,7 @@ export const CellOutputBlock = ({
 						count: countLines(output),
 					})} · ${formatBytes(output)}`}
 					accent={error ? "red" : "blue"}
+					collapsible
 					headerExtras={
 						<>
 							{!error && outputValue !== null && (

--- a/packages/terminal/src/components/terminal-console/terminal-console.tsx
+++ b/packages/terminal/src/components/terminal-console/terminal-console.tsx
@@ -9,7 +9,7 @@ import {
 import { useInsight } from "@semoss/sdk/react";
 import { MonacoEditor } from "@semoss/shared";
 import { useTheme } from "@semoss/ui/next";
-import { CopyIcon, Logo } from "../../assets/logos";
+import { Logo } from "../../assets/logos";
 import type {
 	ConsoleContext,
 	ConsoleHistoryStep,
@@ -60,7 +60,13 @@ const monacoLanguageForContext = (context: ConsoleContext): string => {
 	return "plaintext";
 };
 
-export const TerminalConsole = () => {
+interface TerminalConsoleProps {
+	/** When set, fetches app-specific reactors via GetProjectAvailableReactors
+	 *  and merges them with the platform catalog from help(). */
+	projectId?: string;
+}
+
+export const TerminalConsole = ({ projectId }: TerminalConsoleProps) => {
 	const terminal = useTerminal();
 	const { actions, insightId, isAuthorized } = useInsight();
 	const { theme } = useTheme();
@@ -116,9 +122,24 @@ export const TerminalConsole = () => {
 		null,
 	);
 	const monacoRef = useRef<typeof monacoType | null>(null);
-	// Tracks whether we've registered the pixel completion provider on the
-	// singleton monaco namespace (multiple <MonacoEditor> mounts share it).
 	const completerRegisteredRef = useRef(false);
+	// Disposables for the completion providers — cleaned up on unmount so
+	// that re-mounting (e.g. after SetContext) doesn't stack stale providers.
+	const completionDisposablesRef = useRef<monacoType.IDisposable[]>([]);
+
+	useEffect(() => {
+		return () => {
+			for (const d of completionDisposablesRef.current) {
+				try {
+					d.dispose();
+				} catch {
+					// ignore if already disposed
+				}
+			}
+			completionDisposablesRef.current = [];
+			completerRegisteredRef.current = false;
+		};
+	}, []);
 
 	// Vertical split between editor (top) and transcript (bottom). The
 	// editor's height percentage = drag-handle Y position within the pane.
@@ -423,40 +444,83 @@ export const TerminalConsole = () => {
 	}, []);
 
 	// ---- pixel reactor typeahead -----------------------------------------
-	// Fetch the reactor catalog once via `help()` and stash it in a ref so
-	// the Monaco completion provider can read it without re-registering.
+	// Fetch the reactor catalog via help() + app-specific reactors when a
+	// project context is active (either from the `projectId` prop passed by
+	// the floating terminal, or from the built-in terminal's ScopePicker
+	// selecting an app via terminal.selectedApp).
 	const reactorsRef = useRef<ReactorSuggestion[]>([]);
+
+	// Effective project: explicit prop wins; fall back to the terminal
+	// context's selectedApp when the file-explorer is in APP scope.
+	const effectiveProjectId =
+		projectId !== undefined
+			? projectId
+			: terminal.fileMode.type === "APP"
+				? terminal.selectedApp?.project_id
+				: undefined;
 
 	useEffect(() => {
 		if (!isAuthorized) return;
 		let cancelled = false;
 		(async () => {
-			const resp = await runPixel<string>(actions, `help();`);
-			if (cancelled || !resp) return;
-			if (resp.operationType.some((t) => t.indexOf("ERROR") > -1)) return;
-			const raw =
-				typeof resp.output === "string"
-					? resp.output
-					: String(resp.output ?? "");
-			// collapse runs of 2+ spaces, then split on the now-uniform "  "
-			const tokens = raw.replace(/(\s\s)+/g, "  ").split("  ");
-			const items: ReactorSuggestion[] = [];
-			let category = "";
-			for (const tk of tokens) {
-				const t = tk.trim();
-				if (!t) continue;
-				if (t.endsWith(":")) {
-					category = t.slice(0, -1);
-				} else {
-					items.push({ name: t, meta: category || "pixel" });
+			try {
+				// 1. Platform reactors via help()
+				const helpResp = await runPixel<string>(actions, `help();`);
+				if (cancelled) return;
+
+				const items: ReactorSuggestion[] = [];
+
+				if (
+					helpResp &&
+					Array.isArray(helpResp.operationType) &&
+					!helpResp.operationType.some((t) => t.indexOf("ERROR") > -1)
+				) {
+					const raw =
+						typeof helpResp.output === "string"
+							? helpResp.output
+							: String(helpResp.output ?? "");
+					const tokens = raw.replace(/(\s\s)+/g, "  ").split("  ");
+					let category = "";
+					for (const tk of tokens) {
+						const t = tk.trim();
+						if (!t) continue;
+						if (t.endsWith(":")) {
+							category = t.slice(0, -1);
+						} else {
+							items.push({ name: t, meta: category || "pixel" });
+						}
+					}
 				}
+
+				// 2. App-specific reactors via GetProjectAvailableReactors
+				if (effectiveProjectId) {
+					const appResp = await runPixel<string[]>(
+						actions,
+						`GetProjectAvailableReactors(project=['${effectiveProjectId}']);`,
+					);
+					if (
+						!cancelled &&
+						appResp &&
+						Array.isArray(appResp.output)
+					) {
+						const existing = new Set(items.map((i) => i.name));
+						for (const name of appResp.output) {
+							if (name && !existing.has(name)) {
+								items.push({ name, meta: "app" });
+							}
+						}
+					}
+				}
+
+				if (!cancelled) reactorsRef.current = items;
+			} catch {
+				// silently preserve whatever was previously in the catalog
 			}
-			reactorsRef.current = items;
 		})();
 		return () => {
 			cancelled = true;
 		};
-	}, [isAuthorized, actions]);
+	}, [isAuthorized, actions, effectiveProjectId]);
 
 	// Expose an external submission path so other panes (the file editor's
 	// Run button) can pipe their pixel through this transcript — same async
@@ -480,8 +544,13 @@ export const TerminalConsole = () => {
 			const KeyMod = monaco.KeyMod;
 			const KeyCode = monaco.KeyCode;
 
-			// Cmd/Ctrl-Enter → Submit
+			// Enter → Submit (only when autocomplete popup is closed)
 			editor.addCommand(KeyMod.CtrlCmd | KeyCode.Enter, () => execute());
+			editor.addCommand(
+				KeyCode.Enter,
+				() => execute(),
+				"!suggestWidgetVisible && !inlineSuggestionVisible",
+			);
 
 			// Cmd/Ctrl-Up / Down → unconditional history recall
 			editor.addCommand(KeyMod.CtrlCmd | KeyCode.UpArrow, () =>
@@ -491,26 +560,28 @@ export const TerminalConsole = () => {
 				historyDown(),
 			);
 
-			// Plain Up / Down → conditional. Recall history only when the
-			// cursor is at the boundary; otherwise fall through to Monaco's
-			// built-in cursor navigation.
-			editor.addCommand(KeyCode.UpArrow, () => {
-				const pos = editor.getPosition();
-				if (pos?.lineNumber === 1) {
-					historyUp();
-				} else {
-					editor.trigger("history", "cursorUp", null);
-				}
-			});
-			editor.addCommand(KeyCode.DownArrow, () => {
-				const pos = editor.getPosition();
-				const total = editor.getModel()?.getLineCount() ?? 1;
-				if (pos?.lineNumber === total) {
-					historyDown();
-				} else {
-					editor.trigger("history", "cursorDown", null);
-				}
-			});
+			// Plain Up / Down → history at boundary, cursor otherwise.
+			// Guard on !suggestWidgetVisible so arrow keys navigate the
+			// autocomplete list instead of jumping to history.
+			editor.addCommand(
+				KeyCode.UpArrow,
+				() => {
+					const pos = editor.getPosition();
+					if (pos?.lineNumber === 1) historyUp();
+					else editor.trigger("history", "cursorUp", null);
+				},
+				"!suggestWidgetVisible",
+			);
+			editor.addCommand(
+				KeyCode.DownArrow,
+				() => {
+					const pos = editor.getPosition();
+					const total = editor.getModel()?.getLineCount() ?? 1;
+					if (pos?.lineNumber === total) historyDown();
+					else editor.trigger("history", "cursorDown", null);
+				},
+				"!suggestWidgetVisible",
+			);
 
 			// Register the reactor catalog completer on the languages we use.
 			// The provider checks the active context so it only fires for
@@ -519,6 +590,12 @@ export const TerminalConsole = () => {
 				completerRegisteredRef.current = true;
 				const provider: monacoType.languages.CompletionItemProvider = {
 					provideCompletionItems: (model, position) => {
+						// Scope to this editor's model — prevents stacked providers
+						// from multiple mounted TerminalConsole instances (e.g. tabs)
+						// each returning suggestions for every Monaco editor.
+						if (editorRef.current?.getModel() !== model) {
+							return { suggestions: [] };
+						}
 						if (stateRef.current.context !== "Pixel") {
 							return { suggestions: [] };
 						}
@@ -545,28 +622,17 @@ export const TerminalConsole = () => {
 					"r",
 					"shell",
 				] as const) {
-					monaco.languages.registerCompletionItemProvider(
-						lang,
-						provider,
+					completionDisposablesRef.current.push(
+						monaco.languages.registerCompletionItemProvider(
+							lang,
+							provider,
+						),
 					);
 				}
 			}
 		},
 		[execute, historyUp, historyDown],
 	);
-
-	const copyRecipe = useCallback(async () => {
-		const content = historyRef.current
-			.filter((s) => s.executed)
-			.map((s) => s.expression)
-			.join("\n");
-		try {
-			await navigator.clipboard.writeText(content);
-			terminal.alert("success", t("copyAll.success"));
-		} catch {
-			terminal.alert("error", t("copyAll.error"));
-		}
-	}, [t, terminal]);
 
 	return (
 		<div className="absolute inset-0 flex flex-col overflow-hidden bg-background">
@@ -629,11 +695,9 @@ export const TerminalConsole = () => {
 				</Suspense>
 			</div>
 
-			{/* Upper toolbar — input-affecting controls live with the editor.
-                Persona switcher + Submit clustered together on the right so
-                "I'm submitting in <persona>" reads as one visual group. */}
-			<div className="flex h-10 items-center gap-2 border-border border-t bg-muted px-2">
-				<div className="ml-auto inline-flex overflow-hidden rounded border border-border">
+			{/* Upper toolbar — context switcher only; Enter submits */}
+			<div className="flex h-9 items-center border-border border-t bg-muted/60 px-2">
+				<div className="ml-auto inline-flex overflow-hidden rounded-md border border-border/70">
 					{(["Pixel", "R", "Python", "Shell"] as const).map((c) => (
 						<Tooltip
 							key={c}
@@ -641,28 +705,18 @@ export const TerminalConsole = () => {
 						>
 							<button
 								type="button"
-								className={`flex items-center justify-center border-border border-r px-2 py-1 last:border-r-0 ${
+								className={`flex items-center justify-center border-border/70 border-r px-2 py-1 last:border-r-0 ${
 									state.context === c
 										? "bg-primary/15 text-primary"
-										: "bg-background text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+										: "bg-background/80 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
 								}`}
 								onClick={() => applyContext(c)}
 							>
-								<Logo name={c} className="h-4 w-4" />
+								<Logo name={c} className="h-3.5 w-3.5" />
 							</button>
 						</Tooltip>
 					))}
 				</div>
-
-				<Tooltip label={t("run.tooltip")} align="end">
-					<button
-						type="button"
-						className="rounded bg-primary px-3 py-1 text-primary-foreground text-sm hover:bg-primary/90"
-						onClick={execute}
-					>
-						{t("run.button")}
-					</button>
-				</Tooltip>
 			</div>
 
 			{/* Drag handle separating the input zone (editor + toolbar) from
@@ -686,40 +740,22 @@ export const TerminalConsole = () => {
 				data-section="transcript"
 			>
 				{history.length === 0 ? (
-					<div className="px-3 py-2 text-muted-foreground">
-						{t("emptyState.prefix")}{" "}
-						<kbd className="rounded border border-border bg-muted px-1 text-foreground">
-							Ctrl
-						</kbd>{" "}
-						{t("emptyState.and")}{" "}
-						<kbd className="rounded border border-border bg-muted px-1 text-foreground">
+					<div className="px-3 py-2 text-muted-foreground/70 text-xs">
+						Type a Pixel and press{" "}
+						<kbd className="rounded border border-border bg-muted px-1 text-[11px] text-foreground/80">
 							Enter
 						</kbd>{" "}
-						{t("emptyState.suffix")}
+						to run. Use{" "}
+						<kbd className="rounded border border-border bg-muted px-1 text-[11px] text-foreground/80">
+							↑↓
+						</kbd>{" "}
+						for history.
 					</div>
 				) : (
 					history.map((step) => (
 						<TranscriptRow key={step.id} step={step} />
 					))
 				)}
-			</div>
-
-			{/* Bottom toolbar — passive output controls (Copy recipe). The
-                old settings popover (Raw Output / Row Limit / Word Wrap)
-                wasn't actually wired into the rendering pipeline anymore;
-                per-row Raw/Formatted toggles + the JsonViewer cover those
-                needs now. */}
-			<div className="flex h-9 items-center gap-1 border-border border-t bg-muted px-2">
-				<Tooltip label={t("copyAll.tooltip")} align="start">
-					<button
-						type="button"
-						className="flex items-center gap-1.5 rounded px-2 py-1 text-muted-foreground text-xs hover:bg-accent hover:text-accent-foreground"
-						onClick={copyRecipe}
-					>
-						<CopyIcon className="h-3.5 w-3.5" />
-						{t("copyAll.button")}
-					</button>
-				</Tooltip>
 			</div>
 		</div>
 	);

--- a/packages/terminal/src/components/terminal-console/terminal-console.tsx
+++ b/packages/terminal/src/components/terminal-console/terminal-console.tsx
@@ -444,11 +444,16 @@ export const TerminalConsole = ({ projectId }: TerminalConsoleProps) => {
 	}, []);
 
 	// ---- pixel reactor typeahead -----------------------------------------
-	// Fetch the reactor catalog via help() + app-specific reactors when a
-	// project context is active (either from the `projectId` prop passed by
-	// the floating terminal, or from the built-in terminal's ScopePicker
-	// selecting an app via terminal.selectedApp).
+	// The autocomplete catalog is the merge of two independent sources:
+	//   - platform reactors from help() — identical for every project, so it
+	//     is fetched once on auth and never on a context switch.
+	//   - app-specific reactors via GetProjectAvailableReactors — re-fetched
+	//     only when the effective project changes.
+	// Keeping them in separate refs lets the project-dependent fetch re-run
+	// without dragging the project-independent help() call along with it.
 	const reactorsRef = useRef<ReactorSuggestion[]>([]);
+	const platformReactorsRef = useRef<ReactorSuggestion[]>([]);
+	const appReactorsRef = useRef<ReactorSuggestion[]>([]);
 
 	// Effective project: explicit prop wins; fall back to the terminal
 	// context's selectedApp when the file-explorer is in APP scope.
@@ -459,13 +464,26 @@ export const TerminalConsole = ({ projectId }: TerminalConsoleProps) => {
 				? terminal.selectedApp?.project_id
 				: undefined;
 
+	// Merge the two sources into the consumed catalog; platform names win.
+	const rebuildReactorCatalog = useCallback(() => {
+		const seen = new Set(platformReactorsRef.current.map((i) => i.name));
+		const merged = [...platformReactorsRef.current];
+		for (const r of appReactorsRef.current) {
+			if (!seen.has(r.name)) {
+				seen.add(r.name);
+				merged.push(r);
+			}
+		}
+		reactorsRef.current = merged;
+	}, []);
+
+	// Platform reactors via help() — fetched once per auth, not per project.
 	useEffect(() => {
 		if (!isAuthorized) return;
 		let cancelled = false;
 		(async () => {
 			try {
-				// 1. Platform reactors via help()
-				const helpResp = await runPixel<string>(actions, `help();`);
+				const helpResp = await runPixel<string>(actions, `Help();`);
 				if (cancelled) return;
 
 				const items: ReactorSuggestion[] = [];
@@ -492,27 +510,9 @@ export const TerminalConsole = ({ projectId }: TerminalConsoleProps) => {
 					}
 				}
 
-				// 2. App-specific reactors via GetProjectAvailableReactors
-				if (effectiveProjectId) {
-					const appResp = await runPixel<string[]>(
-						actions,
-						`GetProjectAvailableReactors(project=['${effectiveProjectId}']);`,
-					);
-					if (
-						!cancelled &&
-						appResp &&
-						Array.isArray(appResp.output)
-					) {
-						const existing = new Set(items.map((i) => i.name));
-						for (const name of appResp.output) {
-							if (name && !existing.has(name)) {
-								items.push({ name, meta: "app" });
-							}
-						}
-					}
-				}
-
-				if (!cancelled) reactorsRef.current = items;
+				if (cancelled) return;
+				platformReactorsRef.current = items;
+				rebuildReactorCatalog();
 			} catch {
 				// silently preserve whatever was previously in the catalog
 			}
@@ -520,7 +520,37 @@ export const TerminalConsole = ({ projectId }: TerminalConsoleProps) => {
 		return () => {
 			cancelled = true;
 		};
-	}, [isAuthorized, actions, effectiveProjectId]);
+	}, [isAuthorized, actions, rebuildReactorCatalog]);
+
+	// App-specific reactors — re-fetched only when the project context changes.
+	useEffect(() => {
+		if (!isAuthorized || !effectiveProjectId) {
+			appReactorsRef.current = [];
+			rebuildReactorCatalog();
+			return;
+		}
+		let cancelled = false;
+		(async () => {
+			try {
+				const appResp = await runPixel<string[]>(
+					actions,
+					`GetProjectAvailableReactors(project=['${effectiveProjectId}']);`,
+				);
+				if (cancelled) return;
+				if (appResp && Array.isArray(appResp.output)) {
+					appReactorsRef.current = appResp.output
+						.filter((name) => !!name)
+						.map((name) => ({ name, meta: "app" }));
+					rebuildReactorCatalog();
+				}
+			} catch {
+				// silently preserve whatever was previously in the catalog
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [isAuthorized, actions, effectiveProjectId, rebuildReactorCatalog]);
 
 	// Expose an external submission path so other panes (the file editor's
 	// Run button) can pipe their pixel through this transcript — same async

--- a/packages/terminal/src/components/terminal-console/transcript-row.tsx
+++ b/packages/terminal/src/components/terminal-console/transcript-row.tsx
@@ -2,14 +2,6 @@ import { CellOutputBlock } from "@semoss/shared";
 import { Logo } from "../../assets/logos";
 import type { ConsoleContext, ConsoleHistoryStep } from "../../types";
 
-/**
- * Thin adapter: turns a `ConsoleHistoryStep` (terminal's REPL transcript
- * shape) into the generic props expected by `<CellOutputBlock>` (the shared
- * notebook-style output renderer in `@semoss/shared`). All the actual UI —
- * panels, raw/formatted toggles, copy buttons, popout modal, JSON viewer —
- * lives in the shared component so the client's notebook code-cell can use
- * the same renderer.
- */
 interface TranscriptRowProps {
 	step: ConsoleHistoryStep;
 }

--- a/packages/terminal/src/components/terminal/scope-picker.tsx
+++ b/packages/terminal/src/components/terminal/scope-picker.tsx
@@ -32,6 +32,9 @@ export const ScopePicker = () => {
 	const selectedApp = terminal.selectedApp;
 	const setSelectedApp = terminal.setSelectedApp;
 	const [pickerOpen, setPickerOpen] = useState(false);
+	// True while LoadApp is running — disables the trigger button to prevent
+	// double-clicks queuing a second call before the first resolves.
+	const [loadingApp, setLoadingApp] = useState(false);
 
 	// search + pagination state
 	const [search, setSearch] = useState("");
@@ -163,12 +166,20 @@ export const ScopePicker = () => {
 				<div className="relative" ref={pickerWrapRef}>
 					<button
 						type="button"
-						className={`flex w-full items-center gap-2 rounded border border-border bg-background px-2 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground ${
+						disabled={loadingApp}
+						className={`flex w-full items-center gap-2 rounded border border-border bg-background px-2 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground disabled:opacity-60 ${
 							pickerOpen ? "border-ring" : ""
 						}`}
-						onClick={() => setPickerOpen((v) => !v)}
+						onClick={() => !loadingApp && setPickerOpen((v) => !v)}
 					>
-						{selectedApp ? (
+						{loadingApp ? (
+							<>
+								<span className="inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-primary" />
+								<span className="flex-1 text-muted-foreground text-xs">
+									{t("scope.loadingProjects")}
+								</span>
+							</>
+						) : selectedApp ? (
 							<>
 								<AppCatalogAvatar
 									name={selectedApp.project_name}
@@ -188,7 +199,9 @@ export const ScopePicker = () => {
 								{t("scope.selectProject")}
 							</span>
 						)}
-						<span className="text-muted-foreground">▾</span>
+						{!loadingApp && (
+							<span className="text-muted-foreground">▾</span>
+						)}
 					</button>
 
 					{pickerOpen && (
@@ -245,19 +258,43 @@ export const ScopePicker = () => {
 												? "bg-primary/10"
 												: ""
 										}`}
-										onClick={() => {
-											setSelectedApp(app);
+										onClick={async () => {
 											setPickerOpen(false);
-											// attach the project so
-											// app-scoped reactors (GetAppAssets,
-											// etc.) have what they need
-											// server-side
-											runPixel(
-												actions,
-												`LoadApp("${app.project_id}");`,
-											).catch(() => {
-												/* errors surface on next call */
-											});
+											setLoadingApp(true);
+											try {
+												// LoadApp initializes the project's
+												// reactor hash server-side — await it
+												// before updating selectedApp so that
+												// TerminalConsole's GetProjectAvailableReactors
+												// call sees a populated hash.
+												const result = await runPixel(
+													actions,
+													`LoadApp("${app.project_id}");`,
+												);
+												// Only update context if LoadApp succeeded
+												if (
+													result &&
+													!result.operationType.some(
+														(t) =>
+															t.indexOf("ERROR") >
+															-1,
+													)
+												) {
+													setSelectedApp(app);
+												} else {
+													terminal.alert(
+														"error",
+														`Failed to load app: ${app.project_name}`,
+													);
+												}
+											} catch {
+												terminal.alert(
+													"error",
+													`Failed to load app: ${app.project_name}`,
+												);
+											} finally {
+												setLoadingApp(false);
+											}
 										}}
 										title={app.project_id}
 									>


### PR DESCRIPTION
## Description

Improves the SEMOSS terminal's developer experience across three areas: **autocomplete quality**, **result readability**, and **correctness**. Adds app-specific reactor suggestions when a project context is active, makes the result panel collapsible so large JSON responses don't bury the input, and fixes a set of correctness bugs found in code review.

---

## Changes Made

### Modified Components

| File | Description |
|------|-------------|
| `packages/terminal/src/components/terminal-console/terminal-console.tsx` | Enter key executes (was Ctrl+Enter only); Up/Down arrows gated on `!suggestWidgetVisible` so Monaco autocomplete navigation works; Run button and Copy All toolbar removed; app-specific reactor catalog fetched via `GetProjectAvailableReactors` and merged with platform `help()` results; completion providers scoped per-editor to prevent duplicate suggestions across mounted instances; providers disposed on unmount; dead `copyRecipe` function and unused `CopyIcon` import removed; `try/catch` + `Array.isArray` guard around catalog fetch IIFE |
| `packages/terminal/src/components/terminal-console/transcript-row.tsx` | Removed stale JSDoc comment |
| `packages/terminal/src/components/terminal/scope-picker.tsx` | `LoadApp` now awaited before `setSelectedApp` so `GetProjectAvailableReactors` sees an initialised project hash; `loadingApp` state disables the trigger button and shows a spinner during load, preventing double-clicks; `setSelectedApp` only fires on successful `LoadApp` — failures surface an alert instead of silently corrupting the file-explorer scope |
| `libs/shared/src/components/cell-output/cell-output-block.tsx` | Result panel (`accent="blue"`) marked `collapsible` — clicking the blue header bar toggles the output, making it easy to collapse large JSON responses without scrolling |

---

## How to Test

### 1. Enter key executes

```
1. Open the terminal (packages/terminal/dist or embedded in the workspace)
2. Type any Pixel command
3. Press Enter — it should execute immediately
4. Shift+Enter / multi-line still inserts a newline via Monaco defaults
```

### 2. Autocomplete navigation works

```
1. Type a partial reactor name (e.g. "Get")
2. The Monaco autocomplete popup appears
3. Press Up/Down — it navigates the suggestion list (was previously jumping history)
4. Press Enter — accepts the selected suggestion (was previously executing the command)
```

### 3. App-specific reactors in autocomplete

```
1. In the file explorer, switch scope to "APP" and select an app that has custom Java reactors
2. The trigger button shows a spinner while LoadApp initialises the project
3. After the spinner clears, type a partial reactor name unique to that app
4. The autocomplete list includes the app's custom reactors (labeled "app") alongside platform reactors
5. Switching scope back to INSIGHT removes the app-specific suggestions on next mount
```

### 4. LoadApp failure handling

```
1. Select an app in scope picker
2. If LoadApp fails (e.g. permissions): the spinner clears, an error alert appears, and the selected app does NOT update — the file explorer stays on the previous scope
```

### 5. Collapsible result panel

```
1. Run a Pixel that returns a large JSON response (e.g. GetAllClaims)
2. The blue RESULT panel renders expanded — read the output
3. Click the blue "RESULT · N lines · X KB" header bar → it collapses in place
4. The transcript is now compact; earlier commands are visible without scrolling
5. Click the header again → expands
```

---

## Notes

- **`GetProjectAvailableReactors`** is the correct pixel for app-specific reactor names — `help()` only returns the static platform catalog regardless of `SetContext`. Both calls are merged and deduplicated by name.
- **Completion provider scoping**: Monaco's `registerCompletionItemProvider` is a global registration. The provider now checks `editorRef.current?.getModel() !== model` and returns empty suggestions for any editor it doesn't own — this prevents duplicate suggestion entries when multiple `TerminalConsole` instances are mounted simultaneously (e.g. floating terminal tabs).
- **`LoadApp` sequencing**: `setSelectedApp` previously fired before `LoadApp` resolved (fire-and-forget). `GetProjectAvailableReactors` called immediately after would read an uninitialised `projectSpecificHash` and return an empty list. The await + success check fixes this ordering.
- **No new dependencies**: all changes are within existing packages.
- **Biome**: passes `pnpm check` with no errors (10 pre-existing exhaustive-deps warnings unchanged).
