### PR TITLE
feat: added last login tracking functionality

### DIFF
--- a/packages/client/src/components/shared/LogoutPopover.tsx
+++ b/packages/client/src/components/shared/LogoutPopover.tsx
@@ -86,28 +86,15 @@ export const LogoutPopover: React.FC<LogoutPopoverProps> = (props) => {
 							{configStore.store.user.name}
 						</span>
 					</div>
-					{/* Last login info row */}
-					{configStore.store.user.lastLoginFromTracking && (
-						<div className="flex items-center justify-center border-border border-b px-4 py-2">
-							<span className="text-muted-foreground text-xs">
-								Last login:{" "}
-								{`${new Date(
-									configStore.store.user
-										.lastLoginFromTracking,
-								)
-									.toLocaleString("sv-SE", {
-										year: "numeric",
-										month: "2-digit",
-										day: "2-digit",
-										hour: "2-digit",
-										minute: "2-digit",
-										second: "2-digit",
-										hour12: false,
-									})
-									.replace(",", "")} UTC`}
-							</span>
-						</div>
-					)}
+					{configStore.store.user.lastLogin &&
+						configStore.store.user.lastLogin !== "null" && (
+							<div className="flex items-center justify-center border-border border-b px-4 py-2">
+								<span className="text-muted-foreground text-xs">
+									Last login:{" "}
+									{configStore.store.user.lastLogin} UTC
+								</span>
+							</div>
+						)}
 					{/* Logout button row */}
 					<div className="flex items-center justify-center border-border border-b px-4 py-3">
 						<Button

--- a/packages/client/src/stores/config/config.store.ts
+++ b/packages/client/src/stores/config/config.store.ts
@@ -30,7 +30,6 @@ interface ConfigStoreInterface {
 		admin: boolean;
 		meta: unknown;
 		lastLogin?: string;
-		lastLoginFromTracking?: string;
 		groupInfo?: { groups: string[] };
 	};
 	/** Native mode */
@@ -525,9 +524,6 @@ export class ConfigStore {
 				this._store.userEpoch = user.userEpoch;
 				this._store.user.lastLogin = (user as Record<string, unknown>)
 					.lastLogin as string | undefined;
-				this._store.user.lastLoginFromTracking = (
-					user as Record<string, unknown>
-				).lastLoginFromTracking as string | undefined;
 				this._store.user.groupInfo = (user as Record<string, unknown>)
 					.groupInfo as { groups: string[] } | undefined;
 


### PR DESCRIPTION
## Description
Surfaces the last logged-in date in the user profile popover as a security checkpoint. `lastLogin` is already stored in `SMSS_USER`, returned by the `GetUserInfo` reactor, and held in the config store — this change simply displays it in the UI with no backend changes required.

> The `USER_TRACKING` table was not used; `lastLogin` from `SMSS_USER` was already available.

## Changes Made
- **`LogoutPopover.tsx`** — Added a "Last login: `<value>` UTC" row below the username, conditionally rendered when `lastLogin` is present and non-null.

## How to Test
- Log in to SEMOSS.
- Click your profile/avatar (bottom-left user menu).
- Verify **Last login** appears below your name.
<img width="1084" height="1064" alt="image" src="https://github.com/user-attachments/assets/209f3e91-ea0e-48c1-aedc-d09ef2f623ba" />
