### PR TITLE
fix: update overflow logic for tool calls with large sizes

### DIFF
--- a/packages/playground/src/components/message/response-message-text.tsx
+++ b/packages/playground/src/components/message/response-message-text.tsx
@@ -211,7 +211,8 @@ export const ResponseMessageText: React.FC<ResponseMessageTextProps> = observer(
 								<Markdown
 									dir="auto"
 									components={components}
-									className="[&>*:first-child]:mt-0"
+									// wrap-anywhere: breaks long tokens and collapses min-width so they don't overflow the scroll area
+									className="wrap-anywhere [&>*:first-child]:mt-0"
 									urlTransform={urlTransform}
 								>
 									{postTypewriter.isTyping
@@ -226,7 +227,8 @@ export const ResponseMessageText: React.FC<ResponseMessageTextProps> = observer(
 							<Markdown
 								dir="auto"
 								components={components}
-								className="[&>*:first-child]:mt-0"
+								// wrap-anywhere: breaks long tokens and collapses min-width so they don't overflow the scroll area
+								className="wrap-anywhere [&>*:first-child]:mt-0"
 								urlTransform={urlTransform}
 							>
 								{typewriter.isTyping &&
@@ -251,7 +253,8 @@ export const ResponseMessageText: React.FC<ResponseMessageTextProps> = observer(
 								<Markdown
 									dir="auto"
 									components={components}
-									className="[&>*:first-child]:mt-0"
+									// wrap-anywhere: breaks long tokens and collapses min-width so they don't overflow the scroll area
+									className="wrap-anywhere [&>*:first-child]:mt-0"
 									urlTransform={urlTransform}
 								>
 									{postTypewriter.isTyping
@@ -264,7 +267,8 @@ export const ResponseMessageText: React.FC<ResponseMessageTextProps> = observer(
 					<Markdown
 						dir="auto"
 						components={components}
-						className="[&>*:first-child]:mt-0"
+						// wrap-anywhere: breaks long tokens and collapses min-width so they don't overflow the scroll area
+						className="wrap-anywhere [&>*:first-child]:mt-0"
 						urlTransform={urlTransform}
 					>
 						{renderedText}

--- a/packages/playground/src/components/room/room-content.tsx
+++ b/packages/playground/src/components/room/room-content.tsx
@@ -318,7 +318,8 @@ export const RoomContent: React.FC<RoomContentProps> = observer(({ room }) => {
 		<div className="flex h-full w-full flex-col bg-background transition-all duration-200 ease-in-out">
 			<div className="relative w-full flex-1 overflow-hidden">
 				<ScrollArea
-					className="h-full w-full overflow-hidden"
+					// Force Radix's table-display viewport wrapper to block so wide content can't push the column past the viewport width
+					className="[&_[data-slot=scroll-area-viewport]>div]:!block h-full w-full overflow-hidden"
 					viewportRef={(ele) => {
 						setScrollEle(ele);
 					}}


### PR DESCRIPTION
## Description
Update playground to confine tool ui's to the viewport of the playground

## How to Test
1. Call tool in playground inline with a very large size screen
2. Tool viewport should stay the width of the playground and allow scroll in the tool viewport for viewing

## Notes
also made a quick change to the actual font display of the tools to do better word wrapping of the actual llm reponse