### PR TITLE
feat(audit-log): revamp audit logs dashboard, filters, and timeline

### DIFF
--- a/libs/shared/src/api/permissions.ts
+++ b/libs/shared/src/api/permissions.ts
@@ -29,6 +29,33 @@ export const getUserProjectPermission = async (
 };
 
 /**
+ * Get the current user's permission for an engine
+ * @param engineId - The engine ID
+ * @param admin - Whether to use admin endpoint
+ * @returns The user's permission level
+ */
+export const getUserEnginePermission = async (
+	engineId: string,
+	admin = false,
+): Promise<Role> => {
+	let url = `${Env.MODULE}/api/auth/`;
+	if (admin) {
+		url += "admin/";
+	}
+	url += `engine/getUserEnginePermission?engineId=${engineId}`;
+
+	const response = await get<{ permission: Role }>(url).catch((error) => {
+		throw Error(error);
+	});
+
+	if (!response) {
+		throw Error("No Response to get permission");
+	}
+
+	return response.data.permission;
+};
+
+/**
  * Get users with access to a project
  * @param projectId - The project ID
  * @param admin - Whether to use admin endpoint

--- a/libs/shared/src/components/auditlog/audit-log-filter.tsx
+++ b/libs/shared/src/components/auditlog/audit-log-filter.tsx
@@ -1,6 +1,6 @@
 // biome-ignore-all lint/correctness/useExhaustiveDependencies: TODO
-import { ChevronDownIcon } from "lucide-react";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronDownIcon, Search, X } from "lucide-react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { runPixel } from "@semoss/sdk";
 import {
 	Button,
@@ -14,10 +14,28 @@ import {
 	DropdownMenuTrigger,
 	Input,
 	Popover,
-	PopoverAnchor,
 	PopoverContent,
+	PopoverTrigger,
 } from "@semoss/ui/next";
+import {
+	getUserEnginePermission,
+	getUserProjectPermission,
+} from "../../api/permissions";
 import { dateFormat, ENGINE_TYPES } from "./common";
+import {
+	type AuditLogDateRangeType,
+	type AuditLogScope,
+	type AuditLogUserOption,
+	buildFilterOptionListPixel,
+	hasScope,
+	parseSimpleFilterOptions,
+	parseUserFilterOptions,
+	resolveDateParams,
+} from "./pixel";
+
+//A userId can repeat across auth providers, so options are keyed by userId+userType.
+const userOptionKey = (user: AuditLogUserOption) =>
+	`${user.userId}::${user.userType}`;
 
 //initial state of engine details
 const initialAcc = {
@@ -50,199 +68,553 @@ const DashboardDurations = [
 		dateRangeType: "CUSTOM",
 		dateRangeValue: 1,
 	},
-];
+] as const;
+
+interface AuditLogFilterProps {
+	insightId: string;
+	updateLogs: (value: import("./pixel").AuditLogFilterValue) => void;
+	//"client" hides the scope selectors (scope comes from the route via `scope`);
+	//null renders the engine-type + engine pickers used to choose the scope.
+	parent?: "client" | null;
+	//Fixed scope for the contextual client dashboard (project/engine from the route).
+	scope?: AuditLogScope | null;
+	//Hide the room-id dropdown (e.g. when already scoped to a single room).
+	hideRoomFilter?: boolean;
+	//Hide the date-range control (e.g. in the room activity log).
+	hideDateFilter?: boolean;
+	//Right-aligned actions rendered on the search line (e.g. export / refresh).
+	actions?: React.ReactNode;
+}
+
+//A compact multi-select dropdown backed by the server-driven option lists.
+const MultiSelectDropdown = ({
+	label,
+	options,
+	selected,
+	onChange,
+	onOpen,
+	loading,
+	disabled,
+}: {
+	label: string;
+	options: string[];
+	selected: string[];
+	onChange: (next: string[]) => void;
+	//Called when the menu opens, so options are fetched on demand (not on page load).
+	onOpen?: () => void;
+	loading?: boolean;
+	disabled?: boolean;
+}) => {
+	const summary =
+		selected.length === 0
+			? label
+			: selected.length === 1
+				? selected[0]
+				: `${label} (${selected.length})`;
+	return (
+		<DropdownMenu
+			onOpenChange={(open) => {
+				if (open) onOpen?.();
+			}}
+		>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="outline"
+					size="sm"
+					disabled={disabled}
+					className="flex w-[150px] justify-between self-center"
+				>
+					<span className="truncate">{summary}</span>
+					<ChevronDownIcon className="ms-2 size-4 shrink-0" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent className="max-h-[300px] overflow-y-auto">
+				{loading ? (
+					<div className="px-2 py-1.5 text-muted-foreground text-sm">
+						Loading…
+					</div>
+				) : options.length === 0 ? (
+					<div className="px-2 py-1.5 text-muted-foreground text-sm">
+						No options
+					</div>
+				) : (
+					options.map((option) => (
+						<DropdownMenuCheckboxItem
+							key={`${label}-${option}`}
+							checked={selected.includes(option)}
+							onCheckedChange={(checked) => {
+								onChange(
+									checked
+										? [...selected, option]
+										: selected.filter(
+												(value) => value !== option,
+											),
+								);
+							}}
+							onSelect={(event) => event.preventDefault()}
+						>
+							{option}
+						</DropdownMenuCheckboxItem>
+					))
+				)}
+				{selected.length > 0 && (
+					<>
+						<DropdownMenuSeparator />
+						<Button
+							variant="ghost"
+							size="sm"
+							className="w-full justify-start font-normal"
+							onClick={() => onChange([])}
+						>
+							<X className="me-2 size-4" />
+							Clear
+						</Button>
+					</>
+				)}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+};
 
 /**
- * AuditLogFilter component is used for filtering audit logs
- * It filters by engine type, engine id, and dashboard duration.
- * It also provides a custom date range feature for filtering audit logs.
+ * AuditLogFilter component is used for filtering audit logs.
  *
- * @param {React.ComponentProps} props - The props passed to the component
- * @returns {JSX.Element} - The rendered component shows filter details for audit logs if it is auditlogs package, every filters are shown and for client package it will show duration filter
+ * It drives the server-side filter set documented by the AuditLogsReport contract:
+ * scope (engine type + engine, when not contextual), date range, method name,
+ * engine type, the owner-only user filter, and the global search term. Filter
+ * options are populated from GetAuditLogsReportFilterOptionList and the user
+ * filter is only shown to owners of the scoped project/engine.
+ *
+ * @param {AuditLogFilterProps} props - The props passed to the component
+ * @returns {JSX.Element} - The rendered filter bar
  */
-export const AuditLogFilter = (props) => {
-	const { insightId, updateLogs, parent = null } = props;
+export const AuditLogFilter = (props: AuditLogFilterProps) => {
+	const {
+		insightId,
+		updateLogs,
+		parent = null,
+		scope = null,
+		hideRoomFilter = false,
+		hideDateFilter = false,
+		actions = null,
+	} = props;
 	const [engineDetails, setEngineDetails] = useState({ ...initialAcc }); //engine details for user
 	const [engineSelectionDetails, setEngineSelectionDetails] = useState({
-		engineType: "", // selected engine type
-		engineId: "", //selected engine id
+		engineType: "", // selected scope engine type
+		engineId: "", //selected scope engine id
 	});
-	const [dashboardDuration, setDashboardDuration] =
-		useState<(typeof DashboardDurations)[number]["value"]>(""); //selected dashboard duration
-	const [showCustomPopover, setShowCustomPopover] = useState<boolean>(false); //show custom popover for custom date range
+	const [dashboardDuration, setDashboardDuration] = useState<
+		(typeof DashboardDurations)[number]["value"] | ""
+	>(""); //selected dashboard duration
+	const [dateOpen, setDateOpen] = useState<boolean>(false); //date-range popover open state
 	const [customDateRange, setCustomDateRange] = useState<DateRange | null>({
 		from: new Date(),
 		to: new Date(),
 	}); //custom date range data
 
-	//fetch engines for user
+	//Server-side filters (driven by GetAuditLogsReportFilterOptionList). Option
+	//lists are fetched lazily when a dropdown is opened, not on page load.
+	const [methodOptions, setMethodOptions] = useState<string[]>([]);
+	const [engineTypeOptions, setEngineTypeOptions] = useState<string[]>([]);
+	const [userOptions, setUserOptions] = useState<AuditLogUserOption[]>([]);
+	const [loadingFilters, setLoadingFilters] = useState<
+		Record<string, boolean>
+	>({});
+	//Tracks the scope+date key each option list was last fetched for, so reopening
+	//a dropdown doesn't refetch unless the scope or date window changed.
+	const loadedKeyRef = useRef<Record<string, string>>({});
+	const [selectedMethods, setSelectedMethods] = useState<string[]>([]);
+	const [selectedEngineTypes, setSelectedEngineTypes] = useState<string[]>(
+		[],
+	);
+	const [selectedUserKey, setSelectedUserKey] = useState<string>("");
+	const [searchInput, setSearchInput] = useState<string>("");
+	const [searchTerm, setSearchTerm] = useState<string>("");
+	const [roomOptions, setRoomOptions] = useState<string[]>([]);
+	const [selectedRoomId, setSelectedRoomId] = useState<string>("");
+	const [isOwner, setIsOwner] = useState<boolean>(false);
+
+	//The scope the report is actually run against. For the contextual client
+	//dashboard it is supplied by the page; otherwise it follows the pickers.
+	const effectiveScope = useMemo<AuditLogScope | null>(() => {
+		if (parent === "client") {
+			return scope ?? null;
+		}
+		if (!engineSelectionDetails.engineId) {
+			return null;
+		}
+		return engineSelectionDetails.engineType === "APP"
+			? { projectId: engineSelectionDetails.engineId }
+			: { engineId: engineSelectionDetails.engineId };
+	}, [parent, scope, engineSelectionDetails]);
+
+	//Stable key so scope-dependent effects only refire on a real scope change.
+	const scopeKey = useMemo(
+		() => JSON.stringify(effectiveScope ?? {}),
+		[effectiveScope],
+	);
+
+	//fetch engines + projects for the scope pickers (only when not contextual)
 	useEffect(() => {
+		if (parent === "client" || !insightId) return;
 		async function getMyEngines() {
-			if (insightId) {
-				const response = await runPixel(`MyEngines();`, insightId);
-				const responseData = response.pixelReturn[0].output;
-				let enginesDropdown = (
-					responseData as Array<{
-						engine_id: string;
-						engine_type: string;
-						engine_name: string;
-					}>
-				).reduce(
-					(acc, engine) => {
-						// Only accept known engine types
-						if (Object.hasOwn(acc, engine.engine_type)) {
-							acc[engine.engine_type] = [
-								...acc[engine.engine_type],
-								{
-									value: engine.engine_id,
-									label: engine.engine_name,
-								},
-							];
-						}
-						return acc;
-					},
-					{ ...initialAcc },
-				);
-				const projectResponse = await runPixel(
-					`MyProjects();`,
-					insightId,
-				);
-				const projectResponseData =
-					projectResponse.pixelReturn[0].output;
-				const projectsDropdown = (
-					projectResponseData as Array<{
-						project_id: string;
-						project_type: string;
-						project_name: string;
-					}>
-				).reduce(
-					(acc, engine) => {
-						// Only accept known engine types
-						if (Object.hasOwn(acc, "APP")) {
-							acc.APP = [
-								...acc.APP,
-								{
-									value: engine.project_id,
-									label: engine.project_name,
-								},
-							];
-						}
-						return acc;
-					},
-					{ ...initialAcc },
-				);
-				enginesDropdown = {
-					...enginesDropdown,
-					APP: projectsDropdown.APP,
-				};
-				setEngineDetails((prev) => ({ ...prev, ...enginesDropdown }));
-			}
+			const response = await runPixel(`MyEngines();`, insightId);
+			const responseData = response.pixelReturn[0].output;
+			let enginesDropdown = (
+				responseData as Array<{
+					engine_id: string;
+					engine_type: string;
+					engine_name: string;
+				}>
+			).reduce(
+				(acc, engine) => {
+					if (Object.hasOwn(acc, engine.engine_type)) {
+						acc[engine.engine_type] = [
+							...acc[engine.engine_type],
+							{
+								value: engine.engine_id,
+								label: engine.engine_name,
+							},
+						];
+					}
+					return acc;
+				},
+				{ ...initialAcc },
+			);
+			const projectResponse = await runPixel(`MyProjects();`, insightId);
+			const projectResponseData = projectResponse.pixelReturn[0].output;
+			const projectsDropdown = (
+				projectResponseData as Array<{
+					project_id: string;
+					project_type: string;
+					project_name: string;
+				}>
+			).reduce(
+				(acc, project) => {
+					if (Object.hasOwn(acc, "APP")) {
+						acc.APP = [
+							...acc.APP,
+							{
+								value: project.project_id,
+								label: project.project_name,
+							},
+						];
+					}
+					return acc;
+				},
+				{ ...initialAcc },
+			);
+			enginesDropdown = {
+				...enginesDropdown,
+				APP: projectsDropdown.APP,
+			};
+			setEngineDetails((prev) => ({ ...prev, ...enginesDropdown }));
 		}
 		getMyEngines();
-	}, [insightId]);
+	}, [insightId, parent]);
+
 	//getting details about label, value, daterangetype and value of selected dashboard duration
 	const SelectedDuration = useMemo(() => {
 		return (
 			DashboardDurations.find(
 				(duration) => duration.value === dashboardDuration,
-			) || { label: "", value: "", dateRangeType: "", dateRangeValue: 1 }
+			) || {
+				label: "",
+				value: "",
+				dateRangeType: "DAY" as AuditLogDateRangeType,
+				dateRangeValue: 1,
+			}
 		);
 	}, [dashboardDuration]);
-	//logs table will be updated when engineid or duration or daterange or engine type
+
+	//Resolved date params shared with the table, the option lists, and the export.
+	const dateParams = useMemo(
+		() =>
+			resolveDateParams({
+				dateRangeType: SelectedDuration.dateRangeType,
+				dateRangeValue: SelectedDuration.dateRangeValue,
+				customDateRange: customDateRange
+					? {
+							from: customDateRange.from ?? null,
+							to: customDateRange.to ?? null,
+						}
+					: undefined,
+			}),
+		[SelectedDuration, customDateRange],
+	);
+	//Stable key so date-dependent effects only refire on a real date change.
+	const dateKey = useMemo(() => JSON.stringify(dateParams), [dateParams]);
+
+	//The currently selected user option (keyed by userId+userType).
+	const selectedUser = useMemo(
+		() =>
+			userOptions.find((user) => userOptionKey(user) === selectedUserKey),
+		[userOptions, selectedUserKey],
+	);
+
+	//Resolve ownership for the scoped project/engine. The owner-only user filter
+	//is hidden for non-owners (the backend auto-scopes them to their own logs).
 	useEffect(() => {
-		// Implementation for triggering logs API
-		if (engineSelectionDetails.engineId !== "" || parent) {
-			updateLogs({
-				engineId: engineSelectionDetails.engineId,
-				duration: dashboardDuration,
-				customDateRange: customDateRange,
-				engineType: engineSelectionDetails.engineType,
-				SelectedDuration: SelectedDuration,
-			});
+		let cancelled = false;
+		setIsOwner(false);
+		setSelectedUserKey("");
+		if (!hasScope(effectiveScope) || !effectiveScope) return;
+		const resolveOwnership = async () => {
+			try {
+				let permission: string | undefined;
+				if (effectiveScope.projectId) {
+					permission = await getUserProjectPermission(
+						effectiveScope.projectId,
+					);
+				} else if (effectiveScope.engineId) {
+					permission = await getUserEnginePermission(
+						effectiveScope.engineId,
+					);
+				}
+				if (!cancelled) setIsOwner(permission === "OWNER");
+			} catch (error) {
+				if (!cancelled) setIsOwner(false);
+				console.error("Error resolving audit log ownership:", error);
+			}
+		};
+		resolveOwnership();
+		return () => {
+			cancelled = true;
+		};
+	}, [scopeKey]);
+
+	//Reset selections + cached option lists whenever the scope or date window
+	//changes, so stale picks/options don't leak across engines or time ranges. The
+	//options themselves are (re)fetched lazily the next time a dropdown is opened.
+	useEffect(() => {
+		setSelectedMethods([]);
+		setSelectedEngineTypes([]);
+		setSelectedRoomId("");
+		setMethodOptions([]);
+		setEngineTypeOptions([]);
+		setRoomOptions([]);
+		setUserOptions([]);
+		loadedKeyRef.current = {};
+	}, [scopeKey, dateKey]);
+
+	//Fetch a single option list on demand (when its dropdown opens), caching by
+	//scope+date so we don't refetch on every open. runPixel resolves even on
+	//pixel-level errors, so surface those instead of silently showing "no values".
+	const ensureSimpleOptions = (
+		filterName: "methodName" | "engineType" | "roomId",
+		setOptions: (options: string[]) => void,
+	) => {
+		if (!hasScope(effectiveScope) || !effectiveScope || !insightId) return;
+		const key = `${scopeKey}|${dateKey}`;
+		if (loadedKeyRef.current[filterName] === key) return;
+		loadedKeyRef.current[filterName] = key;
+		setLoadingFilters((prev) => ({ ...prev, [filterName]: true }));
+		runPixel(
+			buildFilterOptionListPixel({
+				filterName,
+				scope: effectiveScope,
+				date: hideDateFilter ? undefined : dateParams,
+			}),
+			insightId,
+		)
+			.then((response) => {
+				const result = response.pixelReturn[0];
+				if (result.operationType?.indexOf("ERROR") > -1) {
+					console.error(
+						`Audit log ${filterName} option list returned an error:`,
+						result.output,
+					);
+				}
+				setOptions(parseSimpleFilterOptions(result.output));
+			})
+			.catch((error) => {
+				loadedKeyRef.current[filterName] = ""; //allow a retry on next open
+				setOptions([]);
+				console.error(
+					`Error loading audit log ${filterName} options:`,
+					error,
+				);
+			})
+			.finally(() =>
+				setLoadingFilters((prev) => ({ ...prev, [filterName]: false })),
+			);
+	};
+
+	//Fetch the owner-only user option list on demand (when its dropdown opens).
+	const ensureUserOptions = () => {
+		if (
+			!hasScope(effectiveScope) ||
+			!effectiveScope ||
+			!insightId ||
+			!isOwner
+		) {
+			return;
 		}
+		const key = `${scopeKey}|${dateKey}`;
+		if (loadedKeyRef.current.user === key) return;
+		loadedKeyRef.current.user = key;
+		setLoadingFilters((prev) => ({ ...prev, user: true }));
+		runPixel(
+			buildFilterOptionListPixel({
+				filterName: "user",
+				scope: effectiveScope,
+				date: hideDateFilter ? undefined : dateParams,
+			}),
+			insightId,
+		)
+			.then((response) => {
+				setUserOptions(
+					parseUserFilterOptions(response.pixelReturn[0].output),
+				);
+			})
+			.catch((error) => {
+				loadedKeyRef.current.user = "";
+				setUserOptions([]);
+				console.error("Error loading audit log user options:", error);
+			})
+			.finally(() =>
+				setLoadingFilters((prev) => ({ ...prev, user: false })),
+			);
+	};
+
+	//Debounce the global search input so we don't refetch on every keystroke.
+	useEffect(() => {
+		const handle = setTimeout(() => setSearchTerm(searchInput), 400);
+		return () => clearTimeout(handle);
+	}, [searchInput]);
+
+	//Emit the full filter value whenever anything changes (once a scope exists).
+	useEffect(() => {
+		if (!hasScope(effectiveScope)) return;
+		updateLogs({
+			scope: effectiveScope,
+			dateRangeType: SelectedDuration.dateRangeType,
+			dateRangeValue: SelectedDuration.dateRangeValue,
+			customDateRange: {
+				from: customDateRange?.from ?? null,
+				to: customDateRange?.to ?? null,
+			},
+			methodNames: selectedMethods,
+			engineTypes: selectedEngineTypes,
+			filterUserId: isOwner ? (selectedUser?.userId ?? "") : "",
+			roomId: selectedRoomId,
+			searchTerm,
+		});
 	}, [
-		engineSelectionDetails.engineId,
-		dashboardDuration,
+		scopeKey,
+		SelectedDuration.dateRangeType,
+		SelectedDuration.dateRangeValue,
 		customDateRange,
-		engineSelectionDetails.engineType,
+		selectedMethods,
+		selectedEngineTypes,
+		selectedUser,
+		selectedRoomId,
+		searchTerm,
+		isOwner,
 	]);
-	//render custom date popover
-	const renderCustomDatePopover = useCallback(() => {
-		if (!showCustomPopover) return null;
-		return (
-			<Popover open={showCustomPopover}>
-				<PopoverAnchor>
-					<PopoverContent className="flex w-[75%] flex-col gap-4 p-4">
-						<div className="flex justify-between gap-2">
-							<Input
-								value={dateFormat(
-									customDateRange.from?.toString(),
-								)}
-								type="text"
-								className="w-[50%]"
-							></Input>
-							<Input
-								value={dateFormat(
-									customDateRange.to?.toString(),
-								)}
-								type="text"
-								className="w-[50%]"
-							></Input>
-						</div>
-						<div className="flex justify-around">
-							<Calendar
-								mode="range"
-								selected={customDateRange}
-								onSelect={(daterange) => {
-									if (daterange?.from && daterange?.to) {
-										setCustomDateRange(daterange);
-									}
-								}}
-								className="rounded-md border shadow-sm"
-								captionLayout="dropdown"
-								timeZone="UTC"
-								disabled={{
-									after: new Date(new Date().toUTCString()),
-								}}
-							/>
-						</div>
-						<div className="flex justify-between">
-							<Button
-								variant="outline"
-								size="sm"
-								onClick={() => {
-									setShowCustomPopover(false);
-								}}
-							>
-								Close
-							</Button>
-							<Button
-								variant="outline"
-								className="w-fit justify-end bg-primary text-white"
-								size="sm"
-								onClick={() => {
-									setShowCustomPopover(false);
-								}}
-							>
-								Apply
-							</Button>
-						</div>
-					</PopoverContent>
-				</PopoverAnchor>
-			</Popover>
-		);
-	}, [showCustomPopover, customDateRange, engineSelectionDetails.engineId]);
+
+	//Calendar content shown under the date dropdown when "Custom" is selected.
+	const customDateContent = (
+		<div className="flex w-[320px] max-w-[90vw] flex-col gap-4">
+			<div className="flex justify-between gap-2">
+				<Input
+					value={dateFormat(customDateRange?.from?.toString())}
+					type="text"
+					className="w-[50%]"
+				></Input>
+				<Input
+					value={dateFormat(customDateRange?.to?.toString())}
+					type="text"
+					className="w-[50%]"
+				></Input>
+			</div>
+			<div className="flex justify-around">
+				<Calendar
+					mode="range"
+					selected={customDateRange ?? undefined}
+					onSelect={(daterange) => {
+						if (daterange?.from && daterange?.to) {
+							setCustomDateRange(daterange);
+						}
+					}}
+					className="rounded-md border shadow-sm"
+					captionLayout="dropdown"
+					timeZone="UTC"
+					disabled={{
+						after: new Date(new Date().toUTCString()),
+					}}
+				/>
+			</div>
+			<div className="flex justify-between">
+				<Button
+					variant="outline"
+					size="sm"
+					onClick={() => {
+						setDateOpen(false);
+					}}
+				>
+					Close
+				</Button>
+				<Button
+					variant="outline"
+					className="w-fit justify-end bg-primary text-white"
+					size="sm"
+					onClick={() => {
+						setDateOpen(false);
+					}}
+				>
+					Apply
+				</Button>
+			</div>
+		</div>
+	);
+
+	const scopeReady = hasScope(effectiveScope);
+	//Filter selections only — the scope pickers (engine type/engine) are left alone
+	//since clearing them would empty the table entirely.
+	const hasActiveFilters =
+		selectedMethods.length > 0 ||
+		selectedEngineTypes.length > 0 ||
+		selectedUserKey !== "" ||
+		searchInput !== "" ||
+		selectedRoomId !== "" ||
+		dashboardDuration !== "";
+
+	const clearAllFilters = () => {
+		setSelectedMethods([]);
+		setSelectedEngineTypes([]);
+		setSelectedUserKey("");
+		setSearchInput("");
+		setSearchTerm("");
+		setSelectedRoomId("");
+		setDashboardDuration("");
+		setDateOpen(false);
+		setCustomDateRange({ from: new Date(), to: new Date() });
+	};
 
 	return (
-		<div className="flex gap-2">
-			{/** rendering duration dropdown filter, engine filter in auditlog if parent is auditlog, and so if client package, it wont render duration filter */}
+		<div className="flex w-full flex-wrap items-center gap-2">
+			{/** unified compact toolbar: search + filters + actions */}
+			<div className="relative flex w-[200px] items-center">
+				<Search className="absolute start-2 size-4 text-muted-foreground" />
+				<Input
+					type="text"
+					placeholder="Search logs..."
+					value={searchInput}
+					onChange={(event) => setSearchInput(event.target.value)}
+					disabled={!scopeReady}
+					className="h-8 w-full ps-8"
+				/>
+			</div>
+
+			{/** scope pickers: only rendered when the scope isn't fixed by the route */}
 			{!parent && (
 				<>
 					<div className="flex min-w-[100px] justify-between">
 						<DropdownMenu>
 							<DropdownMenuTrigger
 								asChild
-								className="flex w-[180px] justify-between align-center"
+								className="flex w-[150px] justify-between align-center"
 							>
 								<Button
 									variant="outline"
@@ -290,12 +662,12 @@ export const AuditLogFilter = (props) => {
 						<DropdownMenu>
 							<DropdownMenuTrigger
 								asChild
-								className="flex w-[180px] justify-between align-center"
+								className="flex w-[150px] justify-between align-center"
 							>
 								<Button
 									variant="outline"
 									size="sm"
-									className={`flex min-w-[180px] justify-between align-center`}
+									className={`flex min-w-[150px] justify-between align-center`}
 								>
 									<div className="flex w-full justify-between">
 										<span className="flex justify-start">
@@ -349,57 +721,226 @@ export const AuditLogFilter = (props) => {
 					</div>
 				</>
 			)}
-			<div className="flex min-w-[100px]">
-				<DropdownMenu>
-					<DropdownMenuTrigger
-						asChild
-						className="flex w-[180px] justify-between align-center"
-					>
-						<Button variant="outline" size="sm">
-							{SelectedDuration?.label === ""
-								? "Today"
-								: SelectedDuration?.label}{" "}
-							<ChevronDownIcon />
+
+			{/** room id filter (single-select, server-driven options; loaded on open) */}
+			{!hideRoomFilter && (
+				<DropdownMenu
+					onOpenChange={(open) => {
+						if (open) ensureSimpleOptions("roomId", setRoomOptions);
+					}}
+				>
+					<DropdownMenuTrigger asChild>
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={!scopeReady}
+							className="flex w-[150px] justify-between self-center"
+						>
+							<span className="truncate">
+								{selectedRoomId || "Room ID"}
+							</span>
+							<ChevronDownIcon className="ms-2 size-4 shrink-0" />
 						</Button>
 					</DropdownMenuTrigger>
-					<DropdownMenuContent>
-						{/* Add dropdown items here */}
-						<DropdownMenuRadioGroup>
+					<DropdownMenuContent className="max-h-[300px] overflow-y-auto">
+						<DropdownMenuCheckboxItem
+							checked={selectedRoomId === ""}
+							onCheckedChange={() => setSelectedRoomId("")}
+							onSelect={(event) => event.preventDefault()}
+						>
+							All Rooms
+						</DropdownMenuCheckboxItem>
+						{loadingFilters.roomId ? (
+							<div className="px-2 py-1.5 text-muted-foreground text-sm">
+								Loading…
+							</div>
+						) : (
+							roomOptions.map((room) => (
+								<DropdownMenuCheckboxItem
+									key={`room-${room}`}
+									checked={selectedRoomId === room}
+									onCheckedChange={(checked) =>
+										setSelectedRoomId(checked ? room : "")
+									}
+									onSelect={(event) => event.preventDefault()}
+								>
+									{room}
+								</DropdownMenuCheckboxItem>
+							))
+						)}
+					</DropdownMenuContent>
+				</DropdownMenu>
+			)}
+
+			{/** method name filter (server-side, multi-select; loaded on open) */}
+			<MultiSelectDropdown
+				label="Method Name"
+				options={methodOptions}
+				selected={selectedMethods}
+				onChange={setSelectedMethods}
+				onOpen={() =>
+					ensureSimpleOptions("methodName", setMethodOptions)
+				}
+				loading={loadingFilters.methodName}
+				disabled={!scopeReady}
+			/>
+
+			{/** engine type filter (server-side, multi-select; loaded on open) */}
+			<MultiSelectDropdown
+				label="Engine Type"
+				options={engineTypeOptions}
+				selected={selectedEngineTypes}
+				onChange={setSelectedEngineTypes}
+				onOpen={() =>
+					ensureSimpleOptions("engineType", setEngineTypeOptions)
+				}
+				loading={loadingFilters.engineType}
+				disabled={!scopeReady}
+			/>
+
+			{/** user filter — owners only (loaded on open) */}
+			{isOwner && (
+				<DropdownMenu
+					onOpenChange={(open) => {
+						if (open) ensureUserOptions();
+					}}
+				>
+					<DropdownMenuTrigger asChild>
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={!scopeReady}
+							className="flex w-[150px] justify-between self-center"
+						>
+							<span className="truncate">
+								{selectedUser
+									? selectedUser.userName
+									: "All Users"}
+							</span>
+							<ChevronDownIcon className="ms-2 size-4 shrink-0" />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent className="max-h-[300px] overflow-y-auto">
+						<DropdownMenuCheckboxItem
+							checked={selectedUserKey === ""}
+							onCheckedChange={() => setSelectedUserKey("")}
+							onSelect={(event) => event.preventDefault()}
+						>
+							All Users
+						</DropdownMenuCheckboxItem>
+						{loadingFilters.user && (
+							<div className="px-2 py-1.5 text-muted-foreground text-sm">
+								Loading…
+							</div>
+						)}
+						{userOptions.map((user) => {
+							const key = userOptionKey(user);
+							return (
+								<DropdownMenuCheckboxItem
+									key={`user-${key}`}
+									checked={selectedUserKey === key}
+									onCheckedChange={(checked) =>
+										setSelectedUserKey(checked ? key : "")
+									}
+									onSelect={(event) => event.preventDefault()}
+								>
+									{user.userName || user.userId}
+									{user.userType ? (
+										<span className="ms-2 text-muted-foreground text-xs">
+											{user.userType}
+										</span>
+									) : null}
+								</DropdownMenuCheckboxItem>
+							);
+						})}
+					</DropdownMenuContent>
+				</DropdownMenu>
+			)}
+
+			{/** date range — a single popover holds the presets and, for "Custom",
+			 * the calendar; using one surface avoids the dropdown→popover conflict
+			 * that closed the calendar immediately. */}
+			{!hideDateFilter && (
+				<Popover open={dateOpen} onOpenChange={setDateOpen}>
+					<PopoverTrigger asChild>
+						<Button
+							variant="outline"
+							size="sm"
+							className="flex w-[150px] justify-between self-center"
+						>
+							<span className="truncate">
+								{SelectedDuration?.label === ""
+									? "Today"
+									: SelectedDuration?.label}
+							</span>
+							<ChevronDownIcon className="ms-2 size-4 shrink-0" />
+						</Button>
+					</PopoverTrigger>
+					<PopoverContent
+						align="end"
+						side="bottom"
+						sideOffset={6}
+						className="w-auto p-2"
+					>
+						<div className="flex flex-col gap-1">
 							{DashboardDurations.map((duration) => (
 								<React.Fragment
 									key={`duration-${duration.value}`}
 								>
-									{duration.renderWithSeparator && (
-										<DropdownMenuSeparator />
-									)}
-									<DropdownMenuCheckboxItem
-										checked={
+									{"renderWithSeparator" in duration &&
+										duration.renderWithSeparator && (
+											<div className="my-1 border-t" />
+										)}
+									<Button
+										variant={
 											duration.value === dashboardDuration
+												? "secondary"
+												: "ghost"
 										}
-										onCheckedChange={() => {
+										size="sm"
+										className="w-full justify-start font-normal"
+										onClick={() => {
 											setDashboardDuration(
 												duration.value,
 											);
-											if (duration.value === "custom") {
-												setShowCustomPopover(true);
-											} else {
-												if (showCustomPopover)
-													setShowCustomPopover(false);
+											//Keep the popover open for Custom so the
+											//calendar shows; close it for presets.
+											if (duration.value !== "custom") {
+												setDateOpen(false);
 											}
 										}}
 									>
 										{duration.label}
-									</DropdownMenuCheckboxItem>
+									</Button>
 								</React.Fragment>
 							))}
-						</DropdownMenuRadioGroup>
-					</DropdownMenuContent>
-				</DropdownMenu>
-			</div>
-			{/**
-			 * Added calendar option newly to filter for handling Custom date range filtering
-			 */}
-			{renderCustomDatePopover()}
+						</div>
+						{dashboardDuration === "custom" && (
+							<div className="mt-2 border-t pt-2">
+								{customDateContent}
+							</div>
+						)}
+					</PopoverContent>
+				</Popover>
+			)}
+
+			{/** clear every filter selection (scope pickers excluded) */}
+			{hasActiveFilters && (
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={clearAllFilters}
+					className="text-muted-foreground"
+				>
+					<X className="me-1 size-4" />
+					Clear filters
+				</Button>
+			)}
+			{actions ? (
+				<div className="ms-auto flex shrink-0 items-center gap-2">
+					{actions}
+				</div>
+			) : null}
 		</div>
 	);
 };

--- a/libs/shared/src/components/auditlog/audit-logs-data-table.tsx
+++ b/libs/shared/src/components/auditlog/audit-logs-data-table.tsx
@@ -3,21 +3,10 @@ import {
 	ChevronLeft,
 	ChevronRight,
 	CircleCheck as CircleCheckIcon,
-	Filter,
-	Search,
-	X,
 } from "lucide-react"; // Example icons
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import {
-	Badge,
 	Button,
-	Checkbox,
-	InputGroup,
-	InputGroupAddon,
-	InputGroupInput,
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
 	Select,
 	SelectContent,
 	SelectItem,
@@ -37,15 +26,6 @@ import { AuditLogsDetailDrawer } from "./audit-logs-detail-drawer";
 import type { EventData } from "./common";
 import { TimeDateFormatter } from "./common";
 
-//filter state basic structre
-interface FilterState {
-	engineType: string[];
-	engineName: string[];
-	status: string[];
-	latencyRange: string[];
-	tokenRange: string[];
-}
-
 //table data props
 interface AuditLogsDataTableProps {
 	logs: EventData[];
@@ -55,20 +35,15 @@ interface AuditLogsDataTableProps {
 	onPaginationChange: (page: number, rowsPerPage: number) => void;
 }
 //truncate text when maxlength is reached
-const ellipsed = (text: string | null, maxLength = 50) => {
+const ellipsed = (text: string | null | undefined, maxLength = 50) => {
 	if (!text) return "";
 	return text.length > maxLength
 		? `${text.substring(0, maxLength - 3)}...`
 		: text;
 };
-//to convert between true/false to success/failed or viceversa
-const STATUS_LABEL_CONVERSION = {
-	Success: true,
-	Failed: false,
-	true: "Success",
-	false: "Failed",
-};
-//handling table data and work with table related events
+//handling table data and work with table related events. Filtering and search are
+//performed server-side (see AuditLogFilter + AuditLogsReport); this component only
+//renders the current page and drives server-side pagination.
 export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 	logs = [],
 	totalCount = 0,
@@ -76,224 +51,15 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 	rowsPerPage,
 	onPaginationChange,
 }) => {
-	// State Management
 	const [selectedEvent, setSelectedEvent] = useState<EventData | null>(null); //setting event when row clicked, and event will have all the rowdata
 	const [drawerOpen, setDrawerOpen] = useState(false); //drawer show or close
-	const [searchQuery, setSearchQuery] = useState(""); //user searched query
-	const [appliedFilters, setAppliedFilters] = useState<FilterState>({
-		engineType: [],
-		engineName: [],
-		status: [],
-		latencyRange: [],
-		tokenRange: [],
-	}); //after clicking on popover apply button, values from tempFilters will be added to here
-	const [tempFilters, setTempFilters] = useState<FilterState>({
-		engineType: [],
-		engineName: [],
-		status: [],
-		latencyRange: [],
-		tokenRange: [],
-	}); //table column level filters for enginetype, name,etc
-	const [popoverColumn, setPopoverColumn] = useState<
-		keyof FilterState | null
-	>(null); //set the popover column, so popover will display over respective column
-	const [popoverOpen, setPopoverOpen] = useState(false); //show popover open or not
 
-	// Generate Filter Options (same logic as before)
-	const filterOptions = useMemo(() => {
-		return {
-			engineType: [
-				...new Set(
-					logs?.map((log) => log.engineType).filter(Boolean) || [],
-				),
-			],
-			engineName: [
-				...new Set(
-					logs?.map((log) => log.engineName).filter(Boolean) || [],
-				),
-			],
-			status: [
-				...new Set(
-					logs?.map((log) => STATUS_LABEL_CONVERSION[log.status]),
-				),
-			].filter((status) => status !== undefined && status !== null) ?? [
-				"Success",
-				"Failed",
-			],
-			latencyRange: [
-				{ label: "Fast (≤ 5ms)", value: "0-5" },
-				{ label: "Medium (5-50ms)", value: "6-50" },
-				{ label: "Slow (> 50ms)", value: "51-999999" },
-			],
-			tokenRange: [
-				{ label: "Short (< 100)", value: "0-100" },
-				{ label: "Medium (100-500)", value: "100-500" },
-				{ label: "Long (> 500)", value: "500-999999" },
-			],
-		};
-	}, [logs]);
-
-	//Check condition for if any filters are applied
-	const filtersApplied = useMemo(
-		() =>
-			Object.values(appliedFilters).some((filter) => filter.length > 0) ||
-			false,
-		[appliedFilters],
-	);
-
-	// Filter Logs (same logic as before)
-	const filteredLogs = useMemo(() => {
-		let filtered = [...logs];
-		if (searchQuery.trim()) {
-			const query = searchQuery.toLowerCase().trim();
-			filtered = filtered.filter(
-				(log) =>
-					log.engineName?.toLowerCase().includes(query) ||
-					log.engineType?.toLowerCase().includes(query) ||
-					log.userId?.toLowerCase().includes(query) ||
-					log.sessionId?.toLowerCase().includes(query) ||
-					log.request?.toLowerCase().includes(query) ||
-					log.response?.toLowerCase().includes(query) ||
-					log.latency
-						?.toString()
-						.concat("ms")
-						.toLowerCase()
-						.includes(query) || //additng latency search with milliseconds option
-					log.tokens?.toString().toLowerCase().includes(query),
-			);
-		}
-		// Apply engine type filter
-		if (appliedFilters.engineType.length > 0) {
-			filtered = filtered.filter((log) =>
-				appliedFilters.engineType.includes(log.engineType),
-			);
-		}
-
-		// Apply engine name filter
-		if (appliedFilters.engineName.length > 0) {
-			filtered = filtered.filter((log) =>
-				appliedFilters.engineName.includes(log.engineName),
-			);
-		}
-
-		// Apply status filter
-		if (appliedFilters.status.length > 0) {
-			filtered = filtered.filter((log) =>
-				appliedFilters.status.includes(
-					STATUS_LABEL_CONVERSION[log.status],
-				),
-			);
-		}
-
-		// Apply latency range filter
-		if (appliedFilters.latencyRange.length > 0) {
-			filtered = filtered.filter((log) => {
-				const logLatency = Number(log.latency);
-				if (Number.isNaN(logLatency)) return false;
-
-				return appliedFilters.latencyRange.some((range) => {
-					const [min, max] = range.split("-").map(Number);
-					return logLatency >= min && logLatency <= max;
-				});
-			});
-		}
-
-		// Apply token range filter
-		if (appliedFilters.tokenRange.length > 0) {
-			filtered = filtered.filter((log) => {
-				const logTokens = parseInt(log.tokens, 10);
-				if (Number.isNaN(logTokens)) return false;
-
-				return appliedFilters.tokenRange.some((range) => {
-					const [min, max] = range.split("-").map(Number);
-					return logTokens >= min && logTokens <= max;
-				});
-			});
-		}
-		// ...apply filters...
-		return filtered;
-	}, [logs, searchQuery, appliedFilters]);
-	//show the filtered total count in the table based on the records
-	const filteredTotalCount = useMemo(() => {
-		return filtersApplied || searchQuery.trim().length > 0
-			? filteredLogs.length
-			: totalCount;
-	}, [filteredLogs, filtersApplied, totalCount, searchQuery]);
-
-	// Event Handlers (same logic as before)
-	const handleFilterClick = useCallback(
-		(column: keyof FilterState) => {
-			setTempFilters({ ...appliedFilters });
-			setPopoverColumn(column);
-			setPopoverOpen(true);
-		},
-		[appliedFilters],
-	);
-	//handle the popover close event gracefully
-	const handlePopoverClose = useCallback(() => {
-		setPopoverOpen(false);
-		setPopoverColumn(null);
-		setTempFilters({ ...appliedFilters });
-	}, [appliedFilters]);
-	//apply the selected values in the filter
-	const handleApplyFilters = useCallback(() => {
-		setAppliedFilters({ ...tempFilters });
-		handlePopoverClose();
-	}, [tempFilters, handlePopoverClose]);
-	//in every filter popover, this function will clear selected options
-	const handleClearFilterPopover = useCallback(() => {
-		if (popoverColumn) {
-			setTempFilters((prev) => ({
-				...prev,
-				[popoverColumn as string]: [],
-			}));
-		}
-	}, [popoverColumn]);
-	//IF Select all is not active and only few options are selected, then this will handle respective filters in search
-	const handleMultiSelectFilter = useCallback(
-		(filterType: keyof FilterState, value: string) => {
-			setTempFilters((prev) => ({
-				...prev,
-				[filterType]: prev[filterType].includes(value)
-					? prev[filterType].filter((item) => item !== value)
-					: [...prev[filterType], value],
-			}));
-		},
-		[],
-	);
-	//Handle select all filter in the every custom popover filter, and when applied all values are added in search
-	const handleSelectAll = useCallback(
-		(filterType: keyof FilterState, allOptions: string[]) => {
-			setTempFilters((prev) => {
-				const isAllSelected =
-					prev[filterType].length === allOptions.length;
-				return {
-					...prev,
-					[filterType]: isAllSelected ? [] : [...allOptions],
-				};
-			});
-		},
-		[],
-	);
-	//Clicking on Clear all filters in near to search dropdown will clear all the filters applied
-	const handleClearAllFilters = useCallback(() => {
-		setSearchQuery("");
-		const clearedFilters: FilterState = {
-			engineType: [],
-			engineName: [],
-			status: [],
-			latencyRange: [],
-			tokenRange: [],
-		};
-		setAppliedFilters(clearedFilters);
-		setTempFilters(clearedFilters);
-	}, []);
 	//onclick drawer has to open, it is handled here
 	const handleRowClick = useCallback((event: EventData) => {
 		setSelectedEvent(event);
 		setDrawerOpen(true);
 	}, []);
-	//handle drawer close by settingg timeout
+	//handle drawer close by setting timeout
 	const handleDrawerClose = useCallback(() => {
 		setDrawerOpen(false);
 		setTimeout(() => {
@@ -301,12 +67,6 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 		}, 300);
 	}, []);
 
-	/*const handleChangePage = useCallback(
-		(_event: unknown, newPage: number) => {
-			onPaginationChange(newPage, rowsPerPage);
-		},
-		[onPaginationChange, rowsPerPage],
-	);*/
 	//handle rows per page dropdown value
 	const handleChangeRowsPerPage = useCallback(
 		(value: string) => {
@@ -315,154 +75,10 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 		},
 		[onPaginationChange],
 	);
-	//getting filters count based on applied filters state
-	const getActiveFiltersCount = useCallback(
-		(column?: keyof FilterState) => {
-			if (column) {
-				return appliedFilters[column].length;
-			}
-			return (
-				appliedFilters.engineType.length +
-				appliedFilters.engineName.length +
-				appliedFilters.latencyRange.length +
-				appliedFilters.tokenRange.length +
-				appliedFilters.status.length
-			);
-		},
-		[appliedFilters],
-	);
 
-	const totalActiveFilters = getActiveFiltersCount() + (searchQuery ? 1 : 0);
-	//Render popover content of Filter options like model, status ,etc
-	//biome-ignore lint/correctness/useExhaustiveDependencies : not adding functions as dependencies
-	const renderPopoverContent = useCallback(
-		(filterName: keyof FilterState) => {
-			return (
-				<Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-					<PopoverTrigger asChild>
-						<Button
-							variant="ghost"
-							size="icon"
-							onClick={() =>
-								handleFilterClick(
-									filterName as keyof FilterState,
-								)
-							}
-						>
-							<Filter className="h-4 w-4" />
-						</Button>
-					</PopoverTrigger>
-					{popoverColumn === filterName ? (
-						<PopoverContent className="w-56">
-							{/* Render filter options for filterType */}
-							{/* ...custom filter UI... */}
-							<div className="flex flex-col gap-2">
-								<div
-									key={`${filterName}SelectAll`}
-									className="flex flex-row items-center gap-4 overflow-x-auto"
-								>
-									<Checkbox
-										checked={
-											tempFilters?.[filterName].length ===
-											filterOptions?.[filterName]?.length
-												? true
-												: tempFilters?.[filterName]
-															?.length > 0
-													? "indeterminate"
-													: false
-										}
-										onCheckedChange={() => {
-											handleSelectAll(
-												filterName,
-												![
-													"latencyRange",
-													"tokenRange",
-												].includes(filterName)
-													? filterOptions?.[
-															filterName
-														]
-													: filterOptions?.[
-															filterName
-														].map(
-															(filtered) =>
-																filtered.value,
-														),
-											);
-										}}
-									/>
-									<span key={`${filterName}SelectAll`}>
-										Select All
-									</span>
-								</div>
-								{filterOptions?.[filterName]?.map((filtered) =>
-									Object.hasOwn(filtered, "value") ? (
-										<div
-											key={`${filtered.value}`}
-											className="items-cemter flex flex-row gap-4 overflow-x-auto"
-										>
-											<Checkbox
-												checked={tempFilters?.[
-													filterName
-												]?.includes(filtered.value)}
-												onCheckedChange={() => {
-													handleMultiSelectFilter(
-														filterName,
-														filtered.value,
-													);
-													return;
-												}}
-											/>
-											<span key={`${filtered.value}`}>
-												{filtered.label}
-											</span>
-										</div>
-									) : (
-										<div
-											key={`${filtered}`}
-											className="flex flex-row items-center gap-4 overflow-x-auto"
-										>
-											<Checkbox
-												checked={tempFilters?.[
-													filterName
-												]?.includes(filtered)}
-												onCheckedChange={() => {
-													handleMultiSelectFilter(
-														filterName,
-														filtered,
-													);
-													return;
-												}}
-											/>
-											<span key={`${filtered}`}>
-												{filtered}
-											</span>
-										</div>
-									),
-								)}
-								<div className="flex flex-row items-center justify-between gap-2 border-t py-2">
-									<Button
-										variant="ghost"
-										onClick={() =>
-											handleClearFilterPopover()
-										}
-									>
-										Clear
-									</Button>
-									<Button
-										variant="default"
-										onClick={handleApplyFilters}
-									>
-										Apply
-									</Button>
-								</div>
-							</div>
-						</PopoverContent>
-					) : null}
-				</Popover>
-			);
-		},
-		[popoverOpen, popoverColumn, tempFilters, filterOptions],
-	);
+	const totalPages = Math.max(1, Math.ceil(totalCount / rowsPerPage));
+	const firstRow = totalCount === 0 ? 0 : page * rowsPerPage + 1;
+	const lastRow = Math.min((page + 1) * rowsPerPage, totalCount);
 
 	// Empty State
 	if (!logs || logs.length === 0) {
@@ -487,44 +103,6 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 					<span className="font-semibold text-lg">
 						Prompt & Response Timeline
 					</span>
-					<div className="flex items-center gap-2">
-						{totalActiveFilters > 0 && (
-							<Button
-								variant="outline"
-								onClick={handleClearAllFilters}
-							>
-								<X className="me-2 h-4 w-4" />
-								Clear All Filters
-							</Button>
-						)}
-						<div className="relative">
-							<InputGroup>
-								<InputGroupInput
-									placeholder="Search logs..."
-									value={searchQuery}
-									onChange={(e) =>
-										setSearchQuery(e.target.value)
-									}
-									className="w-96 ps-10"
-								/>
-								<InputGroupAddon>
-									<Search />
-								</InputGroupAddon>
-								<InputGroupAddon align="inline-end">
-									{searchQuery && (
-										<Button
-											variant="ghost"
-											size="icon"
-											className="absolute end-2 top-2"
-											onClick={() => setSearchQuery("")}
-										>
-											<X className="h-4 w-4" />
-										</Button>
-									)}
-								</InputGroupAddon>
-							</InputGroup>
-						</div>
-					</div>
 				</div>
 				<div className="border-b p-4">
 					<Table>
@@ -532,7 +110,7 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 							<TableRow style={{ backgroundColor: "#F5F9FE" }}>
 								<TableHead>
 									<span className="font-medium font-semibold text-primary text-sm leading-6 tracking-normal">
-										User Id
+										User
 									</span>
 								</TableHead>
 								<TableHead>
@@ -551,68 +129,29 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 									</span>
 								</TableHead>
 								<TableHead>
-									<div className="flex items-center gap-1">
-										<span className="font-medium font-semibold text-primary text-sm leading-6 tracking-normal">
-											Engine Type
-										</span>
-										{appliedFilters.engineType.length >
-										0 ? (
-											<Badge variant="outline">
-												{getActiveFiltersCount(
-													"engineType",
-												)}
-											</Badge>
-										) : null}
-										{renderPopoverContent("engineType")}
-									</div>
+									<span className="font-medium font-semibold text-primary text-sm leading-6 tracking-normal">
+										Method
+									</span>
 								</TableHead>
 								<TableHead>
-									<div className="flex items-center gap-1">
-										<span className="font-medium font-semibold text-primary text-sm leading-6 tracking-normal">
-											Engine Name
-										</span>
-										{appliedFilters.engineName.length >
-										0 ? (
-											<Badge variant="outline">
-												{getActiveFiltersCount(
-													"engineName",
-												)}
-											</Badge>
-										) : null}
-										{renderPopoverContent("engineName")}
-									</div>
+									<span className="font-medium font-semibold text-primary text-sm leading-6 tracking-normal">
+										Engine Type
+									</span>
 								</TableHead>
 								<TableHead>
-									<div className="flex items-center gap-1">
-										<span className="font-medium font-semibold text-primary text-sm leading-6 tracking-normal">
-											Latency
-										</span>
-										{appliedFilters.latencyRange.length >
-										0 ? (
-											<Badge variant="outline">
-												{getActiveFiltersCount(
-													"latencyRange",
-												)}
-											</Badge>
-										) : null}
-										{renderPopoverContent("latencyRange")}
-									</div>
+									<span className="font-medium font-semibold text-primary text-sm leading-6 tracking-normal">
+										Engine Name
+									</span>
 								</TableHead>
 								<TableHead>
-									<div className="flex items-center gap-1">
-										<span className="font-medium font-semibold text-primary text-sm leading-6 tracking-normal">
-											Tokens
-										</span>
-										{appliedFilters.tokenRange.length >
-										0 ? (
-											<Badge variant="outline">
-												{getActiveFiltersCount(
-													"tokenRange",
-												)}
-											</Badge>
-										) : null}
-										{renderPopoverContent("tokenRange")}
-									</div>
+									<span className="font-medium font-semibold text-primary text-sm leading-6 tracking-normal">
+										Latency
+									</span>
+								</TableHead>
+								<TableHead>
+									<span className="font-medium font-semibold text-primary text-sm leading-6 tracking-normal">
+										Tokens
+									</span>
 								</TableHead>
 								<TableHead>
 									<span className="font-medium font-semibold text-primary text-sm leading-6 tracking-normal">
@@ -620,26 +159,16 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 									</span>
 								</TableHead>
 								<TableHead>
-									<div className="flex items-center gap-1">
-										<span className="font-medium font-semibold text-primary text-sm leading-6 tracking-normal">
-											Status
-										</span>
-										{appliedFilters.status.length > 0 ? (
-											<Badge variant="outline">
-												{getActiveFiltersCount(
-													"status",
-												)}
-											</Badge>
-										) : null}
-										{renderPopoverContent("status")}
-									</div>
+									<span className="font-medium font-semibold text-primary text-sm leading-6 tracking-normal">
+										Status
+									</span>
 								</TableHead>
 							</TableRow>
 						</TableHeader>
 						<TableBody>
-							{filteredLogs.map((event, index) => (
+							{logs.map((event, index) => (
 								<TableRow
-									key={`Log-${event.endTime}-${index}`}
+									key={`Log-${event.requestId ?? event.endTime}-${index}`}
 									className="cursor-pointer hover:[background-color:rgb(245,249,254)!important] [a&]:hover:bg-primary"
 									onClick={() => handleRowClick(event)}
 								>
@@ -648,7 +177,10 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 											title={event.userId}
 											className="text-sm"
 										>
-											{ellipsed(event.userId, 23)}
+											{ellipsed(
+												event.userName || event.userId,
+												23,
+											)}
 										</span>
 									</TableCell>
 									<TableCell>
@@ -673,6 +205,14 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 											className="text-sm"
 										>
 											{ellipsed(event.response)}
+										</span>
+									</TableCell>
+									<TableCell>
+										<span
+											title={event.methodName}
+											className="text-sm"
+										>
+											{event.methodName}
 										</span>
 									</TableCell>
 									<TableCell>
@@ -716,9 +256,8 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 						</TableBody>
 					</Table>
 				</div>
-				{/* Pagination: You may need to implement your own or use shadcn/ui's Table.Pagination if available */}
+				{/* Server-side pagination */}
 				<div className="flex items-center gap-2 justify-self-end bg-white p-2">
-					{/* Simple pagination example */}
 					<label
 						htmlFor="rows-per-page"
 						className="font-medium text-gray-700 text-sm"
@@ -729,7 +268,6 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 						value={rowsPerPage.toString()}
 						onValueChange={(value: string) => {
 							handleChangeRowsPerPage(value);
-							return;
 						}}
 					>
 						<SelectTrigger
@@ -747,15 +285,7 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 						</SelectContent>
 					</Select>
 					<span className="mx-2 text-sm">
-						{/**
-							Checking for the case like , if a user searches on 2 or 3rd pages, then the filtered records might not have much records, so 
-							checking and resetting page to 1
-						*/}
-						{page + 1 > Math.ceil(filteredTotalCount / rowsPerPage)
-							? Math.ceil(filteredTotalCount / rowsPerPage)
-							: page + 1}{" "}
-						- {Math.ceil(filteredTotalCount / rowsPerPage)} of{" "}
-						{Math.ceil(filteredTotalCount / rowsPerPage)}
+						{firstRow} - {lastRow} of {totalCount}
 					</span>
 					<Button
 						variant="ghost"
@@ -768,10 +298,7 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 					</Button>
 					<Button
 						variant="ghost"
-						disabled={
-							page + 1 >=
-							Math.ceil(filteredTotalCount / rowsPerPage)
-						}
+						disabled={page + 1 >= totalPages}
 						onClick={() =>
 							onPaginationChange(page + 1, rowsPerPage)
 						}
@@ -783,17 +310,8 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 
 			<div className="flex items-center justify-between border-b bg-gray-50 px-4 py-2">
 				<span className="text-gray-500 text-sm">
-					Showing {filteredLogs.length} of {totalCount} results
-					{totalActiveFilters > 0 &&
-						` (${totalActiveFilters} filter${
-							totalActiveFilters > 1 ? "s" : ""
-						} applied)`}
+					Showing {logs.length} of {totalCount} results
 				</span>
-				{filteredLogs.length === 0 && logs.length > 0 && (
-					<span className="text-red-600 text-sm">
-						No results found. Try adjusting your filters.
-					</span>
-				)}
 			</div>
 			{/** sheet open/close when user clicks on the row in auditlog table */}
 			<Sheet open={drawerOpen} onOpenChange={setDrawerOpen}>
@@ -807,7 +325,6 @@ export const AuditLogsDataTable: React.FC<AuditLogsDataTableProps> = ({
 						handleDrawerClose={handleDrawerClose}
 					/>
 				</SheetContent>
-				{/* <SheetClose /> */}
 			</Sheet>
 		</>
 	);

--- a/libs/shared/src/components/auditlog/audit-logs-detail-drawer.tsx
+++ b/libs/shared/src/components/auditlog/audit-logs-detail-drawer.tsx
@@ -423,14 +423,7 @@ export const AuditLogsDetailDrawer = (props) => {
 								Log Timestamp
 							</span>
 							<span className="font-bold text-gray-900 text-sm leading-[1.43]">
-								{
-									TimeDateFormatter(logDetails.logTimestamp)
-										.time
-								}{" "}
-								{
-									TimeDateFormatter(logDetails.logTimestamp)
-										.date
-								}
+								{`${TimeDateFormatter(logDetails.logTimestamp).date} ${TimeDateFormatter(logDetails.logTimestamp).time}`}
 							</span>
 						</div>
 					</div>

--- a/libs/shared/src/components/auditlog/audit-logs-summary.tsx
+++ b/libs/shared/src/components/auditlog/audit-logs-summary.tsx
@@ -1,0 +1,111 @@
+import type React from "react";
+import { Fragment, useMemo } from "react";
+import type { EventData } from "./common";
+
+interface AuditLogsSummaryProps {
+	logs: EventData[];
+	totalCount: number;
+}
+
+const isSuccess = (status: EventData["status"]) =>
+	Boolean(status) && status !== "false";
+
+//Nearest-rank percentile over an ascending array.
+const percentile = (sorted: number[], p: number) => {
+	if (sorted.length === 0) return 0;
+	const rank = Math.min(
+		sorted.length - 1,
+		Math.max(0, Math.ceil((p / 100) * sorted.length) - 1),
+	);
+	return sorted[rank];
+};
+
+//962 → "962ms", 37600 → "37.6s".
+const formatLatency = (ms: number) =>
+	ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
+
+//2300 → "2.3K", 1_200_000 → "1.2M".
+const formatCompact = (n: number) => {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+	return String(n);
+};
+
+/**
+ * A compact, single-line KPI strip for the audit logs — scannable metrics that sit
+ * above the timeline without competing with it. totalCount is the server total
+ * (all matched rows); the latency / error / token figures are computed over the
+ * currently loaded page.
+ */
+export const AuditLogsSummary: React.FC<AuditLogsSummaryProps> = ({
+	logs,
+	totalCount,
+}) => {
+	const stats = useMemo(() => {
+		const latencies = logs
+			.map((log) => Number(log.latency))
+			.filter((value) => Number.isFinite(value))
+			.sort((a, b) => a - b);
+		const tokens = logs.reduce(
+			(sum, log) => sum + (Number(log.tokens) || 0),
+			0,
+		);
+		const failures = logs.filter((log) => !isSuccess(log.status)).length;
+		return {
+			p50: percentile(latencies, 50),
+			p95: percentile(latencies, 95),
+			tokens,
+			failures,
+		};
+	}, [logs]);
+
+	const value = (text: string, danger = false) => (
+		<span
+			className={`font-semibold ${danger ? "text-destructive" : "text-foreground"}`}
+		>
+			{text}
+		</span>
+	);
+
+	const metrics: { key: string; node: React.ReactNode }[] = [
+		{
+			key: "events",
+			node: <>{value(totalCount.toLocaleString())} Events</>,
+		},
+		{
+			key: "shown",
+			node: <>{value(logs.length.toLocaleString())} Shown</>,
+		},
+		{
+			key: "errors",
+			node: (
+				<>{value(String(stats.failures), stats.failures > 0)} Errors</>
+			),
+		},
+		{ key: "p50", node: <>P50 {value(formatLatency(stats.p50))}</> },
+		{ key: "p95", node: <>P95 {value(formatLatency(stats.p95))}</> },
+		{
+			key: "tokens",
+			node: <>{value(formatCompact(stats.tokens))} Tokens</>,
+		},
+	];
+
+	return (
+		<div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-1 text-muted-foreground text-sm">
+			{metrics.map((metric, index) => (
+				<Fragment key={metric.key}>
+					{index > 0 && (
+						<span className="text-muted-foreground/40">•</span>
+					)}
+					<span>{metric.node}</span>
+				</Fragment>
+			))}
+			<span
+				className="ms-auto text-muted-foreground/70 text-xs"
+				title="Latency, errors and tokens are calculated across the events on the current page."
+			>
+				current page
+			</span>
+		</div>
+	);
+};

--- a/libs/shared/src/components/auditlog/audit-logs-timeline.tsx
+++ b/libs/shared/src/components/auditlog/audit-logs-timeline.tsx
@@ -1,715 +1,723 @@
 import * as echarts from "echarts";
-import { ZoomIn as ZoomInIcon, ZoomOut as ZoomOutIcon } from "lucide-react";
+import {
+	Crop as CropIcon,
+	RotateCcw as ResetIcon,
+	ZoomIn as ZoomInIcon,
+	ZoomOut as ZoomOutIcon,
+} from "lucide-react";
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
-import { Button } from "@semoss/ui/next";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+	Button,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	Sheet,
+	SheetContent,
+	SheetTitle,
+} from "@semoss/ui/next";
+import { AuditLogsDetailDrawer } from "./audit-logs-detail-drawer";
 import type { EventData } from "./common";
 import { TimeDateFormatter } from "./common";
 
-// Type definitions
-interface ProcessedEventData {
-	value: [number, number, number];
-	eventData: EventData;
+//Status colors mirror the data table: success is green, failure is red. Unlike
+//the request/response split (which we removed), status is a real good/bad signal.
+const STATUS_OK_COLOR = "#16a34a";
+const STATUS_FAIL_COLOR = "#dc2626";
+//Cycled per consecutive part within a span (by-span mode) so each segment of the
+//execution is visually distinct and its duration is readable. Avoids green/red so
+//the part colors aren't confused with status.
+const SPAN_PART_COLORS = [
+	"#3b82f6",
+	"#8b5cf6",
+	"#06b6d4",
+	"#f59e0b",
+	"#ec4899",
+];
+
+const isSuccess = (status: EventData["status"]) =>
+	Boolean(status) && status !== "false";
+
+//Granularity options for the time (x) axis labels.
+type AxisMode = "time" | "datetime" | "date" | "month";
+const AXIS_MODE_LABELS: Record<AxisMode, string> = {
+	time: "Time",
+	datetime: "Date & time",
+	date: "Date",
+	month: "Month",
+};
+//Row grouping: one lane per event, or one lane per spanId / requestId (trace-style,
+//where the group's events stack as parts of the execution along the row).
+type RowMode = "event" | "span" | "request";
+const ROW_MODE_LABELS: Record<RowMode, string> = {
+	event: "Row: per event",
+	span: "Row: by span",
+	request: "Row: by request",
+};
+const formatAxisValue = (value: number, mode: AxisMode): string => {
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) return "";
+	switch (mode) {
+		case "month":
+			return date.toLocaleDateString(undefined, {
+				month: "short",
+				year: "numeric",
+			});
+		case "date":
+			return date.toLocaleDateString(undefined, {
+				month: "short",
+				day: "2-digit",
+			});
+		case "datetime":
+			return date.toLocaleString(undefined, {
+				month: "short",
+				day: "2-digit",
+				hour: "2-digit",
+				minute: "2-digit",
+			});
+		default:
+			return date.toLocaleTimeString(undefined, {
+				hour: "2-digit",
+				minute: "2-digit",
+				second: "2-digit",
+			});
+	}
+};
+
+interface WaterfallRow {
+	event: EventData;
+	startMs: number;
+	endMs: number;
+	sessionId: string;
 }
 
-interface ProcessApiDataResult {
-	timeCategories: string[];
-	eventData: ProcessedEventData[];
-	timeToPosition: Map<string, number>;
-}
-
-interface DataZoomParams {
-	batch?: Array<{
-		start?: number;
-		end?: number;
-	}>;
-}
-
-interface TooltipParams {
-	data?: ProcessedEventData;
-}
-
-interface RenderItemParams {
-	coordSys: {
-		x: number;
-		y: number;
-		width: number;
-		height: number;
-	};
-}
-
-interface RenderItemAPI {
-	value: (index: number) => number | undefined;
-	coord: (point: [number, number]) => [number, number];
-}
-
-interface BarRect {
-	x: number;
-	y: number;
-	width: number;
-	height: number;
-}
-
-interface ClippedRect {
-	x: number;
-	y: number;
-	width: number;
-	height: number;
-}
-
-interface ShapeConfig {
-	x: number;
-	y: number;
-	width: number;
-	height: number;
-	r: number[] | number;
-}
-
-interface RenderItemResult {
-	type: "group" | "rect";
-	children?: Array<{
-		type: "rect";
-		shape: ShapeConfig;
-		style: {
-			fill: string;
-		};
-	}>;
-	shape?: ShapeConfig;
-	style?: {
-		fill: string;
-	};
-}
-
-/*const ZoomButtonGroup = styled(ButtonGroup)({
-	backgroundColor: "#fff",
-	boxShadow: "0 1px 3px rgba(0, 0, 0, 0.1)",
-
-	"& .MuiButtonGroup-grouped": {
-		minWidth: "32px",
-		height: "32px",
-		border: "none",
-
-		"&:not(:last-of-type)": {
-			borderRight: "1px solid #e0e0e0",
-		},
-
-		"&:hover": {
-			backgroundColor: "#f5f5f5",
-		},
-
-		"&:disabled": {
-			backgroundColor: "#f9f9f9",
-			opacity: 0.5,
-		},
-	},
-});
-
-const ZoomIconButton = styled(IconButton)<{ position: "left" | "right" }>(
-	({ position }) => ({
-		padding: "4px",
-		borderRadius: position === "left" ? "4px 0 0 4px" : "0 4px 4px 0",
-	}),
-);*/
-//props for audit logs timeline
 interface AuditLogsTimelineProps {
 	logs: EventData[];
 }
+
+//Minimal shapes for echarts custom-series rendering.
+interface RenderItemParams {
+	dataIndex: number;
+	coordSys: { x: number; y: number; width: number; height: number };
+}
+interface RenderItemAPI {
+	value: (index: number) => number;
+	coord: (point: [number, number]) => [number, number];
+	size: (data: [number, number]) => [number, number];
+}
+interface RenderRect {
+	type: "rect";
+	shape: { x: number; y: number; width: number; height: number; r: number };
+	style: { fill: string };
+}
+
 /**
-	Renders a chart with a time series as the x-axis and a custom series 
-	as the y-axis. The chart can be zoomed in and out using the mouse wheel 
-	or by clicking the zoom in/out buttons. The chart can be resized by 
-	dragging one of its corners. The chart is also responsive to window resizing events.
-	*/
+ * A DevTools-style waterfall of audit-log activity. Each event is one lane on a
+ * real, continuous time axis: the bar's horizontal position is its actual start
+ * time and its length is its real duration, so overlap and gaps are meaningful.
+ * Bars are colored by status (green ok / red failed). Clicking a bar opens the
+ * detail drawer. The row mode can be switched from one lane per event to one lane
+ * per spanId or requestId, where the group's events render in sequence on that
+ * single row (alternating colors) — a trace-style breakdown of the execution.
+ */
 export const AuditLogsTimeline: React.FC<AuditLogsTimelineProps> = ({
 	logs,
 }) => {
-	const chartRef = useRef<HTMLDivElement>(null); //ref object for placing chart created
-	const [chartInstance, setChartInstance] = useState<echarts.ECharts | null>(
-		null,
-	); //placing the chart instance in this state obj
-	const [zoomState, setZoomState] = useState({ start: 0, end: 100 }); //setting zoom state
+	const chartRef = useRef<HTMLDivElement>(null);
+	const chartInstanceRef = useRef<echarts.ECharts | null>(null);
+	//Persisted zoom windows (percent) for both axes, so the current zoom survives
+	//chart rebuilds and the rectangle-zoom composes with whatever is already zoomed.
+	const [xZoom, setXZoom] = useState({ start: 0, end: 100 });
+	const [yZoom, setYZoom] = useState({ start: 0, end: 100 });
+	const [axisMode, setAxisMode] = useState<AxisMode>("time");
+	const [rowMode, setRowMode] = useState<RowMode>("event");
+	const [selectedEvent, setSelectedEvent] = useState<EventData | null>(null);
+	const [drawerOpen, setDrawerOpen] = useState(false);
+	//Whether the drag-a-rectangle-to-zoom cursor is currently armed.
+	const [zoomSelectActive, setZoomSelectActive] = useState(false);
+	//Mirror in a ref so the zrender drag handlers (bound once) read the latest value.
+	const zoomSelectActiveRef = useRef(zoomSelectActive);
+	zoomSelectActiveRef.current = zoomSelectActive;
+	const grouped = rowMode !== "event";
 
-	/**
-	 * Processes the logs to prepare the data for the chart.
-	 * It creates a set of all times in the logs, sorts them, and maps each time to its position in the sorted array.
-	 * It then goes through each log and creates a data point for the chart with the start position, latency, and end position.
-	 * The function returns an object with the time categories, event data, and time to position map.
-	 */
-	const processApiData = (): ProcessApiDataResult => {
-		const allTimes = new Set<string>();
-		const timeToPosition = new Map<string, number>();
-
-		logs.forEach((event) => {
-			allTimes.add(TimeDateFormatter(event.startTime).time);
-			allTimes.add(TimeDateFormatter(event.endTime).time);
-		});
-
-		const sortedTimes = Array.from(allTimes).sort((a, b) => {
-			const timeA = new Date(`1970-01-01 ${a}`);
-			const timeB = new Date(`1970-01-01 ${b}`);
-			return timeA.getTime() - timeB.getTime();
-		});
-
-		sortedTimes.forEach((time, index) => {
-			timeToPosition.set(time, index);
-		});
-
-		const eventData: ProcessedEventData[] = [];
-
-		logs.forEach((event) => {
-			const startPos =
-				timeToPosition.get(TimeDateFormatter(event.startTime).time) ??
-				-1; //need testing with -1 position
-			const endPos =
-				timeToPosition.get(TimeDateFormatter(event.endTime).time) ?? -1; //need testing with -1 position
-
-			const dataPoint: ProcessedEventData = {
-				value: [startPos, event.latency, endPos],
-				eventData: event,
-			};
-
-			eventData.push(dataPoint);
-		});
-
-		return {
-			timeCategories: sortedTimes,
-			eventData,
-			timeToPosition,
-		};
-	};
-
-	/**
-	 * Calculates the configuration for the x-axis labels based on the available width and the number of labels.
-	 * If there are too many labels, it uses smart interval calculation to determine the interval between labels.
-	 * If there are very many labels, it tilts the labels by 45 degrees to fit more labels.
-	 * If there are a moderate number of labels, it tilts the labels by 30 degrees.
-	 * If there are few labels, it does not tilt the labels and uses the default margin.
-	 * @param {string[]} timeCategories - The array of time categories.
-	 * @param {number} [chartWidth=800] - The width of the chart in pixels.
-	 * @returns {Object} - An object with the interval, rotate, and margin properties.
-	 */
-	const calculateXAxisLabelConfig = (
-		timeCategories: string[],
-		chartWidth: number = 800,
-	) => {
-		const totalLabels = timeCategories.length;
-		const availableWidth = chartWidth - 80; // Account for margins
-		const averageLabelWidth = 60; // Estimated width per label in pixels
-		const maxLabelsWithoutOverlap = Math.floor(
-			availableWidth / averageLabelWidth,
-		);
-
-		// If we have too many labels, use smart interval calculation
-		if (totalLabels > maxLabelsWithoutOverlap) {
-			const interval =
-				Math.ceil(totalLabels / maxLabelsWithoutOverlap) - 1;
-
-			// For very congested scenarios, tilt the labels
-			if (totalLabels > maxLabelsWithoutOverlap * 1.5) {
-				return {
-					interval: interval,
-					rotate: 45,
-					margin: 12,
-				};
-			} else {
-				return {
-					interval: interval,
-					rotate: 0,
-					margin: 8,
-				};
-			}
-		} else if (totalLabels > maxLabelsWithoutOverlap * 0.7) {
-			// Moderate congestion - just tilt
-			return {
-				interval: 0,
-				rotate: 30,
-				margin: 10,
-			};
-		} else {
-			return {
-				interval: 0,
-				rotate: 0,
-				margin: 8,
-			};
-		}
-	};
-
-	/**
-	 * Zooms in the chart by a factor of 0.6.
-	 * If the current zoom range is less than or equal to 15, the function does nothing.
-	 * Otherwise, it calculates the new start and end points of the zoom range and updates the zoom state.
-	 * Finally, it dispatches an action to the chart with the type "dataZoom" and the new start and end points as parameters.
-	 */
-	const handleZoomIn = () => {
-		if (!chartInstance) return;
-
-		const currentRange = zoomState.end - zoomState.start;
-		if (currentRange <= 15) return;
-
-		const center = (zoomState.start + zoomState.end) / 2;
-		const newRange = currentRange * 0.6;
-		const newStart = Math.max(0, center - newRange / 2);
-		const newEnd = Math.min(100, center + newRange / 2);
-
-		setZoomState({ start: newStart, end: newEnd });
-
-		chartInstance.dispatchAction({
-			type: "dataZoom",
-			start: newStart,
-			end: newEnd,
-		});
-	};
-
-	/**
-	 * Zooms out the chart by a factor of 1.4.
-	 * If the current zoom range is greater than or equal to 100, the function does nothing.
-	 * Otherwise, it calculates the new start and end points of the zoom range and updates the zoom state.
-	 * Finally, it dispatches an action to the chart with the type "dataZoom" and the new start and end points as parameters.
-	 */
-	const handleZoomOut = () => {
-		if (!chartInstance) return;
-
-		const currentRange = zoomState.end - zoomState.start;
-		if (currentRange >= 100) return;
-
-		const center = (zoomState.start + zoomState.end) / 2;
-		const newRange = Math.min(100, currentRange * 1.4);
-		const newStart = Math.max(0, center - newRange / 2);
-		const newEnd = Math.min(100, center + newRange / 2);
-
-		setZoomState({ start: newStart, end: newEnd });
-
-		chartInstance.dispatchAction({
-			type: "dataZoom",
-			start: newStart,
-			end: newEnd,
-		});
-	};
-	//when the logs are available then the chart will start to render
-	//biome-ignore lint/correctness/useExhaustiveDependencies: chart needs to be re-rendered on logs change
-	useEffect(() => {
-		if (chartRef.current && logs.length > 0) {
-			const chart = echarts.init(chartRef.current);
-			setChartInstance(chart);
-
-			const { timeCategories, eventData } = processApiData();
-
-			// Calculate optimal x-axis configuration based on data density
-			const chartWidth = chartRef.current.clientWidth || 800;
-			const xAxisConfig = calculateXAxisLabelConfig(
-				timeCategories,
-				chartWidth,
-			);
-
-			const option = {
-				backgroundColor: "#ffffff",
-				animation: false,
-				tooltip: {
-					trigger: "item",
-					backgroundColor: "rgba(255, 255, 255, 0.98)",
-					borderColor: "#e0e0e0",
-					borderRadius: 8,
-					padding: [12, 16],
-					textStyle: {
-						color: "#333",
-						fontSize: 13,
-						fontFamily:
-							'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
-					},
-					boxShadow: "0 8px 24px rgba(0,0,0,0.12)",
-					formatter: (params: TooltipParams): string => {
-						if (!params || !params.data || !params.data.eventData) {
-							return "No data available";
-						}
-
-						const eventData = params.data.eventData;
-
-						const truncateText = (
-							text: string | null,
-							maxLength: number = 50,
-						): string => {
-							return text?.length > maxLength
-								? `${text.substring(0, maxLength)}...`
-								: text;
-						};
-
-						return `
-              <div style="
-                width: 100%;
-                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-                line-height: 1.4;
-              ">
-                <div style="
-                  display: flex;
-                  justify-content: space-between;
-                  align-items: center;
-                  margin-bottom: 10px;
-                  padding-bottom: 6px;
-                  border-bottom: 1px solid #f0f0f0;
-                ">
-                  <div style="font-weight: 600; color: #333; font-size: 12px;">${
-						TimeDateFormatter(eventData.startTime).time
-					} - ${TimeDateFormatter(eventData.endTime).time}</div>
-                  <div style="
-                    background: linear-gradient(135deg, #e3f2fd, #bbdefb);
-                    padding: 2px 8px;
-                    border-radius: 4px;
-                    font-size: 12px;
-                    font-weight: 600;
-                    color: #333;
-                  ">${eventData.latency}ms</div>
-                </div>
-                
-                <div style="margin-bottom: 8px;">
-                  <div style="
-                    color: #4caf50; 
-                    font-size: 11px; 
-                    font-weight: 600; 
-                    margin-bottom: 4px; 
-                    text-transform: uppercase; 
-                    letter-spacing: 0.5px;
-                  ">Request</div>
-                  <div style="
-                    font-size: 12px; 
-                    line-height: 1.4; 
-                    color: #333;
-                    background: #f8fcf9;
-                    padding: 6px 8px;
-                    border-radius: 4px;
-                    border-left: 2px solid #4caf50;
-                    height: 32px;
-                    display: flex;
-                    align-items: center;
-                    overflow: hidden;
-                  ">${truncateText(eventData.request)}</div>
-                </div>
-                
-                <div style="margin-bottom: 8px;">
-                  <div style="
-                    color: #e91e63; 
-                    font-size: 11px; 
-                    font-weight: 600; 
-                    margin-bottom: 4px; 
-                    text-transform: uppercase; 
-                    letter-spacing: 0.5px;
-                  ">Response</div>
-                  <div style="
-                    font-size: 12px; 
-                    line-height: 1.4; 
-                    color: #333;
-                    background: #fdf8fc;
-                    padding: 6px 8px;
-                    border-radius: 4px;
-                    border-left: 2px solid #e91e63;
-                    height: 32px;
-                    display: flex;
-                    align-items: center;
-                    overflow: hidden;
-                  ">${truncateText(eventData.response)}</div>
-                </div>
-                
-                <div style="
-                  display: flex;
-                  justify-content: flex-end;
-                  margin-top: 6px;
-                ">
-                  <div style="
-                    background: #f5f5f5;
-                    padding: 2px 8px;
-                    border-radius: 10px;
-                    font-size: 11px;
-                    font-weight: 500;
-                    color: #666;
-                  ">${eventData.tokens} tokens</div>
-                </div>
-              </div>
-            `;
-					},
-					extraCssText: `
-            min-width: 300px !important;
-            white-space: normal !important;
-            word-wrap: break-word !important;
-          `,
-				},
-				dataZoom: [
-					{
-						type: "inside",
-						xAxisIndex: 0,
-						filterMode: "filter",
-						zoomOnMouseWheel: true,
-						moveOnMouseWheel: false,
-						preventDefaultMouseMove: true,
-						throttle: 100,
-						minSpan: 10,
-						maxSpan: 100,
-					},
-				],
-				grid: {
-					left: "50px",
-					right: "30px",
-					top: "30px",
-					bottom: xAxisConfig.rotate > 0 ? "90px" : "70px",
-					containLabel: true,
-				},
-				xAxis: {
-					type: "category",
-					data: timeCategories,
-					name: "Timestamp",
-					nameLocation: "middle",
-					nameGap: xAxisConfig.rotate > 0 ? 60 : 40,
-					nameTextStyle: {
-						color: "#666",
-						fontSize: 12,
-					},
-					axisLine: {
-						show: true,
-						onZero: false,
-						lineStyle: {
-							color: "#e0e0e0",
-						},
-					},
-					axisTick: {
-						show: true,
-						alignWithLabel: true,
-						lineStyle: {
-							color: "#e0e0e0",
-						},
-					},
-					axisLabel: {
-						color: "#666",
-						fontSize: 11,
-						margin: xAxisConfig.margin,
-						rotate: xAxisConfig.rotate,
-						interval: xAxisConfig.interval,
-						formatter: (value: string): string => {
-							// Shorten the format when rotated to save space
-							if (xAxisConfig.rotate > 0) {
-								return value.replace(/:\d{2}\s(AM|PM)$/, "$1");
-							}
-							return value.replace(/:\d{2}\s(AM|PM)$/, " $1");
-						},
-						...(xAxisConfig.rotate > 0 && {
-							align: "right",
-							verticalAlign: "middle",
-						}),
-					},
-					splitLine: {
-						show: true,
-						alignWithLabel: true,
-						lineStyle: {
-							color: "#f0f0f0",
-							type: "dashed",
-						},
-					},
-				},
-				yAxis: {
-					type: "value",
-					name: "Latency (ms)",
-					nameLocation: "middle",
-					nameGap: 50,
-					nameTextStyle: {
-						color: "#666",
-						fontSize: 12,
-						fontWeight: 500,
-					},
-					nameRotate: 90,
-					min: 0,
-					max: Math.max(...logs.map((d) => d.latency)) + 20,
-					axisLine: {
-						show: true,
-						lineStyle: {
-							color: "#e0e0e0",
-						},
-					},
-					axisTick: {
-						show: false,
-					},
-					axisLabel: {
-						color: "#666",
-						fontSize: 12,
-					},
-					splitLine: {
-						show: true,
-						lineStyle: {
-							color: "#f0f0f0",
-							type: "dashed",
-						},
-					},
-				},
-				legend: {
-					data: ["Request", "Response"],
-					bottom: 0,
-					left: 15,
-					itemGap: 30,
-					textStyle: {
-						color: "#333",
-						fontSize: 13,
-						fontWeight: 500,
-					},
-					icon: "rect",
-					itemWidth: 20,
-					itemHeight: 6,
-				},
-				series: [
-					{
-						name: "Request",
-						type: "custom",
-						data: eventData,
-						clip: true,
-						itemStyle: {
-							color: "#4caf50",
-						},
-						renderItem: (
-							params: RenderItemParams,
-							api: RenderItemAPI,
-						): RenderItemResult | null => {
-							try {
-								const startPos = api.value(0);
-								const latency = api.value(1);
-								const endPos = api.value(2);
-
-								if (
-									startPos === undefined ||
-									latency === undefined ||
-									endPos === undefined
-								) {
-									return null;
-								}
-
-								const startCoord = api.coord([
-									startPos,
-									latency,
-								]);
-								const endCoord = api.coord([endPos, latency]);
-
-								const coordSys = params.coordSys;
-								if (!coordSys) return null;
-
-								const barRect: BarRect = {
-									x: startCoord[0],
-									y: startCoord[1] - 3,
-									width: Math.max(
-										endCoord[0] - startCoord[0],
-										16,
-									),
-									height: 6,
-								};
-
-								const gridRect = {
-									x: coordSys.x,
-									y: coordSys.y,
-									width: coordSys.width,
-									height: coordSys.height,
-								};
-
-								const clippedRect =
-									echarts.graphic.clipRectByRect(
-										barRect,
-										gridRect,
-									) as ClippedRect | null;
-
-								if (!clippedRect || clippedRect.width <= 0) {
-									return null;
-								}
-
-								const halfWidth = clippedRect.width / 2;
-
-								return {
-									type: "group",
-									children: [
-										{
-											type: "rect",
-											shape: {
-												x: clippedRect.x,
-												y: clippedRect.y,
-												width: halfWidth,
-												height: clippedRect.height,
-												r: [3, 0, 0, 3],
-											},
-											style: {
-												fill: "#4caf50",
-											},
-										},
-										{
-											type: "rect",
-											shape: {
-												x: clippedRect.x + halfWidth,
-												y: clippedRect.y,
-												width: halfWidth,
-												height: clippedRect.height,
-												r: [0, 3, 3, 0],
-											},
-											style: {
-												fill: "#e91e63",
-											},
-										},
-									],
-								};
-							} catch (error) {
-								console.warn(
-									"Error rendering custom series item:",
-									error,
-								);
-								return null;
-							}
-						},
-					},
-					{
-						name: "Response",
-						type: "custom",
-						data: [],
-						itemStyle: {
-							color: "#e91e63",
-						},
-						renderItem: (): null => null,
-					},
-				],
-			};
-
-			chart.setOption(option);
-
-			chart.on("dataZoom", (params: DataZoomParams) => {
-				try {
-					if (params?.batch?.[0]) {
-						const zoomInfo = params.batch[0];
-						setZoomState({
-							start: zoomInfo.start || 0,
-							end: zoomInfo.end || 100,
-						});
-					}
-				} catch (error) {
-					console.warn("Error handling dataZoom event:", error);
+	//Parse + order the rows. Each row becomes one lane (top-to-bottom).
+	const rows = useMemo<WaterfallRow[]>(() => {
+		const parsed = logs
+			.map((event): WaterfallRow | null => {
+				const startMs = new Date(event.startTime).getTime();
+				let endMs = new Date(event.endTime).getTime();
+				const latency = Number(event.latency) || 0;
+				if (!Number.isFinite(startMs)) return null;
+				//Fall back to latency when end is missing/invalid so the bar has width.
+				if (!Number.isFinite(endMs) || endMs < startMs) {
+					endMs = startMs + latency;
 				}
-			});
+				return {
+					event,
+					startMs,
+					endMs,
+					sessionId: event.sessionId || "—",
+				};
+			})
+			.filter((row): row is WaterfallRow => row !== null);
 
-			setTimeout(() => {
-				chart.resize({
-					width: "auto",
-					height: 295,
-				});
-			}, 100);
-
-			const handleResize = () => {
-				chart.resize();
-			};
-
-			window.addEventListener("resize", handleResize);
-
-			return () => {
-				window.removeEventListener("resize", handleResize);
-				chart.dispose();
-			};
-		}
+		parsed.sort((a, b) => a.startMs - b.startMs);
+		return parsed;
 	}, [logs]);
 
-	if (logs.length === 0) {
+	//Row layout. "event" → one lane per event. "span"/"request" → one lane per
+	//spanId/requestId; every event in the group is a part drawn on that single row
+	//at its real start→end, in sequence. subIndex (part order within the group) is
+	//used only to alternate the part colors.
+	const lanes = useMemo(() => {
+		const keyOf = (row: WaterfallRow) =>
+			rowMode === "request"
+				? row.event.requestId || "—"
+				: row.event.spanId || "—";
+
+		if (!grouped) {
+			return {
+				laneOf: rows.map((_, index) => index),
+				subIndexOf: rows.map(() => 0),
+				laneCount: rows.length,
+				laneLabels: rows.map(
+					(row) =>
+						row.event.methodName ||
+						row.event.engineName ||
+						row.event.requestId ||
+						"",
+				),
+			};
+		}
+
+		//rows are already sorted by start, so first-appearance order = chronological.
+		const order: string[] = [];
+		const laneIndexOf = new Map<string, number>();
+		for (const row of rows) {
+			const key = keyOf(row);
+			if (!laneIndexOf.has(key)) {
+				laneIndexOf.set(key, order.length);
+				order.push(key);
+			}
+		}
+		//Part index within the group (drives the alternating part colors).
+		const running = new Map<string, number>();
+		const subIndexOf = rows.map((row) => {
+			const key = keyOf(row);
+			const index = running.get(key) ?? 0;
+			running.set(key, index + 1);
+			return index;
+		});
+		//Label each row by its group id (spanId / requestId), not the method.
+		const laneLabels = [...order];
+		return {
+			laneOf: rows.map((row) => laneIndexOf.get(keyOf(row)) ?? 0),
+			subIndexOf,
+			laneCount: order.length,
+			laneLabels,
+		};
+	}, [rows, rowMode, grouped]);
+	const { laneOf, subIndexOf, laneCount, laneLabels } = lanes;
+
+	//Per-event mode: color encodes status (green ok / red failed). Grouped modes:
+	//cycle colors across the parts of each group so each part is distinct and its
+	//duration is readable (status is still shown in the tooltip).
+	const barColors = useMemo(() => {
+		if (!grouped) {
+			return rows.map((row) =>
+				isSuccess(row.event.status)
+					? STATUS_OK_COLOR
+					: STATUS_FAIL_COLOR,
+			);
+		}
+		return rows.map(
+			(_, index) =>
+				SPAN_PART_COLORS[subIndexOf[index] % SPAN_PART_COLORS.length],
+		);
+	}, [rows, grouped, subIndexOf]);
+
+	//Bounded chart height: the time axis stays pinned at the top and a vertical
+	//scrollbar (echarts dataZoom) pages through rows, instead of an ever-growing
+	//canvas inside a scroll container (which hid the axis and the bottom slider).
+	const chartHeight = useMemo(
+		() => Math.min(Math.max(laneCount * 28 + 96, 240), 560),
+		[laneCount],
+	);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: chart is rebuilt when rows/height change
+	useEffect(() => {
+		if (!chartRef.current || rows.length === 0) return;
+
+		const chart = echarts.init(chartRef.current);
+		chartInstanceRef.current = chart;
+
+		const minStart = Math.min(...rows.map((r) => r.startMs));
+		const maxEnd = Math.max(...rows.map((r) => r.endMs));
+		const pad = Math.max((maxEnd - minStart) * 0.02, 250);
+
+		const seriesData = rows.map((row, index) => ({
+			value: [row.startMs, laneOf[index], row.endMs],
+		}));
+
+		const option = {
+			backgroundColor: "#ffffff",
+			animation: false,
+			tooltip: {
+				trigger: "item",
+				//Render to <body> so the chart's overflow:auto scroll wrapper can't clip the tooltip.
+				appendToBody: true,
+				confine: false,
+				backgroundColor: "rgba(255, 255, 255, 0.98)",
+				borderColor: "#e0e0e0",
+				borderRadius: 8,
+				padding: [10, 14],
+				textStyle: { color: "#333", fontSize: 13 },
+				extraCssText:
+					"box-shadow: 0 8px 24px rgba(0,0,0,0.12); max-width: 320px; white-space: normal;",
+				formatter: (params: unknown): string => {
+					const dataIndex = (params as { dataIndex: number })
+						.dataIndex;
+					const row = rows[dataIndex];
+					if (!row) return "";
+					const e = row.event;
+					const ok = isSuccess(e.status);
+					const truncate = (text: string | null, max = 70) =>
+						text && text.length > max
+							? `${text.substring(0, max)}…`
+							: (text ?? "");
+					const line = (label: string, value: string) =>
+						value
+							? `<div style="display:flex;gap:8px;margin-top:2px;"><span style="color:#888;min-width:78px;flex-shrink:0;">${label}</span><span style="color:#333;flex:1;min-width:0;word-break:break-all;overflow-wrap:anywhere;">${value}</span></div>`
+							: "";
+					const start = TimeDateFormatter(e.startTime);
+					const end = TimeDateFormatter(e.endTime);
+					return `
+						<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;line-height:1.45;">
+							<div style="display:flex;justify-content:space-between;align-items:center;gap:12px;margin-bottom:6px;padding-bottom:6px;border-bottom:1px solid #f0f0f0;">
+								<span style="font-weight:600;">${e.methodName || e.engineName || "Event"}</span>
+								<span style="font-weight:600;color:${ok ? STATUS_OK_COLOR : STATUS_FAIL_COLOR};">${ok ? "Success" : "Failed"}</span>
+							</div>
+							${line("Engine", `${e.engineName ?? ""}${e.engineType ? ` (${e.engineType})` : ""}`)}
+							${line("User", e.userName || e.userId || "")}
+							${line("Latency", `${e.latency}ms`)}
+							${line("Tokens", e.tokens != null ? String(e.tokens) : "")}
+							${line("Start", `${start.date} ${start.time}`)}
+							${line("End", `${end.date} ${end.time}`)}
+							${line("Span", e.spanId || "")}
+							${line("Session", e.sessionId || "")}
+							<div style="margin-top:6px;color:#888;">Request</div>
+							<div style="color:#333;word-break:break-word;overflow-wrap:anywhere;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;">${truncate(e.request)}</div>
+							<div style="margin-top:4px;color:#888;">Response</div>
+							<div style="color:#333;word-break:break-word;overflow-wrap:anywhere;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;">${truncate(e.response)}</div>
+						</div>`;
+				},
+			},
+			grid: {
+				left: grouped ? "190px" : "120px",
+				right: "44px",
+				top: "28px",
+				bottom: "40px",
+				containLabel: false,
+			},
+			dataZoom: [
+				//Horizontal time zoom/scrollbar. start/end restore the current zoom on
+				//rebuild so it isn't lost when the chart re-renders.
+				{
+					id: "xZoom",
+					type: "slider",
+					xAxisIndex: 0,
+					bottom: 4,
+					height: 16,
+					start: xZoom.start,
+					end: xZoom.end,
+				},
+				//Vertical scrollbar through rows (keeps the time axis pinned).
+				{
+					id: "yZoom",
+					type: "slider",
+					yAxisIndex: 0,
+					right: 6,
+					width: 14,
+					start: yZoom.start,
+					end: yZoom.end,
+					filterMode: "none",
+					brushSelect: false,
+					showDetail: false,
+				},
+			],
+			xAxis: {
+				type: "time",
+				min: minStart - pad,
+				max: maxEnd + pad,
+				position: "top",
+				axisLine: { lineStyle: { color: "#e0e0e0" } },
+				axisLabel: {
+					color: "#666",
+					fontSize: 11,
+					hideOverlap: true,
+					formatter: (value: number) =>
+						formatAxisValue(value, axisMode),
+				},
+				splitLine: { show: true, lineStyle: { color: "#f0f0f0" } },
+			},
+			yAxis: {
+				type: "category",
+				inverse: true,
+				data: Array.from({ length: laneCount }, (_, index) =>
+					String(index),
+				),
+				axisTick: { show: false },
+				axisLine: { show: false },
+				axisLabel: {
+					color: "#555",
+					fontSize: 11,
+					width: grouped ? 180 : 110,
+					overflow: "truncate",
+					formatter: (value: string) =>
+						laneLabels[Number(value)] ?? "",
+				},
+			},
+			series: [
+				{
+					type: "custom",
+					clip: true,
+					data: seriesData,
+					renderItem: (
+						params: RenderItemParams,
+						api: RenderItemAPI,
+					): RenderRect | null => {
+						const startCoord = api.coord([
+							api.value(0),
+							api.value(1),
+						]);
+						const endCoord = api.coord([
+							api.value(2),
+							api.value(1),
+						]);
+						const bandHeight = api.size([0, 1])[1];
+						const barHeight = Math.max(
+							Math.min(bandHeight * 0.55, 14),
+							4,
+						);
+						//Leave a 1px gap so consecutive parts on a row read as distinct.
+						const width = Math.max(
+							endCoord[0] - startCoord[0] - 1,
+							2,
+						);
+						return {
+							type: "rect",
+							shape: {
+								x: startCoord[0],
+								y: startCoord[1] - barHeight / 2,
+								width,
+								height: barHeight,
+								r: 2,
+							},
+							style: {
+								fill:
+									barColors[params.dataIndex] ??
+									STATUS_OK_COLOR,
+							},
+						};
+					},
+				},
+			],
+		};
+
+		chart.setOption(option as echarts.EChartsOption);
+
+		chart.on("click", (params: { dataIndex?: number }) => {
+			//Ignore clicks while the highlight (drag-to-zoom) cursor is armed.
+			if (zoomSelectActiveRef.current) return;
+			if (params.dataIndex != null && rows[params.dataIndex]) {
+				setSelectedEvent(rows[params.dataIndex].event);
+				setDrawerOpen(true);
+			}
+		});
+
+		//Manual drag-a-rectangle-to-zoom: when the highlight cursor is armed, dragging
+		//on the plot draws a selection mask and zooms both axes to that region. This is
+		//done with zrender events (rather than the toolbox feature) so it works reliably.
+		const zr = chart.getZr();
+		let dragStart: [number, number] | null = null;
+		let maskEl: echarts.graphic.Rect | null = null;
+		const clearMask = () => {
+			if (maskEl) {
+				zr.remove(maskEl);
+				maskEl = null;
+			}
+			dragStart = null;
+		};
+		const onZrDown = (event: { offsetX: number; offsetY: number }) => {
+			if (!zoomSelectActiveRef.current) return;
+			dragStart = [event.offsetX, event.offsetY];
+			maskEl = new echarts.graphic.Rect({
+				shape: {
+					x: event.offsetX,
+					y: event.offsetY,
+					width: 0,
+					height: 0,
+				},
+				style: {
+					fill: "rgba(59,130,246,0.15)",
+					stroke: "#3b82f6",
+					lineWidth: 1,
+				},
+				z: 100,
+				silent: true,
+			});
+			zr.add(maskEl);
+		};
+		const onZrMove = (event: { offsetX: number; offsetY: number }) => {
+			if (!dragStart || !maskEl) return;
+			maskEl.setShape({
+				x: Math.min(dragStart[0], event.offsetX),
+				y: Math.min(dragStart[1], event.offsetY),
+				width: Math.abs(event.offsetX - dragStart[0]),
+				height: Math.abs(event.offsetY - dragStart[1]),
+			});
+		};
+		const onZrUp = (event: { offsetX: number; offsetY: number }) => {
+			if (!dragStart) return;
+			const [sx, sy] = dragStart;
+			const ex = event.offsetX;
+			const ey = event.offsetY;
+			clearMask();
+			//Ignore tiny drags (treated as a click).
+			if (Math.abs(ex - sx) < 4 && Math.abs(ey - sy) < 4) return;
+			const x1 = chart.convertFromPixel(
+				{ xAxisIndex: 0 },
+				Math.min(sx, ex),
+			) as number;
+			const x2 = chart.convertFromPixel(
+				{ xAxisIndex: 0 },
+				Math.max(sx, ex),
+			) as number;
+			const yTop = chart.convertFromPixel(
+				{ yAxisIndex: 0 },
+				Math.min(sy, ey),
+			) as number;
+			const yBottom = chart.convertFromPixel(
+				{ yAxisIndex: 0 },
+				Math.max(sy, ey),
+			) as number;
+			chart.dispatchAction({
+				type: "dataZoom",
+				dataZoomId: "xZoom",
+				startValue: x1,
+				endValue: x2,
+			});
+			chart.dispatchAction({
+				type: "dataZoom",
+				dataZoomId: "yZoom",
+				startValue: Math.min(yTop, yBottom),
+				endValue: Math.max(yTop, yBottom),
+			});
+			//Stay armed so the user can keep drawing zoom regions until they toggle
+			//the highlight button off.
+		};
+		zr.on("mousedown", onZrDown);
+		zr.on("mousemove", onZrMove);
+		zr.on("mouseup", onZrUp);
+
+		//After any zoom (slider drag, rectangle highlight, or buttons) read the
+		//authoritative current windows off the chart so our state always matches what
+		//is shown — and so a rebuild restores the exact same zoom.
+		chart.on("dataZoom", () => {
+			const dataZooms =
+				(
+					chart.getOption() as {
+						dataZoom?: Array<{
+							id?: string;
+							start?: number;
+							end?: number;
+						}>;
+					}
+				).dataZoom ?? [];
+			const x = dataZooms.find((d) => d.id === "xZoom");
+			const y = dataZooms.find((d) => d.id === "yZoom");
+			if (x && typeof x.start === "number" && typeof x.end === "number") {
+				setXZoom({ start: x.start, end: x.end });
+			}
+			if (y && typeof y.start === "number" && typeof y.end === "number") {
+				setYZoom({ start: y.start, end: y.end });
+			}
+		});
+
+		//Keep the chart sized to its container — covers window resizes AND container
+		//changes that don't fire a window resize (panels, sidebars, devtools docking).
+		const handleResize = () => chart.resize();
+		window.addEventListener("resize", handleResize);
+		const resizeObserver = new ResizeObserver(() => chart.resize());
+		if (chartRef.current) resizeObserver.observe(chartRef.current);
+
+		return () => {
+			window.removeEventListener("resize", handleResize);
+			resizeObserver.disconnect();
+			chart.dispose();
+			chartInstanceRef.current = null;
+		};
+	}, [rows, lanes, barColors, chartHeight, axisMode]);
+
+	//Zoom the time (x) axis around the center of the CURRENT window, so the buttons
+	//compose with whatever is already zoomed (slider/rectangle).
+	const applyXZoom = (start: number, end: number) => {
+		setXZoom({ start, end });
+		chartInstanceRef.current?.dispatchAction({
+			type: "dataZoom",
+			dataZoomId: "xZoom",
+			start,
+			end,
+		});
+	};
+
+	const handleZoomIn = () => {
+		const range = xZoom.end - xZoom.start;
+		if (range <= 5) return;
+		const center = (xZoom.start + xZoom.end) / 2;
+		const newRange = range * 0.6;
+		applyXZoom(
+			Math.max(0, center - newRange / 2),
+			Math.min(100, center + newRange / 2),
+		);
+	};
+
+	const handleZoomOut = () => {
+		const range = xZoom.end - xZoom.start;
+		if (range >= 100) return;
+		const center = (xZoom.start + xZoom.end) / 2;
+		const newRange = Math.min(100, range * 1.4);
+		applyXZoom(
+			Math.max(0, center - newRange / 2),
+			Math.min(100, center + newRange / 2),
+		);
+	};
+
+	//Arm/disarm the rectangle-zoom cursor. While armed, dragging on the chart zooms
+	//into that region; toggling off restores normal click-to-open-drawer behavior.
+	const toggleHighlightZoom = () => {
+		setZoomSelectActive((active) => !active);
+	};
+
+	//Restore the full time + row range.
+	const resetZoom = () => {
+		setXZoom({ start: 0, end: 100 });
+		setYZoom({ start: 0, end: 100 });
+		chartInstanceRef.current?.dispatchAction({
+			type: "dataZoom",
+			dataZoomId: "xZoom",
+			start: 0,
+			end: 100,
+		});
+		chartInstanceRef.current?.dispatchAction({
+			type: "dataZoom",
+			dataZoomId: "yZoom",
+			start: 0,
+			end: 100,
+		});
+	};
+
+	const handleDrawerClose = () => {
+		setDrawerOpen(false);
+		setTimeout(() => setSelectedEvent(null), 300);
+	};
+
+	const header = (
+		<div className="flex flex-wrap items-center justify-between gap-2 p-4">
+			<span className="font-semibold text-[#333] text-[18px]">
+				Event History
+			</span>
+			<div className="flex flex-wrap items-center gap-2">
+				<Select
+					value={rowMode}
+					onValueChange={(value) => setRowMode(value as RowMode)}
+				>
+					<SelectTrigger className="h-8 w-[150px] text-sm">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{(Object.keys(ROW_MODE_LABELS) as RowMode[]).map(
+							(mode) => (
+								<SelectItem key={mode} value={mode}>
+									{ROW_MODE_LABELS[mode]}
+								</SelectItem>
+							),
+						)}
+					</SelectContent>
+				</Select>
+				<Select
+					value={axisMode}
+					onValueChange={(value) => setAxisMode(value as AxisMode)}
+				>
+					<SelectTrigger className="h-8 w-[150px] text-sm">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{(Object.keys(AXIS_MODE_LABELS) as AxisMode[]).map(
+							(mode) => (
+								<SelectItem key={mode} value={mode}>
+									{AXIS_MODE_LABELS[mode]}
+								</SelectItem>
+							),
+						)}
+					</SelectContent>
+				</Select>
+				<fieldset
+					className="inline-flex gap-1 rounded-md bg-white shadow-sm"
+					style={{ boxShadow: "0 1px 3px rgba(0, 0, 0, 0.1)" }}
+				>
+					<Button
+						variant={zoomSelectActive ? "secondary" : "ghost"}
+						className="rounded-[4px_0_0_4px] px-[4px] py-[4px]"
+						onClick={toggleHighlightZoom}
+						title="Highlight a region to zoom in"
+						aria-pressed={zoomSelectActive}
+					>
+						<CropIcon style={{ color: "#666" }} />
+					</Button>
+					<Button
+						variant="ghost"
+						className="rounded-none px-[4px] py-[4px]"
+						onClick={handleZoomIn}
+						title="Zoom in"
+						disabled={xZoom.end - xZoom.start <= 5}
+					>
+						<ZoomInIcon style={{ color: "#666" }} />
+					</Button>
+					<Button
+						variant="ghost"
+						className="rounded-none px-[4px] py-[4px]"
+						onClick={handleZoomOut}
+						title="Zoom out"
+						disabled={xZoom.start === 0 && xZoom.end === 100}
+					>
+						<ZoomOutIcon style={{ color: "#666" }} />
+					</Button>
+					<Button
+						variant="ghost"
+						className="rounded-[0_4px_4px_0] px-[4px] py-[4px]"
+						onClick={resetZoom}
+						title="Reset zoom"
+						disabled={
+							xZoom.start === 0 &&
+							xZoom.end === 100 &&
+							yZoom.start === 0 &&
+							yZoom.end === 100
+						}
+					>
+						<ResetIcon style={{ color: "#666" }} />
+					</Button>
+				</fieldset>
+			</div>
+		</div>
+	);
+
+	if (rows.length === 0) {
 		return (
 			<div className="rounded-[8px] bg-white p-0 pb-2 shadow-lg">
-				<div className="flex items-center justify-between p-4">
-					<span className="font-semibold text-[#333] text-[18px]">
-						Event History
-					</span>
-				</div>
+				{header}
 				<div className="p-4 text-center">
 					<span className="font-normal text-[14px] text-gray-500">
 						No logs available.
@@ -720,49 +728,29 @@ export const AuditLogsTimeline: React.FC<AuditLogsTimelineProps> = ({
 	}
 
 	return (
-		<div className="h-auto rounded-[8px] bg-white p-0 pb-4 shadow-lg">
-			<div className="flex items-center justify-between p-4">
-				<span className="font-semibold text-[#333] text-[18px]">
-					Event History
-				</span>
-				{/** changing from div role="group", to fieldset */}
-				<fieldset
-					className="inline-flex gap-1 rounded-md bg-white shadow-sm"
-					style={{ boxShadow: "0 1px 3px rgba(0, 0, 0, 0.1)" }}
+		<>
+			<div className="rounded-[8px] bg-white p-0 pb-2 shadow-lg">
+				{header}
+				<div className="w-full px-2 pb-2">
+					<div
+						className="w-full bg-[#FFFFFF]"
+						style={{ height: `${chartHeight}px` }}
+						ref={chartRef}
+					/>
+				</div>
+			</div>
+			<Sheet open={drawerOpen} onOpenChange={setDrawerOpen}>
+				<SheetContent
+					side="right"
+					className="min-w-[500px] transition-all duration-400 ease-[cubic-bezier(0.4,0,0.2,1)] data-[state=closed]:translate-x-full data-[state=open]:translate-x-0 data-[state=closed]:opacity-0 data-[state=open]:opacity-100"
 				>
-					<Button
-						variant="ghost"
-						className="rounded-[4px_0_0_4px] px-[4px] py-[4px]"
-						onClick={handleZoomIn}
-						disabled={zoomState.end - zoomState.start <= 15}
-					>
-						<ZoomInIcon
-							fontSize="small"
-							style={{ color: "#666" }}
-						/>
-					</Button>
-					<Button
-						variant="ghost"
-						className="rounded-[0_4px_4px_0] px-[4px] py-[4px]"
-						onClick={handleZoomOut}
-						disabled={
-							zoomState.start === 0 && zoomState.end === 100
-						}
-					>
-						<ZoomOutIcon
-							fontSize="small"
-							style={{ color: "#666" }}
-						/>
-					</Button>
-				</fieldset>
-			</div>
-
-			<div
-				className="m-0 h-[295px] w-full bg-[#FFFFFF] pb-[10px]"
-				ref={chartRef}
-			>
-				&nbsp;
-			</div>
-		</div>
+					<SheetTitle className="sr-only">Audit Details</SheetTitle>
+					<AuditLogsDetailDrawer
+						logDetails={selectedEvent}
+						handleDrawerClose={handleDrawerClose}
+					/>
+				</SheetContent>
+			</Sheet>
+		</>
 	);
 };

--- a/libs/shared/src/components/auditlog/common.ts
+++ b/libs/shared/src/components/auditlog/common.ts
@@ -1,6 +1,7 @@
 //Common place to keep and make changes for audit logs related common functions for enhancing reusablity
 //event data object will have all the details about when the user clicks on table row
 export interface EventData {
+	requestId?: string;
 	startTime: string;
 	endTime: string;
 	logTimestamp: string;
@@ -11,15 +12,22 @@ export interface EventData {
 	status: string | null;
 	engineName: string;
 	engineType: string;
+	methodName?: string;
+	userName?: string;
 	userId: string;
 	sessionId: string;
 	spanId: string;
 }
 /**
- * A function to format a timestamp into a date and time string.
- * @param {string|number|null|undefined} timeStamp - The timestamp to be formatted.
- * @returns {{date: string, time: string}} - An object containing the date and time strings.
- * @return  {{date : "", time: ""}} when the date is not valid
+ * Format an audit-log timestamp into separate date and time strings for display.
+ *
+ * Audit-log timestamps are ISO-8601 UTC strings (e.g. "2026-06-22T17:48:07.123Z").
+ * `new Date(...)` parses the trailing `Z` as a UTC instant, and the toLocale*
+ * formatters render it in the viewer's local timezone (client-side display).
+ *
+ * @param {string|number|null|undefined} timeStamp - ISO-8601 UTC string (or epoch ms).
+ * @returns {{date: string, time: string}} - Localized date ("MM/DD/YYYY") and time
+ *   ("hh:mm:ss AM/PM"); both empty when the timestamp is missing or invalid.
  */
 export const TimeDateFormatter = (
 	timeStamp: string | number | null | undefined,
@@ -28,37 +36,25 @@ export const TimeDateFormatter = (
 		return { date: "", time: "" };
 	}
 
-	try {
-		const tempDate = new Date(timeStamp);
-
-		// Check if date is invalid
-		if (Number.isNaN(tempDate.getTime())) {
-			return { date: "", time: "" };
-		}
-
-		const formattedDate = tempDate.toLocaleTimeString("en-US", {
-			year: "numeric",
-			month: "2-digit",
-			day: "2-digit",
-			hour: "2-digit",
-			minute: "2-digit",
-			second: "2-digit",
-			hour12: true,
-		});
-
-		try {
-			const [datePart, timePart] = formattedDate.split(", ");
-			const date = datePart || "";
-			const time = timePart ? timePart.split(" ")[0] : "";
-			return { date, time };
-		} catch (_formatError) {
-			// Handle string parsing errors
-			return { date: "", time: "" };
-		}
-	} catch (_dateError) {
-		// Handle date creation errors
+	const parsed = new Date(timeStamp);
+	if (Number.isNaN(parsed.getTime())) {
 		return { date: "", time: "" };
 	}
+
+	//Format date and time independently so we don't depend on the locale's
+	//combined-format separator (the previous split on ", " was brittle).
+	const date = parsed.toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	});
+	const time = parsed.toLocaleTimeString("en-US", {
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+		hour12: true,
+	});
+	return { date, time };
 };
 
 /**

--- a/libs/shared/src/components/auditlog/index.ts
+++ b/libs/shared/src/components/auditlog/index.ts
@@ -1,14 +1,56 @@
 import { AuditLogFilter } from "./audit-log-filter";
 import { AuditLogsDataTable } from "./audit-logs-data-table";
+import { AuditLogsSummary } from "./audit-logs-summary";
 import { AuditLogsTimeline } from "./audit-logs-timeline";
 import type { EventData } from "./common";
 import { dateFormat, TimeDateFormatter } from "./common";
+import type {
+	AuditLogDateParams,
+	AuditLogDateRangeType,
+	AuditLogFilterName,
+	AuditLogFilterOptionParams,
+	AuditLogFilterValue,
+	AuditLogReportParams,
+	AuditLogScope,
+	AuditLogSearch,
+	AuditLogUserOption,
+} from "./pixel";
+import {
+	buildAuditLogReportPixel,
+	buildExportAuditLogReportPixel,
+	buildFilterOptionListPixel,
+	filterValueToReportParams,
+	hasScope,
+	parseSimpleFilterOptions,
+	parseUserFilterOptions,
+	resolveDateParams,
+} from "./pixel";
 
 export {
 	AuditLogsDataTable,
+	AuditLogsSummary,
 	AuditLogsTimeline,
 	AuditLogFilter,
 	dateFormat,
 	TimeDateFormatter,
+	buildAuditLogReportPixel,
+	buildExportAuditLogReportPixel,
+	buildFilterOptionListPixel,
+	filterValueToReportParams,
+	hasScope,
+	parseSimpleFilterOptions,
+	parseUserFilterOptions,
+	resolveDateParams,
 };
-export type { EventData };
+export type {
+	EventData,
+	AuditLogDateParams,
+	AuditLogDateRangeType,
+	AuditLogFilterName,
+	AuditLogFilterOptionParams,
+	AuditLogFilterValue,
+	AuditLogReportParams,
+	AuditLogScope,
+	AuditLogSearch,
+	AuditLogUserOption,
+};

--- a/libs/shared/src/components/auditlog/pixel.ts
+++ b/libs/shared/src/components/auditlog/pixel.ts
@@ -1,0 +1,269 @@
+//Centralized builders for the Audit Log pixel reactors so the report table, the
+//CSV/PDF export, and the filter-option dropdowns all share a single contract.
+//
+//IMPORTANT: limit and offset are TOP-LEVEL pixel keys, NOT inside paramValues.
+
+export type AuditLogDateRangeType = "DAY" | "WEEK" | "MONTH" | "CUSTOM";
+
+//Exactly one of these scope ids identifies the project/engine/room the logs belong to.
+export interface AuditLogScope {
+	projectId?: string;
+	engineId?: string;
+	roomId?: string;
+}
+
+//Multi-select server-side filters (IN clause). Values come from
+//GetAuditLogsReportFilterOptionList.
+export interface AuditLogSearch {
+	methodName?: string[];
+	engineType?: string[];
+}
+
+export interface AuditLogReportParams {
+	scope: AuditLogScope;
+	sessionId?: string;
+	//Optional room filter (free-text room id), passed through to the report.
+	roomId?: string;
+	//Owner-only; the backend ignores it (and forces the caller's own id) for non-owners.
+	filterUserId?: string;
+	//Date params are optional — omit them entirely to let the backend apply no date
+	//window (e.g. the room activity log sends only the scope).
+	dateRangeType?: AuditLogDateRangeType;
+	dateRangeValue?: number;
+	startDate?: string; //ISO, custom range only
+	endDate?: string; //ISO, custom range only
+	search?: AuditLogSearch;
+	//Global free-text search; the backend matches it against methodName + engineType only.
+	searchTerm?: string;
+}
+
+export type AuditLogFilterName =
+	| "methodName"
+	| "engineType"
+	| "user"
+	| "roomId";
+
+//Resolved date bounds, shared by the report, the option lists, and the export so
+//all three agree (the backend now date-scopes the option lists too).
+export interface AuditLogDateParams {
+	dateRangeType: AuditLogDateRangeType;
+	dateRangeValue: number;
+	startDate?: string; //ISO, custom range only
+	endDate?: string; //ISO, custom range only
+}
+
+export interface AuditLogFilterOptionParams {
+	filterName: AuditLogFilterName;
+	scope: AuditLogScope;
+	engineType?: string; //optional extra scope (e.g. method names for one engine type)
+	filterUserId?: string; //owner-only
+	search?: string; //type-ahead, narrows by display value
+	//Pass the SAME date params used for the table so the dropdowns match the rows.
+	date?: AuditLogDateParams;
+}
+
+//The shape the AuditLogFilter component emits on every change. Pages convert this
+//into AuditLogReportParams with filterValueToReportParams.
+export interface AuditLogFilterValue {
+	scope: AuditLogScope | null;
+	dateRangeType: AuditLogDateRangeType;
+	dateRangeValue: number;
+	customDateRange: { from: Date | null; to: Date | null };
+	methodNames: string[];
+	engineTypes: string[];
+	filterUserId: string;
+	roomId: string;
+	searchTerm: string;
+}
+
+//A scope is usable once it carries one of the allowed ids.
+export const hasScope = (scope: AuditLogScope | null | undefined): boolean =>
+	Boolean(scope && (scope.projectId || scope.engineId || scope.roomId));
+
+//Resolve a duration selection into concrete date params (with ISO bounds for the
+//custom range). Single source of truth so the table, dropdowns, and export agree.
+export const resolveDateParams = (selection: {
+	dateRangeType: AuditLogDateRangeType;
+	dateRangeValue: number;
+	customDateRange?: { from: Date | null; to: Date | null };
+}): AuditLogDateParams => {
+	const date: AuditLogDateParams = {
+		dateRangeType: selection.dateRangeType || "DAY",
+		dateRangeValue: selection.dateRangeValue || 1,
+	};
+	if (
+		selection.dateRangeType === "CUSTOM" &&
+		selection.customDateRange?.from &&
+		selection.customDateRange?.to
+	) {
+		const start = new Date(selection.customDateRange.from);
+		const end = new Date(selection.customDateRange.to);
+		start.setUTCHours(0, 0, 0, 0);
+		end.setUTCHours(23, 59, 59, 999);
+		date.startDate = start.toISOString();
+		date.endDate = end.toISOString();
+	}
+	return date;
+};
+
+//Write resolved date params onto a paramValues map.
+const applyDateParams = (
+	paramValues: Record<string, unknown>,
+	date: AuditLogDateParams,
+) => {
+	paramValues.dateRangeType = date.dateRangeType;
+	paramValues.dateRangeValue = date.dateRangeValue;
+	if (date.dateRangeType === "CUSTOM") {
+		if (date.startDate) paramValues.startDate = date.startDate;
+		if (date.endDate) paramValues.endDate = date.endDate;
+	}
+};
+
+//Build the paramValues map shared by AuditLogsReport and ExportAuditLogsReport.
+const buildReportParamValues = (
+	params: AuditLogReportParams,
+): Record<string, unknown> => {
+	const { scope, search } = params;
+	const paramValues: Record<string, unknown> = {};
+
+	if (scope.projectId) paramValues.projectId = scope.projectId;
+	if (scope.engineId) paramValues.engineId = scope.engineId;
+	if (scope.roomId) paramValues.roomId = scope.roomId;
+
+	if (params.sessionId) paramValues.sessionId = params.sessionId;
+	if (params.roomId) paramValues.roomId = params.roomId;
+	if (params.filterUserId) paramValues.filterUserId = params.filterUserId;
+
+	//Only send date params when a range is set; omitting them entirely means no
+	//date filter (the room activity log relies on this).
+	if (params.dateRangeType) {
+		applyDateParams(paramValues, {
+			dateRangeType: params.dateRangeType,
+			dateRangeValue: params.dateRangeValue ?? 1,
+			startDate: params.startDate,
+			endDate: params.endDate,
+		});
+	}
+
+	const nestedSearch: AuditLogSearch = {};
+	if (search?.methodName?.length) nestedSearch.methodName = search.methodName;
+	if (search?.engineType?.length) nestedSearch.engineType = search.engineType;
+	if (Object.keys(nestedSearch).length > 0) paramValues.search = nestedSearch;
+
+	const trimmedTerm = params.searchTerm?.trim();
+	if (trimmedTerm) paramValues.searchTerm = trimmedTerm;
+
+	return paramValues;
+};
+
+export const buildAuditLogReportPixel = (
+	params: AuditLogReportParams,
+	limit: number,
+	offset: number,
+): string => {
+	const paramValues = buildReportParamValues(params);
+	return `AuditLogsReport(paramValues=[${JSON.stringify(paramValues)}], limit=[${limit}], offset=[${offset}]);`;
+};
+
+export const buildExportAuditLogReportPixel = (
+	params: AuditLogReportParams,
+	limit: number,
+	offset: number,
+	pdf: boolean,
+): string => {
+	const paramValues = buildReportParamValues(params);
+	if (pdf) paramValues.pdfFormat = "true";
+	return `ExportAuditLogsReport(paramValues=[${JSON.stringify(paramValues)}], limit=[${limit}], offset=[${offset}]);`;
+};
+
+export const buildFilterOptionListPixel = (
+	params: AuditLogFilterOptionParams,
+	limit = 100,
+	offset = 0,
+): string => {
+	const paramValues: Record<string, unknown> = {
+		filterName: params.filterName,
+	};
+
+	if (params.scope.projectId) paramValues.projectId = params.scope.projectId;
+	if (params.scope.engineId) paramValues.engineId = params.scope.engineId;
+	if (params.scope.roomId) paramValues.roomId = params.scope.roomId;
+
+	if (params.engineType) paramValues.engineType = params.engineType;
+	if (params.filterUserId) paramValues.filterUserId = params.filterUserId;
+	const trimmedSearch = params.search?.trim();
+	if (trimmedSearch) paramValues.search = trimmedSearch;
+
+	//Date-scope the dropdown so its values match the visible rows.
+	if (params.date) applyDateParams(paramValues, params.date);
+
+	return `GetAuditLogsReportFilterOptionList(paramValues=[${JSON.stringify(paramValues)}], limit=[${limit}], offset=[${offset}]);`;
+};
+
+//Convert the filter component's emitted value into report params, resolving the
+//custom date range into ISO start/end bounds. Pass { includeDate: false } to omit
+//date params entirely (e.g. the room activity log sends only the scope).
+export const filterValueToReportParams = (
+	value: AuditLogFilterValue,
+	options: { includeDate?: boolean } = {},
+): AuditLogReportParams => {
+	const { includeDate = true } = options;
+	const params: AuditLogReportParams = {
+		scope: value.scope ?? {},
+		search: {
+			methodName: value.methodNames,
+			engineType: value.engineTypes,
+		},
+		searchTerm: value.searchTerm,
+	};
+
+	if (includeDate) {
+		const date = resolveDateParams({
+			dateRangeType: value.dateRangeType,
+			dateRangeValue: value.dateRangeValue,
+			customDateRange: value.customDateRange,
+		});
+		params.dateRangeType = date.dateRangeType;
+		params.dateRangeValue = date.dateRangeValue;
+		params.startDate = date.startDate;
+		params.endDate = date.endDate;
+	}
+
+	if (value.filterUserId) params.filterUserId = value.filterUserId;
+	if (value.roomId?.trim()) params.roomId = value.roomId.trim();
+
+	return params;
+};
+
+//GetAuditLogsReportFilterOptionList returns List<String[]> (distinct rows).
+export interface AuditLogUserOption {
+	userName: string;
+	userId: string;
+	userType: string;
+}
+
+//methodName / engineType rows are single-column: ["<value>"].
+export const parseSimpleFilterOptions = (output: unknown): string[] => {
+	if (!Array.isArray(output)) return [];
+	return output
+		.map((row) => (Array.isArray(row) ? row[0] : row))
+		.filter(
+			(value): value is string =>
+				typeof value === "string" && value.length > 0,
+		);
+};
+
+//user rows are ["<userName>", "<userId>", "<userType>"].
+export const parseUserFilterOptions = (
+	output: unknown,
+): AuditLogUserOption[] => {
+	if (!Array.isArray(output)) return [];
+	return output
+		.filter((row): row is unknown[] => Array.isArray(row) && row.length > 0)
+		.map((row) => ({
+			userName: (row[0] as string) ?? "",
+			userId: (row[1] as string) ?? "",
+			userType: (row[2] as string) ?? "",
+		}))
+		.filter((user) => Boolean(user.userId));
+};

--- a/libs/shared/src/types.ts
+++ b/libs/shared/src/types.ts
@@ -282,6 +282,8 @@ export interface ThemeMap {
 			showKnowledgeMenu?: boolean;
 			/** Whether to show the Toolbox picker in the chat input menu. Defaults to true. */
 			showToolboxMenu?: boolean;
+			/** Whether to show the Activity Log (audit logs) option in the room menu. Defaults to true. */
+			showActivityLog?: boolean;
 			/** Whether to show external links to the SEMOSS platform. Defaults to true. */
 			showPlatformLinks?: boolean;
 			/** Whether to show a text input for feedback comments when rating a response. Defaults to false. */

--- a/packages/auditlog/src/components/audit-log-page.tsx
+++ b/packages/auditlog/src/components/audit-log-page.tsx
@@ -1,15 +1,28 @@
-import { RotateCw } from "lucide-react";
+import { Download, RotateCw } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { runPixel } from "@semoss/sdk";
+import { download, runPixel } from "@semoss/sdk";
 import { useInsight } from "@semoss/sdk/react";
 import {
 	AuditLogFilter,
+	type AuditLogFilterValue,
 	AuditLogsDataTable,
+	AuditLogsSummary,
 	AuditLogsTimeline,
+	buildAuditLogReportPixel,
+	buildExportAuditLogReportPixel,
 	type EventData,
+	filterValueToReportParams,
+	hasScope,
 } from "@semoss/shared";
-import { Button, Skeleton, toast } from "@semoss/ui/next";
-import { useUserRootStore } from "@/hooks/useUserRootStore";
+import {
+	Button,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+	Skeleton,
+	toast,
+} from "@semoss/ui/next";
 
 /**
  * This component displays the audit logs.
@@ -21,89 +34,91 @@ export const AuditLogPage = ({ catalogName }) => {
 	const { insightId } = useInsight(); // fetching insight id for access
 	const [logs, setLogs] = useState<EventData[]>([]);
 	const [page, setPage] = useState(0);
-	const [rowsPerPage, setRowsPerPage] = useState(10);
+	const [rowsPerPage, setRowsPerPage] = useState(50);
 	const [totalCount, setTotalCount] = useState(0);
-	const [loading, setLoading] = useState<boolean>(true);
-	const rootStore = useUserRootStore(insightId);
-	const filteredData = useRef({
-		engineType: "",
-		engineId: "",
-		dashboardDuration: "",
+	const [loading, setLoading] = useState<boolean>(false);
+	const filteredData = useRef<AuditLogFilterValue>({
+		scope: null,
+		dateRangeType: "DAY",
+		dateRangeValue: 1,
 		customDateRange: { from: null, to: null },
-		SelectedDuration: {
-			label: "",
-			value: "",
-			dateRangeType: "",
-			dateRangeValue: 1,
-		},
+		methodNames: [],
+		engineTypes: [],
+		filterUserId: "",
+		roomId: "",
+		searchTerm: "",
 	});
 
 	/**
-	 * Fetches audit logs from the API.
+	 * Fetches audit logs from the API using the current filter state.
 	 *
 	 * @param {number} limit - The limit of the logs to fetch.
 	 * @param {number} offset - The offset of the logs to fetch.
 	 */
 	const fetchLogs = async (limit: number, offset: number) => {
+		const filterValue = filteredData.current;
+		if (!hasScope(filterValue.scope) || !insightId) {
+			setLogs([]);
+			setTotalCount(0);
+			setLoading(false);
+			return;
+		}
 		setLoading(true);
 		try {
-			const date = new Date();
-			const yyyy = date.getFullYear();
-			const mm = String(date.getMonth() + 1).padStart(2, "0");
-			const dd = String(date.getDate()).padStart(2, "0");
-			const hh = String(date.getHours()).padStart(2, "0");
-			const min = String(date.getMinutes()).padStart(2, "0");
-			const ss = String(date.getSeconds()).padStart(2, "0");
-
-			const dateTime = `${yyyy}-${mm}-${dd} ${hh}:${min}:${ss}`;
-			const catalogId = filteredData.current.engineId ?? null;
-			catalogName = filteredData.current.engineType;
-			console.log(catalogName, "catalogName");
-			const startDate = new Date(
-				filteredData.current?.customDateRange?.from?.setUTCHours(
-					0,
-					0,
-					0,
-					0,
-				),
-			);
-			const endDate = new Date(
-				filteredData.current?.customDateRange?.to?.setUTCHours(
-					23,
-					59,
-					59,
-					999,
-				),
-			);
-			const SelectedDuration = filteredData.current.SelectedDuration;
+			const params = filterValueToReportParams(filterValue);
 			const response = await runPixel(
-				`AuditLogReport(paramValues=[{"projectId" : "${catalogName === "APP" ? catalogId : ""}","engineId": "${catalogName === "APP" ? "" : catalogId}","dateTime":"${dateTime}","limit":"${limit}","offset":"${offset}","dateRangeType": "${SelectedDuration.dateRangeType || "DAY"}","dateRangeValue": ${SelectedDuration.dateRangeValue} ${SelectedDuration.dateRangeType === "CUSTOM" ? `,"startDate": "${startDate?.toISOString()}", "endDate": "${endDate?.toISOString()}"` : ""}}]);`,
+				buildAuditLogReportPixel(params, limit, offset),
 				insightId,
 			);
-			const responseData = response.pixelReturn[0].output as {
-				logs: EventData[];
-				totalCount: number;
+			const { operationType, output } = response.pixelReturn[0];
+			if (operationType.indexOf("ERROR") > -1)
+				throw new Error(`API Error: ${output}`);
+
+			const responseData = output as unknown as {
+				logs?: EventData[];
+				totalCount?: number;
 			};
-			if (responseData?.logs) {
-				const responseLogs =
-					responseData?.logs as unknown as EventData[];
-				setLogs((responseLogs as unknown as EventData[]) || []);
-				setTotalCount(responseData?.totalCount || 0);
-			}
-			if (!responseData?.logs) {
-				const responseLogs = responseData as unknown as EventData[];
-				setLogs((responseLogs as unknown as EventData[]) || []);
-				setTotalCount(responseLogs?.length || 0);
-			}
+			setLogs(
+				responseData?.logs ?? (output as unknown as EventData[]) ?? [],
+			);
+			setTotalCount(
+				responseData?.totalCount ??
+					(output as unknown as EventData[])?.length ??
+					0,
+			);
 		} catch (error) {
 			setLogs([]);
-			// notification.add({
-			// 	color: "error",
-			// 	message: `Error fetching logs: ${error}`,
-			// });
+			setTotalCount(0);
+			toast.error(`Error fetching logs: ${error}`);
 			console.error("Error fetching logs:", error);
 		} finally {
 			setLoading(false);
+		}
+	};
+
+	/**
+	 * Exports the current filtered report as CSV or PDF.
+	 */
+	const handleExport = async (pdf: boolean) => {
+		const filterValue = filteredData.current;
+		if (!hasScope(filterValue.scope) || !insightId) {
+			toast.info("Select an engine before exporting logs.");
+			return;
+		}
+		try {
+			const params = filterValueToReportParams(filterValue);
+			const exportLimit = totalCount > 0 ? totalCount : rowsPerPage;
+			const response = await runPixel(
+				buildExportAuditLogReportPixel(params, exportLimit, 0, pdf),
+				insightId,
+			);
+			const { operationType, output } = response.pixelReturn[0];
+			if (operationType.indexOf("ERROR") > -1)
+				throw new Error(`API Error: ${output}`);
+			await download(insightId, output as unknown as string);
+		} catch (error) {
+			toast.error(`Error exporting logs: ${error}`);
+			console.error("Error exporting logs:", error);
 		}
 	};
 
@@ -121,27 +136,9 @@ export const AuditLogPage = ({ catalogName }) => {
 		setRowsPerPage(newRowsPerPage);
 		fetchLogs(newRowsPerPage, offset);
 	};
-	// biome-ignore lint/correctness/useExhaustiveDependencies: adding fetchLogs causes infinite rerender and based on rootStore user id, data has to be fetched
+
+	//Override the parent css container used by Page.
 	useEffect(() => {
-		//By default engine type and id is required to show the logs
-		if (
-			!catalogName ||
-			!rootStore?.user?.id ||
-			!filteredData.current?.engineId
-		) {
-			setLogs([]);
-			setLoading(false);
-			return;
-		}
-		if (
-			catalogName &&
-			rootStore?.user?.id &&
-			filteredData.current?.engineId
-		) {
-			setLogs([]);
-			fetchLogs(rowsPerPage, page * rowsPerPage);
-		}
-		// override the parent css container used by Page
 		const contentElement = document.querySelector(
 			'[data-home-container="true"]',
 		) as HTMLElement | null;
@@ -152,57 +149,54 @@ export const AuditLogPage = ({ catalogName }) => {
 
 		return () => {
 			if (contentElement) {
-				//restore the original styles
 				contentElement.style.padding = "";
 				contentElement.style.maxWidth = "";
 			}
 		};
-	}, [catalogName, rowsPerPage, page, rootStore?.user?.id]);
+	}, []);
 
 	/**
-	 * Updates the filtered data state with the new filter data and fetches logs with the new offset.
-	 * @param {object} filterData - The new filter data.
+	 * Updates the filtered data state (emitted by the filter) and fetches from
+	 * the first page.
+	 * @param {AuditLogFilterValue} filterValue - The new filter value.
 	 */
-	const updateLogs = (filterData) => {
-		filteredData.current = {
-			...filterData,
-		};
-		fetchLogs(rowsPerPage, page * rowsPerPage);
+	const updateLogs = (filterValue: AuditLogFilterValue) => {
+		filteredData.current = filterValue;
+		setPage(0);
+		fetchLogs(rowsPerPage, 0);
 	};
+
 	return (
 		<div className="flex flex-col gap-4 px-8 py-8">
-			<div className="flex w-full items-center py-4">
+			<div className="flex w-full flex-wrap items-center gap-2 py-4">
 				<h6 className="font-medium text-xl leading-[1.6] tracking-normal">
 					{catalogName} Insight Dashboard
 				</h6>
-				<div className="ml-auto flex flex-row gap-4">
-					{/* Disabled for now */}
-					{/* <Select
-							variant="outlined"
-							size="small"
-							onChange={() => {}}
-							sx={{ minWidth: 120 }}
-							value={"Last 30 Days"}
-						>
-							<Menu.Item value="Last 30 Days">
-								Last 30 Days
-							</Menu.Item>
-							<Menu.Item value="Last 90 Days">
-								Last 90 Days
-							</Menu.Item>
-							<Menu.Item value="Last Year">Last Year</Menu.Item>
-						</Select> */}
-					<AuditLogFilter
-						updateLogs={updateLogs}
-						insightId={insightId}
-					/>
+				<div className="ml-auto flex flex-row items-center gap-2">
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button variant="outline">
+								<Download className="mr-2 h-4 w-4" />
+								Export
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent>
+							<DropdownMenuItem
+								onClick={() => handleExport(false)}
+							>
+								Export as CSV
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onClick={() => handleExport(true)}
+							>
+								Export as PDF
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
 					<Button
 						variant="default"
 						onClick={() => {
-							if (
-								filteredData.current.engineId &&
-								filteredData.current.engineType
-							)
+							if (hasScope(filteredData.current.scope))
 								fetchLogs(rowsPerPage, page * rowsPerPage);
 							else {
 								toast.info(
@@ -216,6 +210,9 @@ export const AuditLogPage = ({ catalogName }) => {
 					</Button>
 				</div>
 			</div>
+			<div className="flex w-full flex-wrap items-center gap-2">
+				<AuditLogFilter updateLogs={updateLogs} insightId={insightId} />
+			</div>
 			{loading ? (
 				<div className="flex flex-col gap-4">
 					<Skeleton className="h-[400px] w-full rounded-md" />{" "}
@@ -223,6 +220,7 @@ export const AuditLogPage = ({ catalogName }) => {
 				</div>
 			) : (
 				<>
+					<AuditLogsSummary logs={logs} totalCount={totalCount} />
 					<AuditLogsTimeline logs={logs} />
 					<AuditLogsDataTable
 						logs={logs}

--- a/packages/client/src/components/app/app-tile-card.tsx
+++ b/packages/client/src/components/app/app-tile-card.tsx
@@ -623,14 +623,6 @@ export const AppTileCard = memo((props: AppTileCardProps) => {
 		[favorite, isFavorite],
 	);
 
-	const handleViewDashboard = useCallback(
-		(e: React.MouseEvent) => {
-			e.stopPropagation();
-			navigate(`/app/${app.project_id}/dashboard`);
-		},
-		[navigate, app.project_id],
-	);
-
 	const handleCopyId = useCallback(
 		(e: React.MouseEvent) => {
 			e.stopPropagation();
@@ -668,9 +660,6 @@ export const AppTileCard = memo((props: AppTileCardProps) => {
 
 	const dropdownMenuContent = (
 		<DropdownMenuContent align="end">
-			<DropdownMenuItem onClick={handleViewDashboard}>
-				View Dashboard
-			</DropdownMenuItem>
 			{canEdit && (
 				<>
 					{entityType !== "agent" && (

--- a/packages/client/src/components/engine/generic-engine-cards.tsx
+++ b/packages/client/src/components/engine/generic-engine-cards.tsx
@@ -4,7 +4,6 @@ import {
 	ChevronDown,
 	ChevronUp,
 	Copy,
-	GanttChartSquare,
 	LockKeyhole,
 	LockKeyholeOpen,
 	Star,
@@ -36,7 +35,6 @@ import {
 } from "@semoss/ui/next";
 import { Folder } from "@/assets/img/Folder";
 import GOOGLE from "@/assets/img/GOOGLE.svg";
-import { useNavigate } from "@/hooks/useNavigate";
 import { formatToDataTestId, getTagBadgeStyle } from "@/utility";
 
 const parseUtcDate = (rawDate?: string) => {
@@ -62,18 +60,6 @@ const parseUtcDate = (rawDate?: string) => {
 	}
 
 	return parsedDate;
-};
-
-const getDashboardPath = (engineType: string | undefined, engineId: string) => {
-	const normalizedType = (engineType || "").trim().toLowerCase();
-	if (!normalizedType) {
-		return `${engineId}/dashboard`;
-	}
-	if (normalizedType === "project" || normalizedType === "app") {
-		return `/app/${engineId}/dashboard`;
-	}
-
-	return `/engine/${normalizedType}/${engineId}/dashboard`;
 };
 
 const isProjectType = (engineType?: string) => {
@@ -121,8 +107,6 @@ interface DatabaseCardProps {
 
 	isDiscoverable?: boolean;
 
-	showLogs?: boolean;
-
 	enableGlobalAction?: boolean;
 
 	isUpvoted?: boolean;
@@ -155,7 +139,6 @@ export const EngineLandscapeCard = (props: DatabaseCardProps) => {
 		isFavorite,
 		hideFavorite = false,
 		isDiscoverable = false,
-		showLogs = true,
 		enableGlobalAction = false,
 		isGlobal,
 		type,
@@ -187,8 +170,6 @@ export const EngineLandscapeCard = (props: DatabaseCardProps) => {
 				})
 				.replace(",", "")
 		: "N/A";
-
-	const navigate = useNavigate();
 
 	// Observe the row width and collapse tags when there isn't enough space
 	useEffect(() => {
@@ -426,24 +407,6 @@ export const EngineLandscapeCard = (props: DatabaseCardProps) => {
 							<Bookmark className="size-4" />
 						)}
 					</Button>
-				)}
-				{showLogs && (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								variant="ghost"
-								size="icon-sm"
-								title="View Logs Dashboard"
-								onClick={(e) => {
-									e.stopPropagation();
-									navigate(getDashboardPath(type, id));
-								}}
-							>
-								<GanttChartSquare className="size-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>View Logs Dashboard</TooltipContent>
-					</Tooltip>
 				)}
 				{onDelete && (
 					<Tooltip>

--- a/packages/client/src/pages/app/app-activity-page.tsx
+++ b/packages/client/src/pages/app/app-activity-page.tsx
@@ -1,0 +1,9 @@
+import { AuditLogsDashboard } from "../audit-logs-dashboard";
+
+/**
+ * The "Activity" tab of the app detail layout — renders the audit logs dashboard
+ * embedded (no standalone page chrome). The app id comes from the route params.
+ */
+export const AppActivityPage = () => {
+	return <AuditLogsDashboard catalogName="Apps" embedded />;
+};

--- a/packages/client/src/pages/app/app-detail.constants.ts
+++ b/packages/client/src/pages/app/app-detail.constants.ts
@@ -1,5 +1,6 @@
 import type { AppDetailPermission } from "@/contexts/AppDetailContext";
 import { AppAccessControlPage } from "./app-access-control-page";
+import { AppActivityPage } from "./app-activity-page";
 import { AppCommitsPage } from "./app-commits-page";
 import { AppDependenciesPage } from "./app-dependencies-page";
 import { AppFilesPage } from "./app-files-page";
@@ -43,6 +44,12 @@ export const APP_DETAIL_TABS: AppDetailTab[] = [
 		name: "MCP Usage",
 		path: "mcp-usage",
 		component: AppMcpUsagePage,
+		restrict: ["author", "editor", "readOnly"],
+	},
+	{
+		name: "Activity Log",
+		path: "activity",
+		component: AppActivityPage,
 		restrict: ["author", "editor", "readOnly"],
 	},
 	{

--- a/packages/client/src/pages/audit-logs-dashboard.tsx
+++ b/packages/client/src/pages/audit-logs-dashboard.tsx
@@ -1,38 +1,44 @@
 // biome-ignore-all lint/correctness/useExhaustiveDependencies: TODO
-import { RefreshCw } from "lucide-react";
+import { Download, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
+import { download } from "@semoss/sdk";
 import {
 	AppCatalogAvatar,
 	AuditLogFilter,
+	type AuditLogFilterValue,
+	type AuditLogScope,
 	AuditLogsDataTable,
+	AuditLogsSummary,
 	AuditLogsTimeline,
+	buildAuditLogReportPixel,
+	buildExportAuditLogReportPixel,
 	EngineSubtypeIcon,
 	EntityHeader,
 	type EventData,
+	filterValueToReportParams,
+	hasScope,
 } from "@semoss/shared";
-import { Button, Skeleton, toast } from "@semoss/ui/next";
+import {
+	Button,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+	Skeleton,
+	toast,
+} from "@semoss/ui/next";
 import { NavbarHeader, NavbarLeft } from "@/components/shared";
 import { useRootStore } from "@/hooks";
 
 interface AuditLogsDashboardProps {
 	catalogName: string;
-}
-
-interface AuditLogsFilterData {
-	engineType: string;
-	engineId: string;
-	duration: string;
-	customDateRange: {
-		from: Date | null;
-		to: Date | null;
-	};
-	SelectedDuration: {
-		label: string;
-		value: string;
-		dateRangeType: string;
-		dateRangeValue: number;
-	};
+	/**
+	 * When rendered inside the app/engine detail tabs (not as a standalone page),
+	 * skip the page navbar, the full-page padding side effect, and the entity
+	 * header — the surrounding layout already provides those.
+	 */
+	embedded?: boolean;
 }
 
 interface AppMetadataResponse {
@@ -69,6 +75,7 @@ type ContextEntity =
  */
 export const AuditLogsDashboard = ({
 	catalogName,
+	embedded = false,
 }: AuditLogsDashboardProps) => {
 	const { configStore, monolithStore } = useRootStore();
 	const { appId, engineId } = useParams();
@@ -76,21 +83,19 @@ export const AuditLogsDashboard = ({
 	const [page, setPage] = useState(0);
 	const [rowsPerPage, setRowsPerPage] = useState(50);
 	const [totalCount, setTotalCount] = useState(0);
-	const [loading, setLoading] = useState<boolean>(true);
+	const [loading, setLoading] = useState<boolean>(false);
 	const [contextEntityDetails, setContextEntityDetails] =
 		useState<ContextEntity | null>(null);
-	const hasSkippedInitialFilterFetchRef = useRef(false);
-	const filteredData = useRef<AuditLogsFilterData>({
-		engineType: "",
-		engineId: "",
-		duration: "",
+	const filteredData = useRef<AuditLogFilterValue>({
+		scope: null,
+		dateRangeType: "DAY",
+		dateRangeValue: 1,
 		customDateRange: { from: null, to: null },
-		SelectedDuration: {
-			label: "",
-			value: "",
-			dateRangeType: "",
-			dateRangeValue: 1,
-		},
+		methodNames: [],
+		engineTypes: [],
+		filterUserId: "",
+		roomId: "",
+		searchTerm: "",
 	});
 	const routeContextEntity = useMemo<ContextEntity | null>(() => {
 		if (appId) {
@@ -114,6 +119,13 @@ export const AuditLogsDashboard = ({
 	}, [appId, engineId, catalogName]);
 	const contextEntity = contextEntityDetails || routeContextEntity;
 	const isContextualDashboard = Boolean(routeContextEntity);
+	//Scope passed to the filter for contextual dashboards (route-derived). For the
+	//global "Apps" dashboard this is null and the filter renders its own pickers.
+	const routeScope = useMemo<AuditLogScope | null>(() => {
+		if (appId) return { projectId: appId };
+		if (engineId) return { engineId };
+		return null;
+	}, [appId, engineId]);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -194,84 +206,73 @@ export const AuditLogsDashboard = ({
 	}, [appId, engineId, monolithStore, catalogName]);
 
 	/**
-	 * Fetches the audit logs from the API.
+	 * Fetches the audit logs from the API using the current filter state.
 	 */
 	const fetchLogs = async (limit: number, offset: number) => {
+		const filterValue = filteredData.current;
+		if (!hasScope(filterValue.scope)) {
+			setLogs([]);
+			setTotalCount(0);
+			setLoading(false);
+			return;
+		}
 		setLoading(true);
 		try {
-			const date = new Date();
-			const yyyy = date.getFullYear();
-			const mm = String(date.getMonth() + 1).padStart(2, "0");
-			const dd = String(date.getDate()).padStart(2, "0");
-			const hh = String(date.getHours()).padStart(2, "0");
-			const min = String(date.getMinutes()).padStart(2, "0");
-			const ss = String(date.getSeconds()).padStart(2, "0");
-
-			const dateTime = `${yyyy}-${mm}-${dd} ${hh}:${min}:${ss}`;
-			const routeCatalogId = appId || engineId || "";
-			const catalogId = routeCatalogId || filteredData.current.engineId;
-			const SelectedDuration = filteredData.current.SelectedDuration;
-			const selectedEngineType =
-				filteredData.current.engineType.toUpperCase();
-			const useProjectId =
-				Boolean(appId) ||
-				(!engineId &&
-					(selectedEngineType === "APP" || catalogName === "Apps"));
-			const catalogIdKey = useProjectId ? "projectId" : "engineId";
-
-			if (!catalogId) {
-				setLogs([]);
-				setTotalCount(0);
-				return;
-			}
-
-			const customStartDate = filteredData.current.customDateRange.from;
-			const customEndDate = filteredData.current.customDateRange.to;
-			const hasCustomDateRange =
-				SelectedDuration.dateRangeType === "CUSTOM" &&
-				customStartDate &&
-				customEndDate;
-			let customDateRangeParams = "";
-
-			if (hasCustomDateRange) {
-				const startDate = new Date(customStartDate);
-				const endDate = new Date(customEndDate);
-
-				startDate.setUTCHours(0, 0, 0, 0);
-				endDate.setUTCHours(23, 59, 59, 999);
-
-				customDateRangeParams = `,"startDate": "${startDate.toISOString()}", "endDate": "${endDate.toISOString()}"`;
-			}
+			const params = filterValueToReportParams(filterValue);
 			const response = await monolithStore.runQuery(
-				`AuditLogReport(paramValues=[{"${catalogIdKey}": "${catalogId}","dateTime":"${dateTime}","limit":"${limit}","offset":"${offset}", "dateRangeType": "${SelectedDuration.dateRangeType || "DAY"}","dateRangeValue": ${SelectedDuration.dateRangeValue}${customDateRangeParams}}]);`,
+				buildAuditLogReportPixel(params, limit, offset),
 			);
-			const { operationType } = response.pixelReturn[0];
+			const { operationType, output } = response.pixelReturn[0];
 			if (operationType.indexOf("ERROR") > -1)
-				throw new Error(`API Error: ${response.pixelReturn[0].output}`);
+				throw new Error(`API Error: ${output}`);
 
-			const responseData = response.pixelReturn[0].output;
+			const responseData = output as unknown as {
+				logs?: EventData[];
+				totalCount?: number;
+			};
 			setLogs(
-				(
-					responseData as unknown as {
-						logs: EventData[];
-						totalCount: number;
-					}
-				)?.logs ||
-					(responseData as unknown as EventData[]) ||
-					[],
+				responseData?.logs ?? (output as unknown as EventData[]) ?? [],
 			);
 			setTotalCount(
-				(responseData as unknown as { totalCount: number })
-					?.totalCount ||
-					(responseData as unknown as EventData[])?.length ||
+				responseData?.totalCount ??
+					(output as unknown as EventData[])?.length ??
 					0,
 			);
 		} catch (error) {
 			setLogs([]);
+			setTotalCount(0);
 			toast.error(`Error fetching logs: ${error}`);
 			console.error("Error fetching logs:", error);
 		} finally {
 			setLoading(false);
+		}
+	};
+
+	/**
+	 * Exports the current filtered report as CSV or PDF.
+	 */
+	const handleExport = async (pdf: boolean) => {
+		const filterValue = filteredData.current;
+		if (!hasScope(filterValue.scope)) {
+			toast.info("Select a scope before exporting logs.");
+			return;
+		}
+		try {
+			const params = filterValueToReportParams(filterValue);
+			const exportLimit = totalCount > 0 ? totalCount : rowsPerPage;
+			const response = await monolithStore.runQuery(
+				buildExportAuditLogReportPixel(params, exportLimit, 0, pdf),
+			);
+			const { operationType, output } = response.pixelReturn[0];
+			if (operationType.indexOf("ERROR") > -1)
+				throw new Error(`API Error: ${output}`);
+			await download(
+				configStore.store.insightID,
+				output as unknown as string,
+			);
+		} catch (error) {
+			toast.error(`Error exporting logs: ${error}`);
+			console.error("Error exporting logs:", error);
 		}
 	};
 
@@ -288,11 +289,10 @@ export const AuditLogsDashboard = ({
 		fetchLogs(newRowsPerPage, offset);
 	};
 
+	//Override the parent Page container styles for the dashboard layout. Skipped
+	//when embedded in a tab, where the surrounding layout owns the container.
 	useEffect(() => {
-		if (catalogName) {
-			setLogs([]);
-			fetchLogs(rowsPerPage, page * rowsPerPage);
-		}
+		if (embedded) return;
 		const contentElement = document.querySelector(
 			'[data-home-container="true"]',
 		) as HTMLElement | null;
@@ -310,32 +310,85 @@ export const AuditLogsDashboard = ({
 	}, [catalogName, appId, engineId]);
 
 	/**
-	 * Updates the filtered data state and refetches logs.
+	 * Updates the filtered data state (emitted by the filter) and refetches from
+	 * the first page.
 	 */
-	const updateLogs = (filterData: AuditLogsFilterData) => {
-		filteredData.current = {
-			...filterData,
-		};
-		if (isContextualDashboard && !hasSkippedInitialFilterFetchRef.current) {
-			hasSkippedInitialFilterFetchRef.current = true;
-			return;
-		}
-		fetchLogs(rowsPerPage, page * rowsPerPage);
+	const updateLogs = (filterValue: AuditLogFilterValue) => {
+		filteredData.current = filterValue;
+		setPage(0);
+		fetchLogs(rowsPerPage, 0);
 	};
 
-	const dashboardControls = (
-		<div className="flex flex-row items-center gap-4">
+	//Compact header actions (Export + Refresh). The filter set lives in its own
+	//full-width row below so it can wrap instead of overlapping the header.
+	const headerActions = (
+		<div className="flex flex-row items-center gap-2">
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<Button variant="outline" size="icon-sm" title="Export">
+						<Download className="size-4" />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent>
+					<DropdownMenuItem onClick={() => handleExport(false)}>
+						Export as CSV
+					</DropdownMenuItem>
+					<DropdownMenuItem onClick={() => handleExport(true)}>
+						Export as PDF
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+			<Button
+				variant="outline"
+				size="icon-sm"
+				title="Refresh"
+				onClick={() => fetchLogs(rowsPerPage, page * rowsPerPage)}
+			>
+				<RefreshCw className="size-4" />
+			</Button>
+		</div>
+	);
+
+	const filterBar = (
+		<div className="flex w-full flex-wrap items-center gap-2">
 			<AuditLogFilter
 				updateLogs={updateLogs}
 				insightId={configStore.store.insightID}
 				parent={isContextualDashboard ? "client" : null}
+				scope={routeScope}
+				actions={headerActions}
 			/>
-			<Button onClick={() => fetchLogs(rowsPerPage, page * rowsPerPage)}>
-				<RefreshCw className="mr-2 size-4" />
-				Refresh
-			</Button>
 		</div>
 	);
+
+	const body = loading ? (
+		<div className="flex flex-col gap-4">
+			<Skeleton className="h-[400px] w-full" />
+			<Skeleton className="h-[400px] w-full" />
+		</div>
+	) : (
+		<>
+			<AuditLogsSummary logs={logs} totalCount={totalCount} />
+			<AuditLogsTimeline logs={logs} />
+			<AuditLogsDataTable
+				logs={logs}
+				totalCount={totalCount}
+				page={page}
+				rowsPerPage={rowsPerPage}
+				onPaginationChange={handlePaginationChange}
+			/>
+		</>
+	);
+
+	//Embedded in a settings tab: filters (with search + export/refresh inline) + body.
+	if (embedded) {
+		return (
+			<div className="flex flex-col gap-4">
+				{filterBar}
+				{body}
+			</div>
+		);
+	}
 
 	return (
 		<>
@@ -376,34 +429,18 @@ export const AuditLogsDashboard = ({
 									? "Copy App ID"
 									: "Copy Engine ID"
 							}
-							actions={dashboardControls}
 						/>
+						{filterBar}
 					</div>
 				) : (
-					<div className="flex w-full items-center py-2">
+					<div className="flex w-full flex-col gap-4 py-2">
 						<h6 className="font-semibold text-xl">
 							{catalogName} Insight Dashboard
 						</h6>
-						<div className="ml-auto">{dashboardControls}</div>
+						{filterBar}
 					</div>
 				)}
-				{loading ? (
-					<div className="flex flex-col gap-4">
-						<Skeleton className="h-[400px] w-full" />
-						<Skeleton className="h-[400px] w-full" />
-					</div>
-				) : (
-					<>
-						<AuditLogsTimeline logs={logs} />
-						<AuditLogsDataTable
-							logs={logs}
-							totalCount={totalCount}
-							page={page}
-							rowsPerPage={rowsPerPage}
-							onPaginationChange={handlePaginationChange}
-						/>
-					</>
-				)}
+				{body}
 			</div>
 		</>
 	);

--- a/packages/client/src/pages/engine/engine-activity-page.tsx
+++ b/packages/client/src/pages/engine/engine-activity-page.tsx
@@ -1,0 +1,12 @@
+import { useEngine } from "@/hooks/useEngine";
+import { AuditLogsDashboard } from "../audit-logs-dashboard";
+
+/**
+ * The "Activity" tab of the engine detail layout — renders the audit logs
+ * dashboard embedded (no standalone page chrome). The engine id comes from the
+ * route params; the engine-type display name comes from the engine context.
+ */
+export const EngineActivityPage = () => {
+	const { name } = useEngine();
+	return <AuditLogsDashboard catalogName={name} embedded />;
+};

--- a/packages/client/src/pages/engine/engine-router.tsx
+++ b/packages/client/src/pages/engine/engine-router.tsx
@@ -5,7 +5,6 @@ import { Help } from "@/components/help";
 import { NavbarHeader, NavbarLeft } from "@/components/shared";
 import { SettingsContext } from "@/contexts";
 import { useRootStore } from "@/hooks";
-import { AuditLogsDashboard } from "../audit-logs-dashboard";
 import { ImportPage } from "../import";
 import { ENGINE_ROUTES } from "./engine.constants";
 import { EngineEditPage } from "./engine-edit-page";
@@ -67,12 +66,6 @@ export const EngineRouter = observer(() => {
 									element={<EngineEditPage />}
 								/>
 							</Route>
-							<Route
-								path=":engineId/dashboard"
-								element={
-									<AuditLogsDashboard catalogName={r.name} />
-								}
-							/>
 							<Route
 								path="*"
 								element={<Navigate to="." replace />}

--- a/packages/client/src/pages/engine/engine.constants.ts
+++ b/packages/client/src/pages/engine/engine.constants.ts
@@ -2,6 +2,7 @@ import { Boxes, Braces, Coins } from "lucide-react";
 import { Database } from "@/assets/img/Database";
 import { ModelBrain } from "@/assets/img/ModelBrain";
 import type { ENGINE_TYPES, Role } from "@/types";
+import { EngineActivityPage } from "./engine-activity-page";
 import { EngineCommitsPage } from "./engine-commits-page";
 import { EngineFileManagerPage } from "./engine-file-manager-page";
 import { EngineFilePage } from "./engine-file-page";
@@ -17,7 +18,7 @@ import { EngineSqlQueryPage } from "./engine-sql-query-page";
 import { EngineStorageViewerPage } from "./engine-storage-viewer-page";
 import { EngineUsagePage } from "./engine-usage-page";
 
-export const ENGINE_ROUTES: {
+const ENGINE_ROUTES_BASE: {
 	/** Name of the route */
 	name: string;
 
@@ -367,3 +368,23 @@ export const ENGINE_ROUTES: {
 		],
 	},
 ];
+
+//The audit-logs dashboard, shown as an "Activity Log" tab on every engine type.
+//Inserted right after each engine's "MCP Usage" tab (falling back to "Usage", then
+//the Overview tab). Visible to anyone with access; the backend role-scopes the rows.
+const ENGINE_ACTIVITY_TAB = {
+	name: "Activity Log",
+	path: "activity",
+	component: EngineActivityPage,
+	restrict: ["READ_ONLY", "EDIT", "OWNER"] as Role[],
+};
+
+export const ENGINE_ROUTES = ENGINE_ROUTES_BASE.map((route) => {
+	const specific = [...route.specific];
+	const mcpIndex = specific.findIndex((tab) => tab.path === "mcp-usage");
+	const usageIndex = specific.findIndex((tab) => tab.path === "usage");
+	const insertAt =
+		mcpIndex >= 0 ? mcpIndex + 1 : usageIndex >= 0 ? usageIndex + 1 : 1;
+	specific.splice(insertAt, 0, ENGINE_ACTIVITY_TAB);
+	return { ...route, specific };
+});

--- a/packages/client/src/pages/engine/index.ts
+++ b/packages/client/src/pages/engine/index.ts
@@ -1,3 +1,3 @@
-import { EngineRouter } from "./EngineRouter";
+import { EngineRouter } from "./engine-router";
 
 export { EngineRouter };

--- a/packages/client/src/pages/router.tsx
+++ b/packages/client/src/pages/router.tsx
@@ -50,13 +50,8 @@ const NewPromptBuilderAppPage = lazy(() =>
 const ViewAppPage = lazy(() =>
 	import("./app/view-app-page").then((m) => ({ default: m.ViewAppPage })),
 );
-const AuditLogsDashboard = lazy(() =>
-	import("./audit-logs-dashboard").then((m) => ({
-		default: m.AuditLogsDashboard,
-	})),
-);
 const EngineRouter = lazy(() =>
-	import("./engine/EngineRouter").then((m) => ({ default: m.EngineRouter })),
+	import("./engine/engine-router").then((m) => ({ default: m.EngineRouter })),
 );
 const LandingPage = lazy(() =>
 	import("./landing-page").then((m) => ({ default: m.LandingPage })),
@@ -181,12 +176,6 @@ export const Router = observer(() => {
 							<Route
 								path=":appId/edit/*"
 								element={<EditAppPage />}
-							/>
-							<Route
-								path=":appId/dashboard/*"
-								element={
-									<AuditLogsDashboard catalogName={"Apps"} />
-								}
 							/>
 						</Route>
 						<Route path="engine/*" element={<EngineRouter />} />

--- a/packages/client/src/pages/settings/admin-theme-page.tsx
+++ b/packages/client/src/pages/settings/admin-theme-page.tsx
@@ -169,6 +169,7 @@ const EMPTY_PLAYGROUND: ThemeMap["playground"] = {
 		allowEmbeddingOptions: true,
 		showKnowledgeMenu: true,
 		showToolboxMenu: true,
+		showActivityLog: true,
 		showPlatformLinks: true,
 	},
 };
@@ -193,6 +194,7 @@ const FEATURE_FLAGS: {
 	{ key: "allowEmbeddingOptions", label: "Allow Embedding Options" },
 	{ key: "showKnowledgeMenu", label: "Show Knowledge Menu" },
 	{ key: "showToolboxMenu", label: "Show Toolbox Menu" },
+	{ key: "showActivityLog", label: "Show Activity Log" },
 	{ key: "showPlatformLinks", label: "Show Platform Links" },
 	{ key: "enableFeedbackText", label: "Enable Feedback Text" },
 ];

--- a/packages/client/src/pages/settings/insight-settings-page.tsx
+++ b/packages/client/src/pages/settings/insight-settings-page.tsx
@@ -281,7 +281,6 @@ export const InsightSettingsPage = () => {
 								)}
 								hideFavorite={true}
 								isDiscoverable={true}
-								showLogs={false}
 								enableGlobalAction={canManage}
 								global={() => {
 									void setInsightGlobal(insight);

--- a/packages/playground/src/components/room/room-audit-log-report.tsx
+++ b/packages/playground/src/components/room/room-audit-log-report.tsx
@@ -1,0 +1,198 @@
+import { Download, RefreshCw } from "lucide-react";
+import { observer } from "mobx-react-lite";
+import { useRef, useState } from "react";
+import { download } from "@semoss/sdk";
+import {
+	AuditLogFilter,
+	type AuditLogFilterValue,
+	type AuditLogScope,
+	AuditLogsDataTable,
+	AuditLogsSummary,
+	AuditLogsTimeline,
+	buildAuditLogReportPixel,
+	buildExportAuditLogReportPixel,
+	type EventData,
+	filterValueToReportParams,
+	hasScope,
+} from "@semoss/shared";
+import {
+	Button,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+	Skeleton,
+	toast,
+} from "@semoss/ui/next";
+import type { RoomStore } from "@/stores";
+
+interface RoomAuditLogReportProps {
+	room: RoomStore;
+}
+
+/**
+ * The audit logs dashboard scoped to the current room, shown in the room's
+ * right-hand side panel. Reuses the shared audit components and the shared pixel
+ * builders, run through the room's insight. The scope is locked to the room's id
+ * (no engine/project pickers), so it can't be changed from this view.
+ */
+export const RoomAuditLogReport = observer(
+	({ room }: RoomAuditLogReportProps) => {
+		const roomId = room.roomId;
+		const insightId = room.insightId;
+		const scope: AuditLogScope = { roomId };
+
+		const [logs, setLogs] = useState<EventData[]>([]);
+		const [page, setPage] = useState(0);
+		const [rowsPerPage, setRowsPerPage] = useState(50);
+		const [totalCount, setTotalCount] = useState(0);
+		const [loading, setLoading] = useState(false);
+		const filteredData = useRef<AuditLogFilterValue>({
+			scope,
+			dateRangeType: "DAY",
+			dateRangeValue: 1,
+			customDateRange: { from: null, to: null },
+			methodNames: [],
+			engineTypes: [],
+			filterUserId: "",
+			roomId: "",
+			searchTerm: "",
+		});
+
+		const fetchLogs = async (limit: number, offset: number) => {
+			const filterValue = filteredData.current;
+			if (!hasScope(filterValue.scope) || !insightId) {
+				setLogs([]);
+				setTotalCount(0);
+				setLoading(false);
+				return;
+			}
+			setLoading(true);
+			try {
+				//Room scope only — no date filter values are sent.
+				const params = filterValueToReportParams(filterValue, {
+					includeDate: false,
+				});
+				const response = await room.runRoomPixel<
+					[{ logs?: EventData[]; totalCount?: number }]
+				>(buildAuditLogReportPixel(params, limit, offset), false);
+				const { operationType, output } = response.pixelReturn[0];
+				if (operationType.indexOf("ERROR") > -1)
+					throw new Error(`API Error: ${output}`);
+				const responseData = output as {
+					logs?: EventData[];
+					totalCount?: number;
+				};
+				setLogs(responseData?.logs ?? []);
+				setTotalCount(responseData?.totalCount ?? 0);
+			} catch (error) {
+				setLogs([]);
+				setTotalCount(0);
+				toast.error(`Error fetching logs: ${error}`);
+				console.error("Error fetching room logs:", error);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		const handleExport = async (pdf: boolean) => {
+			const filterValue = filteredData.current;
+			if (!hasScope(filterValue.scope) || !insightId) return;
+			try {
+				const params = filterValueToReportParams(filterValue, {
+					includeDate: false,
+				});
+				const exportLimit = totalCount > 0 ? totalCount : rowsPerPage;
+				const response = await room.runRoomPixel<[string]>(
+					buildExportAuditLogReportPixel(params, exportLimit, 0, pdf),
+					false,
+				);
+				const { operationType, output } = response.pixelReturn[0];
+				if (operationType.indexOf("ERROR") > -1)
+					throw new Error(`API Error: ${output}`);
+				await download(insightId, output as unknown as string);
+			} catch (error) {
+				toast.error(`Error exporting logs: ${error}`);
+				console.error("Error exporting room logs:", error);
+			}
+		};
+
+		const handlePaginationChange = (
+			newPage: number,
+			newRowsPerPage: number,
+		) => {
+			setPage(newPage);
+			setRowsPerPage(newRowsPerPage);
+			fetchLogs(newRowsPerPage, newPage * newRowsPerPage);
+		};
+
+		const updateLogs = (filterValue: AuditLogFilterValue) => {
+			//Keep the scope locked to this room regardless of what the filter emits.
+			filteredData.current = { ...filterValue, scope };
+			setPage(0);
+			fetchLogs(rowsPerPage, 0);
+		};
+
+		const actions = (
+			<>
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button variant="outline" size="icon-sm" title="Export">
+							<Download className="size-4" />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent>
+						<DropdownMenuItem onClick={() => handleExport(false)}>
+							Export as CSV
+						</DropdownMenuItem>
+						<DropdownMenuItem onClick={() => handleExport(true)}>
+							Export as PDF
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+				<Button
+					variant="outline"
+					size="icon-sm"
+					title="Refresh"
+					onClick={() => fetchLogs(rowsPerPage, page * rowsPerPage)}
+				>
+					<RefreshCw className="size-4" />
+				</Button>
+			</>
+		);
+
+		return (
+			<div className="flex h-full w-full flex-col gap-4 overflow-auto p-4">
+				<div className="flex w-full flex-wrap items-center gap-2">
+					<AuditLogFilter
+						updateLogs={updateLogs}
+						insightId={insightId}
+						parent="client"
+						scope={scope}
+						hideRoomFilter
+						hideDateFilter
+						actions={actions}
+					/>
+				</div>
+				{loading ? (
+					<div className="flex flex-col gap-4">
+						<Skeleton className="h-[300px] w-full" />
+						<Skeleton className="h-[300px] w-full" />
+					</div>
+				) : (
+					<>
+						<AuditLogsSummary logs={logs} totalCount={totalCount} />
+						<AuditLogsTimeline logs={logs} />
+						<AuditLogsDataTable
+							logs={logs}
+							totalCount={totalCount}
+							page={page}
+							rowsPerPage={rowsPerPage}
+							onPaginationChange={handlePaginationChange}
+						/>
+					</>
+				)}
+			</div>
+		);
+	},
+);

--- a/packages/playground/src/components/room/room-content.tsx
+++ b/packages/playground/src/components/room/room-content.tsx
@@ -1,6 +1,7 @@
 import {
 	MoveDownIcon,
 	MoveUpIcon,
+	ScrollTextIcon,
 	Settings2Icon,
 	TriangleAlertIcon,
 } from "lucide-react";
@@ -79,6 +80,19 @@ export const RoomContent: React.FC<RoomContentProps> = observer(({ room }) => {
 			type: "tab",
 			name: "Configuration",
 			component: "room-configuration",
+			config: {},
+			enableClose: true,
+		});
+	}, [room]);
+
+	/**
+	 * Open the audit logs dashboard for this room in the right side panel.
+	 */
+	const handleOpenActivityLog = useCallback(() => {
+		room.addSidebarNode("room-activity-log", {
+			type: "tab",
+			name: "Activity Log",
+			component: "audit-log-report",
 			config: {},
 			enableClose: true,
 		});
@@ -474,6 +488,21 @@ export const RoomContent: React.FC<RoomContentProps> = observer(({ room }) => {
 									room={room}
 									onSelect={() => onOpenChange(false)}
 								/>
+								{room.theme.featureFlags?.showActivityLog !==
+									false && (
+									<DropdownMenuItem
+										onSelect={(e) => {
+											e.preventDefault();
+											handleOpenActivityLog();
+											onOpenChange(false);
+										}}
+									>
+										<ScrollTextIcon />
+										<span className="flex-1">
+											Activity Log
+										</span>
+									</DropdownMenuItem>
+								)}
 								<DropdownMenuItem
 									onSelect={(e) => {
 										e.preventDefault();

--- a/packages/playground/src/components/room/room-sidebar.tsx
+++ b/packages/playground/src/components/room/room-sidebar.tsx
@@ -30,6 +30,7 @@ import {
 	TooltipTrigger,
 } from "@semoss/ui/next";
 import type { RoomStore } from "@/stores";
+import { RoomAuditLogReport } from "./room-audit-log-report";
 import { RoomConfiguration } from "./room-configuration";
 import { RoomFileEditor } from "./room-file-editor";
 import { RoomFileExplorer } from "./room-file-explorer";
@@ -338,6 +339,8 @@ export const RoomSidebar: React.FC<RoomSidebarProps> = observer(({ room }) => {
 									);
 								} else if (component === "room-configuration") {
 									return <RoomConfiguration room={room} />;
+								} else if (component === "audit-log-report") {
+									return <RoomAuditLogReport room={room} />;
 								} else if (component === "room-file-editor") {
 									return (
 										<RoomFileEditor

--- a/packages/playground/src/stores/root/root.store.ts
+++ b/packages/playground/src/stores/root/root.store.ts
@@ -103,6 +103,7 @@ export class RootStore {
 				allowEmbeddingOptions: true,
 				showKnowledgeMenu: true,
 				showToolboxMenu: true,
+				showActivityLog: true,
 				showPlatformLinks: true,
 				enableFeedbackText: true,
 			},


### PR DESCRIPTION
- Server-driven filters (method, engine type, owner-only user, room) lazy-loaded on open, plus global search and clear-all; reactors renamed to AuditLogsReport / ExportAuditLogsReport / GetAuditLogsReportFilterOptionList; parse ISO-8601 UTC timestamps.
- Rebuild Event History as a real time-axis waterfall: status colors, row modes (per event / by span / by request), time/date/month axis, drag-to-zoom + reset that compose with the sliders, vertical scrollbar, click-to-open drawer, and a ResizeObserver so it reflows with its container.
- Compact unified toolbar (search + filters + icon-only export/refresh) and an inline KPI metrics strip in place of the large summary card.
- Move the dashboard into an "Activity Log" tab on the app and every engine (after MCP Usage); remove the standalone routes and catalog-card buttons.
- Add the Activity Log to the playground room side panel, scoped to roomId with no date params; gate it behind a "Show Activity Log" admin theme flag (defaults to on).
- Rename EngineRouter.tsx to engine-router.tsx.