### PR TITLE
feat(shared): show context window even when below 12.5

### DIFF
--- a/libs/shared/src/components/engine/engine-select.tsx
+++ b/libs/shared/src/components/engine/engine-select.tsx
@@ -220,12 +220,12 @@ export const EngineSelect = ({
 			: undefined;
 
 	const showContextIndicator =
-		contextUsedPercent !== undefined && contextUsedPercent >= 12.5;
+		contextUsedPercent !== undefined && contextUsedPercent > 0;
 
 	// Calculate pie chart geometry
 	const roundedPercent =
-		contextUsedPercent !== undefined
-			? Math.round(contextUsedPercent / 12.5) * 12.5
+		contextUsedPercent !== undefined && contextUsedPercent > 0
+			? Math.max(12.5, Math.round(contextUsedPercent / 12.5) * 12.5)
 			: 0;
 	const radius = 8;
 	const cx = 9;


### PR DESCRIPTION
## Description
The context window pie chart in the engine select modal was hidden until usage reached 12.5% (one full slice). Now it appears as soon as any tokens are used, always rendering at least the minimum 1/8 slice.

## Changes Made
- **engine-select.tsx:** Lowered `showContextIndicator` threshold from `>= 12.5` to `> 0`
- **engine-select.tsx:** Clamped `roundedPercent` to a minimum of `12.5` when usage is nonzero, so the geometry never collapses to an invisible arc

## How to Test
1. Open a new room — the context indicator should not be visible
2. Send a message — the indicator should appear showing at least the minimum 1/8 slice