### PR TITLE
feat: role-based feature visibility (UI) — App Profiles + Platform Profiles

### DIFF
--- a/packages/client/src/pages/AuthenticatedLayout.tsx
+++ b/packages/client/src/pages/AuthenticatedLayout.tsx
@@ -1,22 +1,64 @@
 import { observer } from "mobx-react-lite";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { useRootStore } from "@/hooks/";
 
+/** Platform feature visibility map. A missing or true key means the feature is visible. */
+export type PlatformFeatures = Record<string, boolean>;
+
+interface PlatformFeaturesContextValue {
+	platformFeatures: PlatformFeatures;
+}
+
+export const PlatformFeaturesContext =
+	createContext<PlatformFeaturesContextValue>({
+		platformFeatures: {},
+	});
+
+export const usePlatformFeatures = () => useContext(PlatformFeaturesContext);
+
 /**
- * Wrap the database routes and add additional funcitonality
+ * Wrap the database routes and add additional functionality.
+ * Loads platform nav feature visibility once per authenticated session.
  */
 export const AuthenticatedLayout = observer(() => {
-	const { configStore } = useRootStore();
+	const { configStore, monolithStore } = useRootStore();
 	const location = useLocation();
+	const [platformFeatures, setPlatformFeatures] = useState<PlatformFeatures>(
+		{},
+	);
+	const loadedRef = useRef(false);
 
-	// wait till the config is authenticated to load the view
-	if (configStore.store.status === "MISSING AUTHENTICATION") {
+	const isAuthenticated =
+		configStore.store.status !== "MISSING AUTHENTICATION";
+
+	useEffect(() => {
+		if (!isAuthenticated || loadedRef.current) return;
+		loadedRef.current = true;
+		monolithStore
+			.runQuery("GetUserPlatformFeatures();")
+			.then((response) => {
+				const { operationType, output } = response.pixelReturn[0];
+				if (
+					operationType.indexOf("ERROR") === -1 &&
+					output &&
+					typeof output === "object"
+				) {
+					setPlatformFeatures(output as PlatformFeatures);
+				}
+			})
+			.catch(() => {
+				// fail open — if the call fails, leave features as empty (all visible)
+			});
+	}, [isAuthenticated, monolithStore]);
+
+	if (!isAuthenticated) {
 		return <Navigate to="/login" state={{ from: location }} replace />;
 	}
 
 	return (
-		<>
+		<PlatformFeaturesContext.Provider value={{ platformFeatures }}>
 			<Outlet />
-		</>
+		</PlatformFeaturesContext.Provider>
 	);
 });

--- a/packages/client/src/pages/app/app-detail-tabs/profiles.tsx
+++ b/packages/client/src/pages/app/app-detail-tabs/profiles.tsx
@@ -1,0 +1,586 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@semoss/ui/next";
+import { useRootStore } from "@/hooks/";
+
+interface Profile {
+	profileId: string;
+	profileName: string;
+	description: string;
+	isDefault: boolean;
+	userCount: number;
+}
+
+interface Feature {
+	featureId: string;
+	featureKey: string;
+	description: string;
+	enabled: boolean;
+}
+
+interface ProfileUser {
+	userId: string;
+	assignedBy: string;
+	assignedAt: string;
+}
+
+interface AppProfilesProps {
+	appId: string;
+	permission: string;
+}
+
+function sanitizeForPixel(s: string): string {
+	return s.replace(/[^a-zA-Z0-9 _\-.,!?]/g, "");
+}
+
+function validateFeatureKey(key: string): boolean {
+	return /^[a-zA-Z0-9-]+$/.test(key) && key.length <= 100;
+}
+
+export const AppProfiles = ({ appId }: AppProfilesProps) => {
+	const { monolithStore } = useRootStore();
+
+	const [profiles, setProfiles] = useState<Profile[]>([]);
+	const [selectedProfile, setSelectedProfile] = useState<Profile | null>(
+		null,
+	);
+	const [features, setFeatures] = useState<Feature[]>([]);
+	const [profileUsers, setProfileUsers] = useState<ProfileUser[]>([]);
+	const [activeTab, setActiveTab] = useState<"features" | "members">(
+		"features",
+	);
+
+	// New Profile form state
+	const [showProfileForm, setShowProfileForm] = useState(false);
+	const [editingProfile, setEditingProfile] = useState<Profile | null>(null);
+	const [profileFormName, setProfileFormName] = useState("");
+	const [profileFormDesc, setProfileFormDesc] = useState("");
+	const [profileFormDefault, setProfileFormDefault] = useState(false);
+
+	// New Feature form state
+	const [showFeatureForm, setShowFeatureForm] = useState(false);
+	const [featureFormKey, setFeatureFormKey] = useState("");
+	const [featureFormDesc, setFeatureFormDesc] = useState("");
+	const [featureKeyError, setFeatureKeyError] = useState("");
+
+	// Assign User form state
+	const [showAssignUser, setShowAssignUser] = useState(false);
+	const [assignUserId, setAssignUserId] = useState("");
+
+	const [loading, setLoading] = useState(false);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: loadProfiles is defined in component scope
+	useEffect(() => {
+		loadProfiles();
+	}, [appId]);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: loader functions are defined in component scope
+	useEffect(() => {
+		if (selectedProfile) {
+			loadProfileFeatures(selectedProfile.profileId);
+			loadProfileUsers(selectedProfile.profileId);
+		}
+	}, [selectedProfile]);
+
+	async function runPixel<T = unknown>(pixel: string): Promise<T | null> {
+		const response = await monolithStore.runQuery(pixel);
+		const { operationType, output } = response.pixelReturn[0];
+		if (operationType.indexOf("ERROR") > -1) {
+			toast.error(
+				typeof output === "string" ? output : "Operation failed.",
+			);
+			return null;
+		}
+		return output as T;
+	}
+
+	async function loadProfiles() {
+		const result = await runPixel<Profile[]>(
+			`GetAppProfiles(app="${appId}");`,
+		);
+		if (result) setProfiles(result);
+	}
+
+	async function loadProfileFeatures(profileId: string) {
+		const result = await runPixel<Feature[]>(
+			`GetProfileFeatures(app="${appId}", profileId="${profileId}");`,
+		);
+		if (result) setFeatures(result);
+	}
+
+	async function loadProfileUsers(profileId: string) {
+		const result = await runPixel<ProfileUser[]>(
+			`GetProfileUsers(app="${appId}", profileId="${profileId}");`,
+		);
+		if (result) setProfileUsers(result);
+	}
+
+	async function handleSaveProfile() {
+		const name = sanitizeForPixel(profileFormName.trim());
+		if (!name) {
+			toast.error("Profile name is required.");
+			return;
+		}
+		const desc = sanitizeForPixel(profileFormDesc);
+		setLoading(true);
+		try {
+			if (editingProfile) {
+				await runPixel(
+					`UpdateAppProfile(app="${appId}", profileId="${editingProfile.profileId}", name="${name}", description="${desc}", isDefault="${profileFormDefault}");`,
+				);
+			} else {
+				await runPixel(
+					`CreateAppProfile(app="${appId}", name="${name}", description="${desc}", isDefault="${profileFormDefault}");`,
+				);
+			}
+			await loadProfiles();
+			setShowProfileForm(false);
+			setEditingProfile(null);
+			setProfileFormName("");
+			setProfileFormDesc("");
+			setProfileFormDefault(false);
+		} finally {
+			setLoading(false);
+		}
+	}
+
+	async function handleDeleteProfile(profile: Profile) {
+		if (profile.userCount > 0) return;
+		if (!confirm(`Delete profile "${profile.profileName}"?`)) return;
+		await runPixel(
+			`DeleteAppProfile(app="${appId}", profileId="${profile.profileId}");`,
+		);
+		await loadProfiles();
+		if (selectedProfile?.profileId === profile.profileId)
+			setSelectedProfile(null);
+	}
+
+	async function handleToggleFeature(feature: Feature) {
+		if (!selectedProfile) return;
+		await runPixel(
+			`SetProfileFeature(app="${appId}", profileId="${selectedProfile.profileId}", featureId="${feature.featureId}", enabled="${!feature.enabled}");`,
+		);
+		await loadProfileFeatures(selectedProfile.profileId);
+	}
+
+	async function handleAddFeature() {
+		if (!validateFeatureKey(featureFormKey)) {
+			setFeatureKeyError(
+				"Key must be alphanumeric + hyphens only, max 100 chars.",
+			);
+			return;
+		}
+		setFeatureKeyError("");
+		const desc = sanitizeForPixel(featureFormDesc);
+		await runPixel(
+			`CreateAppFeature(app="${appId}", key="${featureFormKey}", description="${desc}");`,
+		);
+		if (selectedProfile)
+			await loadProfileFeatures(selectedProfile.profileId);
+		setShowFeatureForm(false);
+		setFeatureFormKey("");
+		setFeatureFormDesc("");
+	}
+
+	async function handleAssignUser() {
+		if (!selectedProfile || !assignUserId.trim()) return;
+		const uid = sanitizeForPixel(assignUserId.trim());
+		await runPixel(
+			`AssignUserProfile(app="${appId}", userId="${uid}", profileId="${selectedProfile.profileId}");`,
+		);
+		await loadProfileUsers(selectedProfile.profileId);
+		setShowAssignUser(false);
+		setAssignUserId("");
+	}
+
+	async function handleRemoveUser(userId: string) {
+		if (!confirm(`Remove user ${userId} from this profile?`)) return;
+		await runPixel(
+			`RemoveUserProfile(app="${appId}", userId="${userId}");`,
+		);
+		if (selectedProfile) await loadProfileUsers(selectedProfile.profileId);
+	}
+
+	return (
+		<div className="flex h-full gap-4">
+			{/* Left panel — Profile list */}
+			<div className="flex w-72 flex-shrink-0 flex-col gap-2">
+				<div className="mb-1 flex items-center justify-between">
+					<span className="font-semibold text-sm">Profiles</span>
+					<Button
+						size="sm"
+						variant="outline"
+						onClick={() => {
+							setShowProfileForm(true);
+							setEditingProfile(null);
+							setProfileFormName("");
+							setProfileFormDesc("");
+							setProfileFormDefault(false);
+						}}
+					>
+						New Profile
+					</Button>
+				</div>
+
+				{showProfileForm && (
+					<div className="flex flex-col gap-2 rounded-md border bg-card p-3">
+						<input
+							className="w-full rounded border px-2 py-1 text-sm"
+							placeholder="Profile name *"
+							value={profileFormName}
+							onChange={(e) => setProfileFormName(e.target.value)}
+							maxLength={100}
+						/>
+						<input
+							className="w-full rounded border px-2 py-1 text-sm"
+							placeholder="Description"
+							value={profileFormDesc}
+							onChange={(e) => setProfileFormDesc(e.target.value)}
+						/>
+						<label className="flex items-center gap-2 text-xs">
+							<input
+								type="checkbox"
+								checked={profileFormDefault}
+								onChange={(e) =>
+									setProfileFormDefault(e.target.checked)
+								}
+							/>
+							Set as default
+						</label>
+						<div className="flex justify-end gap-2">
+							<Button
+								size="sm"
+								variant="ghost"
+								onClick={() => setShowProfileForm(false)}
+							>
+								Cancel
+							</Button>
+							<Button
+								size="sm"
+								onClick={handleSaveProfile}
+								disabled={loading}
+							>
+								Save
+							</Button>
+						</div>
+					</div>
+				)}
+
+				{profiles.length === 0 && (
+					<p className="text-muted-foreground text-sm">
+						No profiles defined yet.
+					</p>
+				)}
+
+				{profiles.map((p) => (
+					// biome-ignore lint/a11y/useSemanticElements: card contains nested interactive elements, cannot use button
+					<div
+						key={p.profileId}
+						role="button"
+						tabIndex={0}
+						className={`cursor-pointer rounded-md border p-3 transition-colors hover:bg-muted/50 ${selectedProfile?.profileId === p.profileId ? "border-primary bg-muted/30" : ""}`}
+						onClick={() => setSelectedProfile(p)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter" || e.key === " ")
+								setSelectedProfile(p);
+						}}
+					>
+						<div className="flex items-center justify-between">
+							<div className="flex items-center gap-2">
+								<span className="font-medium text-sm">
+									{p.profileName}
+								</span>
+								{p.isDefault && (
+									<span className="rounded bg-primary/10 px-1 text-primary text-xs">
+										Default
+									</span>
+								)}
+							</div>
+							<div className="flex items-center gap-1">
+								<span className="text-muted-foreground text-xs">
+									{p.userCount} users
+								</span>
+								<button
+									type="button"
+									className="ml-1 text-muted-foreground hover:text-foreground"
+									title="Edit"
+									onClick={(e) => {
+										e.stopPropagation();
+										setEditingProfile(p);
+										setProfileFormName(p.profileName);
+										setProfileFormDesc(p.description || "");
+										setProfileFormDefault(p.isDefault);
+										setShowProfileForm(true);
+									}}
+								>
+									✎
+								</button>
+								<button
+									type="button"
+									className={`ml-1 text-muted-foreground ${p.userCount > 0 ? "cursor-not-allowed opacity-30" : "hover:text-destructive"}`}
+									title={
+										p.userCount > 0
+											? `${p.userCount} users assigned — reassign first`
+											: "Delete"
+									}
+									onClick={(e) => {
+										e.stopPropagation();
+										handleDeleteProfile(p);
+									}}
+									disabled={p.userCount > 0}
+								>
+									🗑
+								</button>
+							</div>
+						</div>
+						{p.description && (
+							<p className="mt-1 text-muted-foreground text-xs">
+								{p.description}
+							</p>
+						)}
+					</div>
+				))}
+			</div>
+
+			{/* Right panel — Profile detail */}
+			{selectedProfile ? (
+				<div className="flex flex-1 flex-col gap-3">
+					<div className="flex items-center gap-3 border-b pb-2">
+						<h3 className="font-semibold">
+							{selectedProfile.profileName}
+						</h3>
+						<div className="flex gap-2">
+							<button
+								type="button"
+								className={`rounded-md px-3 py-1 text-sm ${activeTab === "features" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted"}`}
+								onClick={() => setActiveTab("features")}
+							>
+								Features
+							</button>
+							<button
+								type="button"
+								className={`rounded-md px-3 py-1 text-sm ${activeTab === "members" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted"}`}
+								onClick={() => setActiveTab("members")}
+							>
+								Members
+							</button>
+						</div>
+					</div>
+
+					{activeTab === "features" && (
+						<div className="flex flex-col gap-2">
+							<div className="flex items-center justify-between">
+								<span className="font-medium text-sm">
+									Features
+								</span>
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={() => setShowFeatureForm(true)}
+								>
+									Add Feature
+								</Button>
+							</div>
+
+							{showFeatureForm && (
+								<div className="flex flex-col gap-2 rounded-md border bg-card p-3">
+									<input
+										className={`w-full rounded border px-2 py-1 text-sm ${featureKeyError ? "border-destructive" : ""}`}
+										placeholder="Feature key * (e.g. export-csv)"
+										value={featureFormKey}
+										onChange={(e) => {
+											setFeatureFormKey(e.target.value);
+											setFeatureKeyError(
+												validateFeatureKey(
+													e.target.value,
+												) || !e.target.value
+													? ""
+													: "Alphanumeric + hyphens only, max 100 chars.",
+											);
+										}}
+									/>
+									{featureKeyError && (
+										<p className="text-destructive text-xs">
+											{featureKeyError}
+										</p>
+									)}
+									<input
+										className="w-full rounded border px-2 py-1 text-sm"
+										placeholder="Description"
+										value={featureFormDesc}
+										onChange={(e) =>
+											setFeatureFormDesc(e.target.value)
+										}
+									/>
+									<div className="flex justify-end gap-2">
+										<Button
+											size="sm"
+											variant="ghost"
+											onClick={() => {
+												setShowFeatureForm(false);
+												setFeatureKeyError("");
+											}}
+										>
+											Cancel
+										</Button>
+										<Button
+											size="sm"
+											onClick={handleAddFeature}
+										>
+											Add
+										</Button>
+									</div>
+								</div>
+							)}
+
+							{features.length === 0 ? (
+								<p className="text-muted-foreground text-sm">
+									No features defined for this app yet.
+								</p>
+							) : (
+								features.map((f) => (
+									<div
+										key={f.featureId}
+										className="flex items-center justify-between rounded-md border px-3 py-2"
+									>
+										<div>
+											<span className="font-mono text-sm">
+												{f.featureKey}
+											</span>
+											{f.description && (
+												<p className="text-muted-foreground text-xs">
+													{f.description}
+												</p>
+											)}
+										</div>
+										<label className="relative inline-flex cursor-pointer items-center">
+											<input
+												type="checkbox"
+												className="peer sr-only"
+												checked={f.enabled}
+												onChange={() =>
+													handleToggleFeature(f)
+												}
+											/>
+											<div className="peer h-5 w-9 rounded-full bg-gray-200 after:absolute after:top-[2px] after:left-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-primary peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none" />
+										</label>
+									</div>
+								))
+							)}
+						</div>
+					)}
+
+					{activeTab === "members" && (
+						<div className="flex flex-col gap-2">
+							<div className="flex items-center justify-between">
+								<span className="font-medium text-sm">
+									Members
+								</span>
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={() => setShowAssignUser(true)}
+								>
+									Assign User
+								</Button>
+							</div>
+
+							{showAssignUser && (
+								<div className="flex flex-col gap-2 rounded-md border bg-card p-3">
+									<input
+										className="w-full rounded border px-2 py-1 text-sm"
+										placeholder="User ID"
+										value={assignUserId}
+										onChange={(e) =>
+											setAssignUserId(e.target.value)
+										}
+									/>
+									<div className="flex justify-end gap-2">
+										<Button
+											size="sm"
+											variant="ghost"
+											onClick={() =>
+												setShowAssignUser(false)
+											}
+										>
+											Cancel
+										</Button>
+										<Button
+											size="sm"
+											onClick={handleAssignUser}
+										>
+											Assign
+										</Button>
+									</div>
+								</div>
+							)}
+
+							{profileUsers.length === 0 ? (
+								<p className="text-muted-foreground text-sm">
+									No users assigned to this profile.
+								</p>
+							) : (
+								<table className="w-full text-sm">
+									<thead>
+										<tr className="border-b">
+											<th className="py-1 text-left font-medium">
+												User ID
+											</th>
+											<th className="py-1 text-left font-medium">
+												Assigned By
+											</th>
+											<th className="py-1 text-left font-medium">
+												Assigned At
+											</th>
+											<th />
+										</tr>
+									</thead>
+									<tbody>
+										{profileUsers.map((u) => (
+											<tr
+												key={u.userId}
+												className="border-b hover:bg-muted/30"
+											>
+												<td className="py-1">
+													{u.userId}
+												</td>
+												<td className="py-1 text-muted-foreground">
+													{u.assignedBy}
+												</td>
+												<td className="py-1 text-muted-foreground">
+													{u.assignedAt
+														? new Date(
+																u.assignedAt,
+															).toLocaleDateString()
+														: "—"}
+												</td>
+												<td className="py-1">
+													<Button
+														size="sm"
+														variant="ghost"
+														onClick={() =>
+															handleRemoveUser(
+																u.userId,
+															)
+														}
+														className="text-destructive hover:text-destructive"
+													>
+														Remove
+													</Button>
+												</td>
+											</tr>
+										))}
+									</tbody>
+								</table>
+							)}
+						</div>
+					)}
+				</div>
+			) : (
+				<div className="flex flex-1 items-center justify-center text-muted-foreground text-sm">
+					Select a profile to view details.
+				</div>
+			)}
+		</div>
+	);
+};

--- a/packages/client/src/pages/app/app-detail-tabs/profiles.tsx
+++ b/packages/client/src/pages/app/app-detail-tabs/profiles.tsx
@@ -1,6 +1,34 @@
-import { useEffect, useState } from "react";
-import { toast } from "sonner";
-import { Button } from "@semoss/ui/next";
+import { Pencil, Trash2, UserPlus } from "lucide-react";
+import { useEffect, useId, useState } from "react";
+import {
+	Badge,
+	Button,
+	Checkbox,
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Input,
+	Label,
+	Separator,
+	Switch,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+	toast,
+} from "@semoss/ui/next";
 import { useRootStore } from "@/hooks/";
 
 interface Profile {
@@ -39,6 +67,7 @@ function validateFeatureKey(key: string): boolean {
 
 export const AppProfiles = ({ appId }: AppProfilesProps) => {
 	const { monolithStore } = useRootStore();
+	const uid = useId();
 
 	const [profiles, setProfiles] = useState<Profile[]>([]);
 	const [selectedProfile, setSelectedProfile] = useState<Profile | null>(
@@ -46,28 +75,34 @@ export const AppProfiles = ({ appId }: AppProfilesProps) => {
 	);
 	const [features, setFeatures] = useState<Feature[]>([]);
 	const [profileUsers, setProfileUsers] = useState<ProfileUser[]>([]);
-	const [activeTab, setActiveTab] = useState<"features" | "members">(
-		"features",
-	);
 
-	// New Profile form state
+	// Profile form state
 	const [showProfileForm, setShowProfileForm] = useState(false);
 	const [editingProfile, setEditingProfile] = useState<Profile | null>(null);
 	const [profileFormName, setProfileFormName] = useState("");
 	const [profileFormDesc, setProfileFormDesc] = useState("");
 	const [profileFormDefault, setProfileFormDefault] = useState(false);
+	const [savingProfile, setSavingProfile] = useState(false);
 
-	// New Feature form state
+	// Feature form state
 	const [showFeatureForm, setShowFeatureForm] = useState(false);
 	const [featureFormKey, setFeatureFormKey] = useState("");
 	const [featureFormDesc, setFeatureFormDesc] = useState("");
 	const [featureKeyError, setFeatureKeyError] = useState("");
+	const [savingFeature, setSavingFeature] = useState(false);
 
-	// Assign User form state
+	// Assign user state
 	const [showAssignUser, setShowAssignUser] = useState(false);
 	const [assignUserId, setAssignUserId] = useState("");
+	const [assigningUser, setAssigningUser] = useState(false);
 
-	const [loading, setLoading] = useState(false);
+	// Confirmation dialogs
+	const [deleteProfileTarget, setDeleteProfileTarget] =
+		useState<Profile | null>(null);
+	const [removeUserTarget, setRemoveUserTarget] = useState<string | null>(
+		null,
+	);
+	const [confirmLoading, setConfirmLoading] = useState(false);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: loadProfiles is defined in component scope
 	useEffect(() => {
@@ -115,6 +150,23 @@ export const AppProfiles = ({ appId }: AppProfilesProps) => {
 		if (result) setProfileUsers(result);
 	}
 
+	function openNewProfileForm() {
+		setEditingProfile(null);
+		setProfileFormName("");
+		setProfileFormDesc("");
+		setProfileFormDefault(false);
+		setShowProfileForm(true);
+	}
+
+	function openEditProfileForm(p: Profile, e: React.MouseEvent) {
+		e.stopPropagation();
+		setEditingProfile(p);
+		setProfileFormName(p.profileName);
+		setProfileFormDesc(p.description || "");
+		setProfileFormDefault(p.isDefault);
+		setShowProfileForm(true);
+	}
+
 	async function handleSaveProfile() {
 		const name = sanitizeForPixel(profileFormName.trim());
 		if (!name) {
@@ -122,7 +174,7 @@ export const AppProfiles = ({ appId }: AppProfilesProps) => {
 			return;
 		}
 		const desc = sanitizeForPixel(profileFormDesc);
-		setLoading(true);
+		setSavingProfile(true);
 		try {
 			if (editingProfile) {
 				await runPixel(
@@ -136,23 +188,26 @@ export const AppProfiles = ({ appId }: AppProfilesProps) => {
 			await loadProfiles();
 			setShowProfileForm(false);
 			setEditingProfile(null);
-			setProfileFormName("");
-			setProfileFormDesc("");
-			setProfileFormDefault(false);
 		} finally {
-			setLoading(false);
+			setSavingProfile(false);
 		}
 	}
 
-	async function handleDeleteProfile(profile: Profile) {
-		if (profile.userCount > 0) return;
-		if (!confirm(`Delete profile "${profile.profileName}"?`)) return;
-		await runPixel(
-			`DeleteAppProfile(app="${appId}", profileId="${profile.profileId}");`,
-		);
-		await loadProfiles();
-		if (selectedProfile?.profileId === profile.profileId)
-			setSelectedProfile(null);
+	async function confirmDeleteProfile() {
+		if (!deleteProfileTarget) return;
+		setConfirmLoading(true);
+		try {
+			await runPixel(
+				`DeleteAppProfile(app="${appId}", profileId="${deleteProfileTarget.profileId}");`,
+			);
+			await loadProfiles();
+			if (selectedProfile?.profileId === deleteProfileTarget.profileId) {
+				setSelectedProfile(null);
+			}
+			setDeleteProfileTarget(null);
+		} finally {
+			setConfirmLoading(false);
+		}
 	}
 
 	async function handleToggleFeature(feature: Feature) {
@@ -165,88 +220,127 @@ export const AppProfiles = ({ appId }: AppProfilesProps) => {
 
 	async function handleAddFeature() {
 		if (!validateFeatureKey(featureFormKey)) {
-			setFeatureKeyError(
-				"Key must be alphanumeric + hyphens only, max 100 chars.",
-			);
+			setFeatureKeyError("Alphanumeric + hyphens only, max 100 chars.");
 			return;
 		}
 		setFeatureKeyError("");
-		const desc = sanitizeForPixel(featureFormDesc);
-		await runPixel(
-			`CreateAppFeature(app="${appId}", key="${featureFormKey}", description="${desc}");`,
-		);
-		if (selectedProfile)
-			await loadProfileFeatures(selectedProfile.profileId);
-		setShowFeatureForm(false);
-		setFeatureFormKey("");
-		setFeatureFormDesc("");
+		setSavingFeature(true);
+		try {
+			const desc = sanitizeForPixel(featureFormDesc);
+			await runPixel(
+				`CreateAppFeature(app="${appId}", key="${featureFormKey}", description="${desc}");`,
+			);
+			if (selectedProfile)
+				await loadProfileFeatures(selectedProfile.profileId);
+			setShowFeatureForm(false);
+			setFeatureFormKey("");
+			setFeatureFormDesc("");
+		} finally {
+			setSavingFeature(false);
+		}
 	}
 
 	async function handleAssignUser() {
 		if (!selectedProfile || !assignUserId.trim()) return;
-		const uid = sanitizeForPixel(assignUserId.trim());
-		await runPixel(
-			`AssignUserProfile(app="${appId}", userId="${uid}", profileId="${selectedProfile.profileId}");`,
-		);
-		await loadProfileUsers(selectedProfile.profileId);
-		setShowAssignUser(false);
-		setAssignUserId("");
+		const safeUserId = sanitizeForPixel(assignUserId.trim());
+		setAssigningUser(true);
+		try {
+			await runPixel(
+				`AssignUserProfile(app="${appId}", userId="${safeUserId}", profileId="${selectedProfile.profileId}");`,
+			);
+			await loadProfileUsers(selectedProfile.profileId);
+			setShowAssignUser(false);
+			setAssignUserId("");
+		} finally {
+			setAssigningUser(false);
+		}
 	}
 
-	async function handleRemoveUser(userId: string) {
-		if (!confirm(`Remove user ${userId} from this profile?`)) return;
-		await runPixel(
-			`RemoveUserProfile(app="${appId}", userId="${userId}");`,
-		);
-		if (selectedProfile) await loadProfileUsers(selectedProfile.profileId);
+	async function confirmRemoveUser() {
+		if (!removeUserTarget) return;
+		setConfirmLoading(true);
+		try {
+			await runPixel(
+				`RemoveUserProfile(app="${appId}", userId="${removeUserTarget}");`,
+			);
+			if (selectedProfile)
+				await loadProfileUsers(selectedProfile.profileId);
+			setRemoveUserTarget(null);
+		} finally {
+			setConfirmLoading(false);
+		}
 	}
 
 	return (
-		<div className="flex h-full gap-4">
+		<div className="flex h-full gap-4 p-1">
 			{/* Left panel — Profile list */}
 			<div className="flex w-72 flex-shrink-0 flex-col gap-2">
-				<div className="mb-1 flex items-center justify-between">
+				<div className="flex items-center justify-between">
 					<span className="font-semibold text-sm">Profiles</span>
 					<Button
 						size="sm"
 						variant="outline"
-						onClick={() => {
-							setShowProfileForm(true);
-							setEditingProfile(null);
-							setProfileFormName("");
-							setProfileFormDesc("");
-							setProfileFormDefault(false);
-						}}
+						onClick={openNewProfileForm}
 					>
 						New Profile
 					</Button>
 				</div>
 
 				{showProfileForm && (
-					<div className="flex flex-col gap-2 rounded-md border bg-card p-3">
-						<input
-							className="w-full rounded border px-2 py-1 text-sm"
-							placeholder="Profile name *"
-							value={profileFormName}
-							onChange={(e) => setProfileFormName(e.target.value)}
-							maxLength={100}
-						/>
-						<input
-							className="w-full rounded border px-2 py-1 text-sm"
-							placeholder="Description"
-							value={profileFormDesc}
-							onChange={(e) => setProfileFormDesc(e.target.value)}
-						/>
-						<label className="flex items-center gap-2 text-xs">
-							<input
-								type="checkbox"
-								checked={profileFormDefault}
+					<div className="flex flex-col gap-3 rounded-lg border bg-card p-3 shadow-sm">
+						<p className="font-medium text-sm">
+							{editingProfile ? "Edit Profile" : "New Profile"}
+						</p>
+						<div className="flex flex-col gap-1.5">
+							<Label
+								htmlFor={`${uid}-profile-name`}
+								className="text-xs"
+							>
+								Name <span className="text-destructive">*</span>
+							</Label>
+							<Input
+								id={`${uid}-profile-name`}
+								placeholder="e.g. beta, power-user"
+								value={profileFormName}
 								onChange={(e) =>
-									setProfileFormDefault(e.target.checked)
+									setProfileFormName(e.target.value)
+								}
+								maxLength={100}
+								autoFocus
+							/>
+						</div>
+						<div className="flex flex-col gap-1.5">
+							<Label
+								htmlFor={`${uid}-profile-desc`}
+								className="text-xs"
+							>
+								Description
+							</Label>
+							<Input
+								id={`${uid}-profile-desc`}
+								placeholder="Optional description"
+								value={profileFormDesc}
+								onChange={(e) =>
+									setProfileFormDesc(e.target.value)
 								}
 							/>
-							Set as default
-						</label>
+						</div>
+						<div className="flex items-center gap-2">
+							<Checkbox
+								id={`${uid}-profile-default`}
+								checked={profileFormDefault}
+								onCheckedChange={(v) =>
+									setProfileFormDefault(v === true)
+								}
+							/>
+							<Label
+								htmlFor={`${uid}-profile-default`}
+								className="cursor-pointer text-xs"
+							>
+								Set as default profile
+							</Label>
+						</div>
+						<Separator />
 						<div className="flex justify-end gap-2">
 							<Button
 								size="sm"
@@ -258,121 +352,139 @@ export const AppProfiles = ({ appId }: AppProfilesProps) => {
 							<Button
 								size="sm"
 								onClick={handleSaveProfile}
-								disabled={loading}
+								disabled={savingProfile}
 							>
-								Save
+								{savingProfile ? "Saving…" : "Save"}
 							</Button>
 						</div>
 					</div>
 				)}
 
-				{profiles.length === 0 && (
+				{profiles.length === 0 && !showProfileForm && (
 					<p className="text-muted-foreground text-sm">
 						No profiles defined yet.
 					</p>
 				)}
 
-				{profiles.map((p) => (
-					// biome-ignore lint/a11y/useSemanticElements: card contains nested interactive elements, cannot use button
-					<div
-						key={p.profileId}
-						role="button"
-						tabIndex={0}
-						className={`cursor-pointer rounded-md border p-3 transition-colors hover:bg-muted/50 ${selectedProfile?.profileId === p.profileId ? "border-primary bg-muted/30" : ""}`}
-						onClick={() => setSelectedProfile(p)}
-						onKeyDown={(e) => {
-							if (e.key === "Enter" || e.key === " ")
-								setSelectedProfile(p);
-						}}
-					>
-						<div className="flex items-center justify-between">
-							<div className="flex items-center gap-2">
-								<span className="font-medium text-sm">
-									{p.profileName}
-								</span>
-								{p.isDefault && (
-									<span className="rounded bg-primary/10 px-1 text-primary text-xs">
-										Default
+				<div className="flex flex-col gap-1.5">
+					{profiles.map((p) => (
+						// biome-ignore lint/a11y/useSemanticElements: card contains nested interactive elements
+						<div
+							key={p.profileId}
+							role="button"
+							tabIndex={0}
+							className={`cursor-pointer rounded-lg border p-3 transition-colors hover:bg-muted/50 ${selectedProfile?.profileId === p.profileId ? "border-primary bg-muted/30" : ""}`}
+							onClick={() => setSelectedProfile(p)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter" || e.key === " ")
+									setSelectedProfile(p);
+							}}
+						>
+							<div className="flex items-start justify-between gap-2">
+								<div className="flex min-w-0 flex-col gap-1">
+									<div className="flex items-center gap-1.5">
+										<span className="truncate font-medium text-sm">
+											{p.profileName}
+										</span>
+										{p.isDefault && (
+											<Badge
+												variant="secondary"
+												className="text-xs"
+											>
+												Default
+											</Badge>
+										)}
+									</div>
+									{p.description && (
+										<p className="truncate text-muted-foreground text-xs">
+											{p.description}
+										</p>
+									)}
+									<span className="text-muted-foreground text-xs">
+										{p.userCount}{" "}
+										{p.userCount === 1 ? "user" : "users"}
 									</span>
-								)}
-							</div>
-							<div className="flex items-center gap-1">
-								<span className="text-muted-foreground text-xs">
-									{p.userCount} users
-								</span>
-								<button
-									type="button"
-									className="ml-1 text-muted-foreground hover:text-foreground"
-									title="Edit"
-									onClick={(e) => {
-										e.stopPropagation();
-										setEditingProfile(p);
-										setProfileFormName(p.profileName);
-										setProfileFormDesc(p.description || "");
-										setProfileFormDefault(p.isDefault);
-										setShowProfileForm(true);
-									}}
-								>
-									✎
-								</button>
-								<button
-									type="button"
-									className={`ml-1 text-muted-foreground ${p.userCount > 0 ? "cursor-not-allowed opacity-30" : "hover:text-destructive"}`}
-									title={
-										p.userCount > 0
-											? `${p.userCount} users assigned — reassign first`
-											: "Delete"
-									}
-									onClick={(e) => {
-										e.stopPropagation();
-										handleDeleteProfile(p);
-									}}
-									disabled={p.userCount > 0}
-								>
-									🗑
-								</button>
+								</div>
+								<div className="flex shrink-0 items-center gap-0.5">
+									<Button
+										size="icon"
+										variant="ghost"
+										className="size-6"
+										title="Edit profile"
+										onClick={(e) =>
+											openEditProfileForm(p, e)
+										}
+									>
+										<Pencil className="size-3.5" />
+									</Button>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span>
+												<Button
+													size="icon"
+													variant="ghost"
+													className="size-6 text-muted-foreground hover:text-destructive disabled:pointer-events-none"
+													disabled={p.userCount > 0}
+													onClick={(e) => {
+														e.stopPropagation();
+														setDeleteProfileTarget(
+															p,
+														);
+													}}
+												>
+													<Trash2 className="size-3.5" />
+												</Button>
+											</span>
+										</TooltipTrigger>
+										{p.userCount > 0 && (
+											<TooltipContent>
+												{p.userCount}{" "}
+												{p.userCount === 1
+													? "user"
+													: "users"}{" "}
+												assigned — reassign first
+											</TooltipContent>
+										)}
+									</Tooltip>
+								</div>
 							</div>
 						</div>
-						{p.description && (
-							<p className="mt-1 text-muted-foreground text-xs">
-								{p.description}
-							</p>
-						)}
-					</div>
-				))}
+					))}
+				</div>
 			</div>
 
 			{/* Right panel — Profile detail */}
 			{selectedProfile ? (
-				<div className="flex flex-1 flex-col gap-3">
-					<div className="flex items-center gap-3 border-b pb-2">
-						<h3 className="font-semibold">
-							{selectedProfile.profileName}
-						</h3>
-						<div className="flex gap-2">
-							<button
-								type="button"
-								className={`rounded-md px-3 py-1 text-sm ${activeTab === "features" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted"}`}
-								onClick={() => setActiveTab("features")}
-							>
-								Features
-							</button>
-							<button
-								type="button"
-								className={`rounded-md px-3 py-1 text-sm ${activeTab === "members" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted"}`}
-								onClick={() => setActiveTab("members")}
-							>
-								Members
-							</button>
+				<div className="flex flex-1 flex-col gap-3 overflow-hidden">
+					<div className="flex items-center justify-between border-b pb-2">
+						<div className="flex items-center gap-2">
+							<h3 className="font-semibold">
+								{selectedProfile.profileName}
+							</h3>
+							{selectedProfile.isDefault && (
+								<Badge variant="secondary">Default</Badge>
+							)}
 						</div>
 					</div>
 
-					{activeTab === "features" && (
-						<div className="flex flex-col gap-2">
+					<Tabs
+						defaultValue="features"
+						className="flex flex-1 flex-col gap-3 overflow-hidden"
+					>
+						<TabsList className="w-fit">
+							<TabsTrigger value="features">Features</TabsTrigger>
+							<TabsTrigger value="members">Members</TabsTrigger>
+						</TabsList>
+
+						<TabsContent
+							value="features"
+							className="flex flex-col gap-2 overflow-auto"
+						>
 							<div className="flex items-center justify-between">
-								<span className="font-medium text-sm">
-									Features
-								</span>
+								<p className="text-muted-foreground text-sm">
+									Toggle which features are enabled for this
+									profile.
+								</p>
 								<Button
 									size="sm"
 									variant="outline"
@@ -383,35 +495,68 @@ export const AppProfiles = ({ appId }: AppProfilesProps) => {
 							</div>
 
 							{showFeatureForm && (
-								<div className="flex flex-col gap-2 rounded-md border bg-card p-3">
-									<input
-										className={`w-full rounded border px-2 py-1 text-sm ${featureKeyError ? "border-destructive" : ""}`}
-										placeholder="Feature key * (e.g. export-csv)"
-										value={featureFormKey}
-										onChange={(e) => {
-											setFeatureFormKey(e.target.value);
-											setFeatureKeyError(
-												validateFeatureKey(
+								<div className="flex flex-col gap-3 rounded-lg border bg-card p-3 shadow-sm">
+									<p className="font-medium text-sm">
+										New Feature
+									</p>
+									<div className="flex flex-col gap-1.5">
+										<Label
+											htmlFor={`${uid}-feature-key`}
+											className="text-xs"
+										>
+											Key{" "}
+											<span className="text-destructive">
+												*
+											</span>
+										</Label>
+										<Input
+											id={`${uid}-feature-key`}
+											placeholder="e.g. export-csv"
+											value={featureFormKey}
+											className={
+												featureKeyError
+													? "border-destructive"
+													: ""
+											}
+											onChange={(e) => {
+												setFeatureFormKey(
 													e.target.value,
-												) || !e.target.value
-													? ""
-													: "Alphanumeric + hyphens only, max 100 chars.",
-											);
-										}}
-									/>
-									{featureKeyError && (
-										<p className="text-destructive text-xs">
-											{featureKeyError}
-										</p>
-									)}
-									<input
-										className="w-full rounded border px-2 py-1 text-sm"
-										placeholder="Description"
-										value={featureFormDesc}
-										onChange={(e) =>
-											setFeatureFormDesc(e.target.value)
-										}
-									/>
+												);
+												setFeatureKeyError(
+													validateFeatureKey(
+														e.target.value,
+													) || !e.target.value
+														? ""
+														: "Alphanumeric + hyphens only, max 100 chars.",
+												);
+											}}
+											autoFocus
+										/>
+										{featureKeyError && (
+											<p className="text-destructive text-xs">
+												{featureKeyError}
+											</p>
+										)}
+									</div>
+									<div className="flex flex-col gap-1.5">
+										<Label
+											htmlFor={`${uid}-feature-desc`}
+											className="text-xs"
+										>
+											Description
+										</Label>
+										<Input
+											id={`${uid}-feature-desc`}
+											placeholder="Optional description"
+											value={featureFormDesc}
+											onChange={(e) =>
+												setFeatureFormDesc(
+													e.target.value,
+												)
+											}
+										/>
+									</div>
+									<Separator />
 									<div className="flex justify-end gap-2">
 										<Button
 											size="sm"
@@ -426,8 +571,9 @@ export const AppProfiles = ({ appId }: AppProfilesProps) => {
 										<Button
 											size="sm"
 											onClick={handleAddFeature}
+											disabled={savingFeature}
 										>
-											Add
+											{savingFeature ? "Adding…" : "Add"}
 										</Button>
 									</div>
 								</div>
@@ -438,78 +584,100 @@ export const AppProfiles = ({ appId }: AppProfilesProps) => {
 									No features defined for this app yet.
 								</p>
 							) : (
-								features.map((f) => (
-									<div
-										key={f.featureId}
-										className="flex items-center justify-between rounded-md border px-3 py-2"
-									>
-										<div>
-											<span className="font-mono text-sm">
-												{f.featureKey}
-											</span>
-											{f.description && (
-												<p className="text-muted-foreground text-xs">
-													{f.description}
-												</p>
-											)}
-										</div>
-										<label className="relative inline-flex cursor-pointer items-center">
-											<input
-												type="checkbox"
-												className="peer sr-only"
+								<div className="flex flex-col gap-1.5">
+									{features.map((f) => (
+										<div
+											key={f.featureId}
+											className="flex items-center justify-between rounded-lg border px-3 py-2.5"
+										>
+											<div>
+												<span className="font-mono text-sm">
+													{f.featureKey}
+												</span>
+												{f.description && (
+													<p className="text-muted-foreground text-xs">
+														{f.description}
+													</p>
+												)}
+											</div>
+											<Switch
 												checked={f.enabled}
-												onChange={() =>
+												onCheckedChange={() =>
 													handleToggleFeature(f)
 												}
 											/>
-											<div className="peer h-5 w-9 rounded-full bg-gray-200 after:absolute after:top-[2px] after:left-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-primary peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none" />
-										</label>
-									</div>
-								))
+										</div>
+									))}
+								</div>
 							)}
-						</div>
-					)}
+						</TabsContent>
 
-					{activeTab === "members" && (
-						<div className="flex flex-col gap-2">
+						<TabsContent
+							value="members"
+							className="flex flex-col gap-2 overflow-auto"
+						>
 							<div className="flex items-center justify-between">
-								<span className="font-medium text-sm">
-									Members
-								</span>
+								<p className="text-muted-foreground text-sm">
+									Users explicitly assigned to this profile.
+								</p>
 								<Button
 									size="sm"
 									variant="outline"
 									onClick={() => setShowAssignUser(true)}
 								>
+									<UserPlus className="mr-1.5 size-3.5" />
 									Assign User
 								</Button>
 							</div>
 
 							{showAssignUser && (
-								<div className="flex flex-col gap-2 rounded-md border bg-card p-3">
-									<input
-										className="w-full rounded border px-2 py-1 text-sm"
-										placeholder="User ID"
-										value={assignUserId}
-										onChange={(e) =>
-											setAssignUserId(e.target.value)
-										}
-									/>
+								<div className="flex flex-col gap-3 rounded-lg border bg-card p-3 shadow-sm">
+									<p className="font-medium text-sm">
+										Assign User
+									</p>
+									<div className="flex flex-col gap-1.5">
+										<Label
+											htmlFor={`${uid}-assign-uid`}
+											className="text-xs"
+										>
+											User ID{" "}
+											<span className="text-destructive">
+												*
+											</span>
+										</Label>
+										<Input
+											id={`${uid}-assign-uid`}
+											placeholder="Enter user ID"
+											value={assignUserId}
+											onChange={(e) =>
+												setAssignUserId(e.target.value)
+											}
+											autoFocus
+										/>
+									</div>
+									<Separator />
 									<div className="flex justify-end gap-2">
 										<Button
 											size="sm"
 											variant="ghost"
-											onClick={() =>
-												setShowAssignUser(false)
-											}
+											onClick={() => {
+												setShowAssignUser(false);
+												setAssignUserId("");
+											}}
 										>
 											Cancel
 										</Button>
 										<Button
 											size="sm"
 											onClick={handleAssignUser}
+											disabled={
+												assigningUser ||
+												!assignUserId.trim()
+											}
 										>
-											Assign
+											{assigningUser
+												? "Assigning…"
+												: "Assign"}
 										</Button>
 									</div>
 								</div>
@@ -517,70 +685,129 @@ export const AppProfiles = ({ appId }: AppProfilesProps) => {
 
 							{profileUsers.length === 0 ? (
 								<p className="text-muted-foreground text-sm">
-									No users assigned to this profile.
+									No users explicitly assigned to this
+									profile.
 								</p>
 							) : (
-								<table className="w-full text-sm">
-									<thead>
-										<tr className="border-b">
-											<th className="py-1 text-left font-medium">
-												User ID
-											</th>
-											<th className="py-1 text-left font-medium">
-												Assigned By
-											</th>
-											<th className="py-1 text-left font-medium">
-												Assigned At
-											</th>
-											<th />
-										</tr>
-									</thead>
-									<tbody>
+								<Table>
+									<TableHeader>
+										<TableRow>
+											<TableHead>User ID</TableHead>
+											<TableHead>Assigned By</TableHead>
+											<TableHead>Assigned At</TableHead>
+											<TableHead className="w-16" />
+										</TableRow>
+									</TableHeader>
+									<TableBody>
 										{profileUsers.map((u) => (
-											<tr
-												key={u.userId}
-												className="border-b hover:bg-muted/30"
-											>
-												<td className="py-1">
+											<TableRow key={u.userId}>
+												<TableCell className="font-mono text-sm">
 													{u.userId}
-												</td>
-												<td className="py-1 text-muted-foreground">
-													{u.assignedBy}
-												</td>
-												<td className="py-1 text-muted-foreground">
+												</TableCell>
+												<TableCell className="text-muted-foreground">
+													{u.assignedBy ?? "—"}
+												</TableCell>
+												<TableCell className="text-muted-foreground">
 													{u.assignedAt
 														? new Date(
 																u.assignedAt,
 															).toLocaleDateString()
 														: "—"}
-												</td>
-												<td className="py-1">
+												</TableCell>
+												<TableCell>
 													<Button
 														size="sm"
 														variant="ghost"
+														className="text-destructive hover:text-destructive"
 														onClick={() =>
-															handleRemoveUser(
+															setRemoveUserTarget(
 																u.userId,
 															)
 														}
-														className="text-destructive hover:text-destructive"
 													>
 														Remove
 													</Button>
-												</td>
-											</tr>
+												</TableCell>
+											</TableRow>
 										))}
-									</tbody>
-								</table>
+									</TableBody>
+								</Table>
 							)}
-						</div>
-					)}
+						</TabsContent>
+					</Tabs>
 				</div>
 			) : (
-				<div className="flex flex-1 items-center justify-center text-muted-foreground text-sm">
-					Select a profile to view details.
+				<div className="flex flex-1 items-center justify-center">
+					<p className="text-muted-foreground text-sm">
+						Select a profile to view details.
+					</p>
 				</div>
 			)}
+
+			{/* Delete profile confirmation */}
+			<Dialog
+				open={!!deleteProfileTarget}
+				onOpenChange={(open) => !open && setDeleteProfileTarget(null)}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Delete Profile</DialogTitle>
+						<DialogDescription>
+							Delete profile &quot;
+							{deleteProfileTarget?.profileName}&quot;? This
+							cannot be undone.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							variant="ghost"
+							onClick={() => setDeleteProfileTarget(null)}
+							disabled={confirmLoading}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							onClick={confirmDeleteProfile}
+							disabled={confirmLoading}
+						>
+							{confirmLoading ? "Deleting…" : "Delete"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Remove user confirmation */}
+			<Dialog
+				open={!!removeUserTarget}
+				onOpenChange={(open) => !open && setRemoveUserTarget(null)}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Remove User</DialogTitle>
+						<DialogDescription>
+							Remove user &quot;{removeUserTarget}&quot; from this
+							profile? They will fall back to the default profile.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							variant="ghost"
+							onClick={() => setRemoveUserTarget(null)}
+							disabled={confirmLoading}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							onClick={confirmRemoveUser}
+							disabled={confirmLoading}
+						>
+							{confirmLoading ? "Removing…" : "Remove"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 };

--- a/packages/client/src/pages/app/app-detail.constants.ts
+++ b/packages/client/src/pages/app/app-detail.constants.ts
@@ -7,6 +7,7 @@ import { AppFilesPage } from "./app-files-page";
 import { AppGithubPage } from "./app-github-page";
 import { AppMcpUsagePage } from "./app-mcp-usage-page";
 import { AppOverviewPage } from "./app-overview-page";
+import { AppProfilesPage } from "./app-profiles-page";
 import { AppSettingsPage } from "./app-settings-page";
 import { AppSmssPage } from "./app-smss-page";
 
@@ -76,6 +77,12 @@ export const APP_DETAIL_TABS: AppDetailTab[] = [
 		name: "Access Control",
 		path: "access-control",
 		component: AppAccessControlPage,
+		restrict: ["author", "editor"],
+	},
+	{
+		name: "Profiles",
+		path: "profiles",
+		component: AppProfilesPage,
 		restrict: ["author", "editor"],
 	},
 	{

--- a/packages/client/src/pages/app/app-profiles-page.tsx
+++ b/packages/client/src/pages/app/app-profiles-page.tsx
@@ -1,0 +1,7 @@
+import { useAppDetail } from "@/contexts";
+import { AppProfiles } from "./app-detail-tabs/profiles";
+
+export const AppProfilesPage = () => {
+	const { appId, permission } = useAppDetail();
+	return <AppProfiles appId={appId} permission={permission} />;
+};

--- a/packages/client/src/pages/settings/platform-profiles-page.tsx
+++ b/packages/client/src/pages/settings/platform-profiles-page.tsx
@@ -1,6 +1,32 @@
-import { useEffect, useState } from "react";
-import { toast } from "sonner";
-import { Button } from "@semoss/ui/next";
+import { Pencil, Trash2, UserPlus } from "lucide-react";
+import { useEffect, useId, useState } from "react";
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Input,
+	Label,
+	Separator,
+	Switch,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+	toast,
+} from "@semoss/ui/next";
 import { useRootStore } from "@/hooks/";
 
 interface PlatformProfile {
@@ -30,26 +56,35 @@ function sanitizeForPixel(s: string): string {
 
 export const PlatformProfilesPage = () => {
 	const { monolithStore } = useRootStore();
+	const uid = useId();
 
 	const [profiles, setProfiles] = useState<PlatformProfile[]>([]);
 	const [selectedProfile, setSelectedProfile] =
 		useState<PlatformProfile | null>(null);
 	const [features, setFeatures] = useState<Record<string, boolean>>({});
 	const [profileUsers, setProfileUsers] = useState<ProfileUser[]>([]);
-	const [activeTab, setActiveTab] = useState<"features" | "members">(
-		"features",
-	);
 
+	// Profile form state
 	const [showProfileForm, setShowProfileForm] = useState(false);
 	const [editingProfile, setEditingProfile] =
 		useState<PlatformProfile | null>(null);
 	const [profileFormName, setProfileFormName] = useState("");
 	const [profileFormDesc, setProfileFormDesc] = useState("");
+	const [savingProfile, setSavingProfile] = useState(false);
 
+	// Assign user state
 	const [showAssignUser, setShowAssignUser] = useState(false);
 	const [assignUserId, setAssignUserId] = useState("");
+	const [assigningUser, setAssigningUser] = useState(false);
 
-	const [loading, setLoading] = useState(false);
+	// Confirmation dialogs
+	const [deleteTarget, setDeleteTarget] = useState<PlatformProfile | null>(
+		null,
+	);
+	const [removeUserTarget, setRemoveUserTarget] = useState<string | null>(
+		null,
+	);
+	const [confirmLoading, setConfirmLoading] = useState(false);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: loadProfiles is defined in component scope
 	useEffect(() => {
@@ -91,12 +126,25 @@ export const PlatformProfilesPage = () => {
 	}
 
 	async function loadProfileUsers(profileId: string) {
-		// Reuse GetProfileUsers concept — platform profiles list users via a future admin API
-		// For now we fetch assigned users from the platform profile
 		const result = await runPixel<ProfileUser[]>(
 			`GetPlatformProfileUsers(profileId="${profileId}");`,
 		);
 		if (result) setProfileUsers(result);
+	}
+
+	function openNewProfileForm() {
+		setEditingProfile(null);
+		setProfileFormName("");
+		setProfileFormDesc("");
+		setShowProfileForm(true);
+	}
+
+	function openEditProfileForm(p: PlatformProfile, e: React.MouseEvent) {
+		e.stopPropagation();
+		setEditingProfile(p);
+		setProfileFormName(p.profileName);
+		setProfileFormDesc(p.description || "");
+		setShowProfileForm(true);
 	}
 
 	async function handleSaveProfile() {
@@ -106,7 +154,7 @@ export const PlatformProfilesPage = () => {
 			return;
 		}
 		const desc = sanitizeForPixel(profileFormDesc);
-		setLoading(true);
+		setSavingProfile(true);
 		try {
 			if (editingProfile) {
 				await runPixel(
@@ -120,23 +168,26 @@ export const PlatformProfilesPage = () => {
 			await loadProfiles();
 			setShowProfileForm(false);
 			setEditingProfile(null);
-			setProfileFormName("");
-			setProfileFormDesc("");
 		} finally {
-			setLoading(false);
+			setSavingProfile(false);
 		}
 	}
 
-	async function handleDeleteProfile(profile: PlatformProfile) {
-		if (profile.userCount > 0) return;
-		if (!confirm(`Delete platform profile "${profile.profileName}"?`))
-			return;
-		await runPixel(
-			`DeletePlatformProfile(profileId="${profile.profileId}");`,
-		);
-		await loadProfiles();
-		if (selectedProfile?.profileId === profile.profileId)
-			setSelectedProfile(null);
+	async function confirmDeleteProfile() {
+		if (!deleteTarget) return;
+		setConfirmLoading(true);
+		try {
+			await runPixel(
+				`DeletePlatformProfile(profileId="${deleteTarget.profileId}");`,
+			);
+			await loadProfiles();
+			if (selectedProfile?.profileId === deleteTarget.profileId) {
+				setSelectedProfile(null);
+			}
+			setDeleteTarget(null);
+		} finally {
+			setConfirmLoading(false);
+		}
 	}
 
 	async function handleToggleFeature(featureKey: string) {
@@ -150,58 +201,92 @@ export const PlatformProfilesPage = () => {
 
 	async function handleAssignUser() {
 		if (!selectedProfile || !assignUserId.trim()) return;
-		const uid = sanitizeForPixel(assignUserId.trim());
-		await runPixel(
-			`AssignUserPlatformProfile(userId="${uid}", profileId="${selectedProfile.profileId}");`,
-		);
-		await loadProfileUsers(selectedProfile.profileId);
-		setShowAssignUser(false);
-		setAssignUserId("");
+		const safeUserId = sanitizeForPixel(assignUserId.trim());
+		setAssigningUser(true);
+		try {
+			await runPixel(
+				`AssignUserPlatformProfile(userId="${safeUserId}", profileId="${selectedProfile.profileId}");`,
+			);
+			await loadProfileUsers(selectedProfile.profileId);
+			setShowAssignUser(false);
+			setAssignUserId("");
+		} finally {
+			setAssigningUser(false);
+		}
 	}
 
-	async function handleRemoveUser(userId: string) {
-		if (!confirm(`Remove user ${userId} from this platform profile?`))
-			return;
-		await runPixel(`RemoveUserPlatformProfile(userId="${userId}");`);
-		if (selectedProfile) await loadProfileUsers(selectedProfile.profileId);
+	async function confirmRemoveUser() {
+		if (!removeUserTarget) return;
+		setConfirmLoading(true);
+		try {
+			await runPixel(
+				`RemoveUserPlatformProfile(userId="${removeUserTarget}");`,
+			);
+			if (selectedProfile)
+				await loadProfileUsers(selectedProfile.profileId);
+			setRemoveUserTarget(null);
+		} finally {
+			setConfirmLoading(false);
+		}
 	}
 
 	return (
 		<div className="flex h-full gap-4 p-4">
 			{/* Left panel */}
 			<div className="flex w-72 flex-shrink-0 flex-col gap-2">
-				<div className="mb-1 flex items-center justify-between">
+				<div className="flex items-center justify-between">
 					<span className="font-semibold text-sm">
 						Platform Profiles
 					</span>
 					<Button
 						size="sm"
 						variant="outline"
-						onClick={() => {
-							setShowProfileForm(true);
-							setEditingProfile(null);
-							setProfileFormName("");
-							setProfileFormDesc("");
-						}}
+						onClick={openNewProfileForm}
 					>
 						New Profile
 					</Button>
 				</div>
 
 				{showProfileForm && (
-					<div className="flex flex-col gap-2 rounded-md border bg-card p-3">
-						<input
-							className="w-full rounded border px-2 py-1 text-sm"
-							placeholder="Profile name *"
-							value={profileFormName}
-							onChange={(e) => setProfileFormName(e.target.value)}
-						/>
-						<input
-							className="w-full rounded border px-2 py-1 text-sm"
-							placeholder="Description"
-							value={profileFormDesc}
-							onChange={(e) => setProfileFormDesc(e.target.value)}
-						/>
+					<div className="flex flex-col gap-3 rounded-lg border bg-card p-3 shadow-sm">
+						<p className="font-medium text-sm">
+							{editingProfile ? "Edit Profile" : "New Profile"}
+						</p>
+						<div className="flex flex-col gap-1.5">
+							<Label
+								htmlFor={`${uid}-plat-profile-name`}
+								className="text-xs"
+							>
+								Name <span className="text-destructive">*</span>
+							</Label>
+							<Input
+								id={`${uid}-plat-profile-name`}
+								placeholder="e.g. catalog-only"
+								value={profileFormName}
+								onChange={(e) =>
+									setProfileFormName(e.target.value)
+								}
+								maxLength={100}
+								autoFocus
+							/>
+						</div>
+						<div className="flex flex-col gap-1.5">
+							<Label
+								htmlFor={`${uid}-plat-profile-desc`}
+								className="text-xs"
+							>
+								Description
+							</Label>
+							<Input
+								id={`${uid}-plat-profile-desc`}
+								placeholder="Optional description"
+								value={profileFormDesc}
+								onChange={(e) =>
+									setProfileFormDesc(e.target.value)
+								}
+							/>
+						</div>
+						<Separator />
 						<div className="flex justify-end gap-2">
 							<Button
 								size="sm"
@@ -213,175 +298,214 @@ export const PlatformProfilesPage = () => {
 							<Button
 								size="sm"
 								onClick={handleSaveProfile}
-								disabled={loading}
+								disabled={savingProfile}
 							>
-								Save
+								{savingProfile ? "Saving…" : "Save"}
 							</Button>
 						</div>
 					</div>
 				)}
 
-				{profiles.length === 0 && (
+				{profiles.length === 0 && !showProfileForm && (
 					<p className="text-muted-foreground text-sm">
 						No platform profiles defined yet.
 					</p>
 				)}
 
-				{profiles.map((p) => (
-					// biome-ignore lint/a11y/useSemanticElements: card contains nested interactive elements, cannot use button
-					<div
-						key={p.profileId}
-						role="button"
-						tabIndex={0}
-						className={`cursor-pointer rounded-md border p-3 transition-colors hover:bg-muted/50 ${selectedProfile?.profileId === p.profileId ? "border-primary bg-muted/30" : ""}`}
-						onClick={() => setSelectedProfile(p)}
-						onKeyDown={(e) => {
-							if (e.key === "Enter" || e.key === " ")
-								setSelectedProfile(p);
-						}}
-					>
-						<div className="flex items-center justify-between">
-							<span className="font-medium text-sm">
-								{p.profileName}
-							</span>
-							<div className="flex items-center gap-1">
-								<span className="text-muted-foreground text-xs">
-									{p.userCount} users
-								</span>
-								<button
-									type="button"
-									className="ml-1 text-muted-foreground hover:text-foreground"
-									title="Edit"
-									onClick={(e) => {
-										e.stopPropagation();
-										setEditingProfile(p);
-										setProfileFormName(p.profileName);
-										setProfileFormDesc(p.description || "");
-										setShowProfileForm(true);
-									}}
-								>
-									✎
-								</button>
-								<button
-									type="button"
-									className={`ml-1 text-muted-foreground ${p.userCount > 0 ? "cursor-not-allowed opacity-30" : "hover:text-destructive"}`}
-									title={
-										p.userCount > 0
-											? `${p.userCount} users assigned — reassign first`
-											: "Delete"
-									}
-									onClick={(e) => {
-										e.stopPropagation();
-										handleDeleteProfile(p);
-									}}
-									disabled={p.userCount > 0}
-								>
-									🗑
-								</button>
+				<div className="flex flex-col gap-1.5">
+					{profiles.map((p) => (
+						// biome-ignore lint/a11y/useSemanticElements: card contains nested interactive elements
+						<div
+							key={p.profileId}
+							role="button"
+							tabIndex={0}
+							className={`cursor-pointer rounded-lg border p-3 transition-colors hover:bg-muted/50 ${selectedProfile?.profileId === p.profileId ? "border-primary bg-muted/30" : ""}`}
+							onClick={() => setSelectedProfile(p)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter" || e.key === " ")
+									setSelectedProfile(p);
+							}}
+						>
+							<div className="flex items-start justify-between gap-2">
+								<div className="flex min-w-0 flex-col gap-1">
+									<span className="truncate font-medium text-sm">
+										{p.profileName}
+									</span>
+									{p.description && (
+										<p className="truncate text-muted-foreground text-xs">
+											{p.description}
+										</p>
+									)}
+									<span className="text-muted-foreground text-xs">
+										{p.userCount}{" "}
+										{p.userCount === 1 ? "user" : "users"}
+									</span>
+								</div>
+								<div className="flex shrink-0 items-center gap-0.5">
+									<Button
+										size="icon"
+										variant="ghost"
+										className="size-6"
+										title="Edit profile"
+										onClick={(e) =>
+											openEditProfileForm(p, e)
+										}
+									>
+										<Pencil className="size-3.5" />
+									</Button>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span>
+												<Button
+													size="icon"
+													variant="ghost"
+													className="size-6 text-muted-foreground hover:text-destructive disabled:pointer-events-none"
+													disabled={p.userCount > 0}
+													onClick={(e) => {
+														e.stopPropagation();
+														setDeleteTarget(p);
+													}}
+												>
+													<Trash2 className="size-3.5" />
+												</Button>
+											</span>
+										</TooltipTrigger>
+										{p.userCount > 0 && (
+											<TooltipContent>
+												{p.userCount}{" "}
+												{p.userCount === 1
+													? "user"
+													: "users"}{" "}
+												assigned — reassign first
+											</TooltipContent>
+										)}
+									</Tooltip>
+								</div>
 							</div>
 						</div>
-						{p.description && (
-							<p className="mt-1 text-muted-foreground text-xs">
-								{p.description}
-							</p>
-						)}
-					</div>
-				))}
+					))}
+				</div>
 			</div>
 
 			{/* Right panel */}
 			{selectedProfile ? (
-				<div className="flex flex-1 flex-col gap-3">
-					<div className="flex items-center gap-3 border-b pb-2">
+				<div className="flex flex-1 flex-col gap-3 overflow-hidden">
+					<div className="flex items-center border-b pb-2">
 						<h3 className="font-semibold">
 							{selectedProfile.profileName}
 						</h3>
-						<div className="flex gap-2">
-							<button
-								type="button"
-								className={`rounded-md px-3 py-1 text-sm ${activeTab === "features" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted"}`}
-								onClick={() => setActiveTab("features")}
-							>
-								Platform Features
-							</button>
-							<button
-								type="button"
-								className={`rounded-md px-3 py-1 text-sm ${activeTab === "members" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted"}`}
-								onClick={() => setActiveTab("members")}
-							>
-								Members
-							</button>
-						</div>
 					</div>
 
-					{activeTab === "features" && (
-						<div className="flex flex-col gap-2">
+					<Tabs
+						defaultValue="features"
+						className="flex flex-1 flex-col gap-3 overflow-hidden"
+					>
+						<TabsList className="w-fit">
+							<TabsTrigger value="features">
+								Platform Features
+							</TabsTrigger>
+							<TabsTrigger value="members">Members</TabsTrigger>
+						</TabsList>
+
+						<TabsContent
+							value="features"
+							className="flex flex-col gap-2 overflow-auto"
+						>
 							<p className="text-muted-foreground text-sm">
 								Toggle which platform navigation items are
 								visible to users assigned to this profile.
 							</p>
-							{PLATFORM_FEATURES.map((f) => (
-								<div
-									key={f.key}
-									className="flex items-center justify-between rounded-md border px-3 py-2"
-								>
-									<span className="text-sm">{f.label}</span>
-									<label className="relative inline-flex cursor-pointer items-center">
-										<input
-											type="checkbox"
-											className="peer sr-only"
+							<div className="flex flex-col gap-1.5">
+								{PLATFORM_FEATURES.map((f) => (
+									<div
+										key={f.key}
+										className="flex items-center justify-between rounded-lg border px-3 py-2.5"
+									>
+										<div>
+											<span className="text-sm">
+												{f.label}
+											</span>
+											<p className="font-mono text-muted-foreground text-xs">
+												{f.key}
+											</p>
+										</div>
+										<Switch
 											checked={features[f.key] ?? false}
-											onChange={() =>
+											onCheckedChange={() =>
 												handleToggleFeature(f.key)
 											}
 										/>
-										<div className="peer h-5 w-9 rounded-full bg-gray-200 after:absolute after:top-[2px] after:left-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-primary peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none" />
-									</label>
-								</div>
-							))}
-						</div>
-					)}
+									</div>
+								))}
+							</div>
+						</TabsContent>
 
-					{activeTab === "members" && (
-						<div className="flex flex-col gap-2">
+						<TabsContent
+							value="members"
+							className="flex flex-col gap-2 overflow-auto"
+						>
 							<div className="flex items-center justify-between">
-								<span className="font-medium text-sm">
-									Members
-								</span>
+								<p className="text-muted-foreground text-sm">
+									Users assigned to this platform profile.
+								</p>
 								<Button
 									size="sm"
 									variant="outline"
 									onClick={() => setShowAssignUser(true)}
 								>
+									<UserPlus className="mr-1.5 size-3.5" />
 									Assign User
 								</Button>
 							</div>
 
 							{showAssignUser && (
-								<div className="flex flex-col gap-2 rounded-md border bg-card p-3">
-									<input
-										className="w-full rounded border px-2 py-1 text-sm"
-										placeholder="User ID"
-										value={assignUserId}
-										onChange={(e) =>
-											setAssignUserId(e.target.value)
-										}
-									/>
+								<div className="flex flex-col gap-3 rounded-lg border bg-card p-3 shadow-sm">
+									<p className="font-medium text-sm">
+										Assign User
+									</p>
+									<div className="flex flex-col gap-1.5">
+										<Label
+											htmlFor={`${uid}-plat-assign-uid`}
+											className="text-xs"
+										>
+											User ID{" "}
+											<span className="text-destructive">
+												*
+											</span>
+										</Label>
+										<Input
+											id={`${uid}-plat-assign-uid`}
+											placeholder="Enter user ID"
+											value={assignUserId}
+											onChange={(e) =>
+												setAssignUserId(e.target.value)
+											}
+											autoFocus
+										/>
+									</div>
+									<Separator />
 									<div className="flex justify-end gap-2">
 										<Button
 											size="sm"
 											variant="ghost"
-											onClick={() =>
-												setShowAssignUser(false)
-											}
+											onClick={() => {
+												setShowAssignUser(false);
+												setAssignUserId("");
+											}}
 										>
 											Cancel
 										</Button>
 										<Button
 											size="sm"
 											onClick={handleAssignUser}
+											disabled={
+												assigningUser ||
+												!assignUserId.trim()
+											}
 										>
-											Assign
+											{assigningUser
+												? "Assigning…"
+												: "Assign"}
 										</Button>
 									</div>
 								</div>
@@ -392,67 +516,125 @@ export const PlatformProfilesPage = () => {
 									No users assigned to this platform profile.
 								</p>
 							) : (
-								<table className="w-full text-sm">
-									<thead>
-										<tr className="border-b">
-											<th className="py-1 text-left font-medium">
-												User ID
-											</th>
-											<th className="py-1 text-left font-medium">
-												Assigned By
-											</th>
-											<th className="py-1 text-left font-medium">
-												Assigned At
-											</th>
-											<th />
-										</tr>
-									</thead>
-									<tbody>
+								<Table>
+									<TableHeader>
+										<TableRow>
+											<TableHead>User ID</TableHead>
+											<TableHead>Assigned By</TableHead>
+											<TableHead>Assigned At</TableHead>
+											<TableHead className="w-16" />
+										</TableRow>
+									</TableHeader>
+									<TableBody>
 										{profileUsers.map((u) => (
-											<tr
-												key={u.userId}
-												className="border-b hover:bg-muted/30"
-											>
-												<td className="py-1">
+											<TableRow key={u.userId}>
+												<TableCell className="font-mono text-sm">
 													{u.userId}
-												</td>
-												<td className="py-1 text-muted-foreground">
-													{u.assignedBy}
-												</td>
-												<td className="py-1 text-muted-foreground">
+												</TableCell>
+												<TableCell className="text-muted-foreground">
+													{u.assignedBy ?? "—"}
+												</TableCell>
+												<TableCell className="text-muted-foreground">
 													{u.assignedAt
 														? new Date(
 																u.assignedAt,
 															).toLocaleDateString()
 														: "—"}
-												</td>
-												<td className="py-1">
+												</TableCell>
+												<TableCell>
 													<Button
 														size="sm"
 														variant="ghost"
+														className="text-destructive hover:text-destructive"
 														onClick={() =>
-															handleRemoveUser(
+															setRemoveUserTarget(
 																u.userId,
 															)
 														}
-														className="text-destructive hover:text-destructive"
 													>
 														Remove
 													</Button>
-												</td>
-											</tr>
+												</TableCell>
+											</TableRow>
 										))}
-									</tbody>
-								</table>
+									</TableBody>
+								</Table>
 							)}
-						</div>
-					)}
+						</TabsContent>
+					</Tabs>
 				</div>
 			) : (
-				<div className="flex flex-1 items-center justify-center text-muted-foreground text-sm">
-					Select a platform profile to view details.
+				<div className="flex flex-1 items-center justify-center">
+					<p className="text-muted-foreground text-sm">
+						Select a platform profile to view details.
+					</p>
 				</div>
 			)}
+
+			{/* Delete profile confirmation */}
+			<Dialog
+				open={!!deleteTarget}
+				onOpenChange={(open) => !open && setDeleteTarget(null)}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Delete Platform Profile</DialogTitle>
+						<DialogDescription>
+							Delete profile &quot;{deleteTarget?.profileName}
+							&quot;? This cannot be undone.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							variant="ghost"
+							onClick={() => setDeleteTarget(null)}
+							disabled={confirmLoading}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							onClick={confirmDeleteProfile}
+							disabled={confirmLoading}
+						>
+							{confirmLoading ? "Deleting…" : "Delete"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Remove user confirmation */}
+			<Dialog
+				open={!!removeUserTarget}
+				onOpenChange={(open) => !open && setRemoveUserTarget(null)}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Remove User</DialogTitle>
+						<DialogDescription>
+							Remove user &quot;{removeUserTarget}&quot; from this
+							platform profile? They will be unrestricted (all nav
+							items visible).
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							variant="ghost"
+							onClick={() => setRemoveUserTarget(null)}
+							disabled={confirmLoading}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							onClick={confirmRemoveUser}
+							disabled={confirmLoading}
+						>
+							{confirmLoading ? "Removing…" : "Remove"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 };

--- a/packages/client/src/pages/settings/platform-profiles-page.tsx
+++ b/packages/client/src/pages/settings/platform-profiles-page.tsx
@@ -1,0 +1,458 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@semoss/ui/next";
+import { useRootStore } from "@/hooks/";
+
+interface PlatformProfile {
+	profileId: string;
+	profileName: string;
+	description: string;
+	userCount: number;
+}
+
+interface ProfileUser {
+	userId: string;
+	assignedBy: string;
+	assignedAt: string;
+}
+
+const PLATFORM_FEATURES: { key: string; label: string }[] = [
+	{ key: "nav.app-catalog", label: "App Catalog" },
+	{ key: "nav.build", label: "Build" },
+	{ key: "nav.skills", label: "Skills" },
+	{ key: "nav.settings", label: "Settings" },
+	{ key: "nav.engine", label: "Engines" },
+];
+
+function sanitizeForPixel(s: string): string {
+	return s.replace(/[^a-zA-Z0-9 _\-.,!?]/g, "");
+}
+
+export const PlatformProfilesPage = () => {
+	const { monolithStore } = useRootStore();
+
+	const [profiles, setProfiles] = useState<PlatformProfile[]>([]);
+	const [selectedProfile, setSelectedProfile] =
+		useState<PlatformProfile | null>(null);
+	const [features, setFeatures] = useState<Record<string, boolean>>({});
+	const [profileUsers, setProfileUsers] = useState<ProfileUser[]>([]);
+	const [activeTab, setActiveTab] = useState<"features" | "members">(
+		"features",
+	);
+
+	const [showProfileForm, setShowProfileForm] = useState(false);
+	const [editingProfile, setEditingProfile] =
+		useState<PlatformProfile | null>(null);
+	const [profileFormName, setProfileFormName] = useState("");
+	const [profileFormDesc, setProfileFormDesc] = useState("");
+
+	const [showAssignUser, setShowAssignUser] = useState(false);
+	const [assignUserId, setAssignUserId] = useState("");
+
+	const [loading, setLoading] = useState(false);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: loadProfiles is defined in component scope
+	useEffect(() => {
+		loadProfiles();
+	}, []);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: loader functions are defined in component scope
+	useEffect(() => {
+		if (selectedProfile) {
+			loadProfileFeatures(selectedProfile.profileId);
+			loadProfileUsers(selectedProfile.profileId);
+		}
+	}, [selectedProfile]);
+
+	async function runPixel<T = unknown>(pixel: string): Promise<T | null> {
+		const response = await monolithStore.runQuery(pixel);
+		const { operationType, output } = response.pixelReturn[0];
+		if (operationType.indexOf("ERROR") > -1) {
+			toast.error(
+				typeof output === "string" ? output : "Operation failed.",
+			);
+			return null;
+		}
+		return output as T;
+	}
+
+	async function loadProfiles() {
+		const result = await runPixel<PlatformProfile[]>(
+			"GetPlatformProfiles();",
+		);
+		if (result) setProfiles(result);
+	}
+
+	async function loadProfileFeatures(profileId: string) {
+		const result = await runPixel<Record<string, boolean>>(
+			`GetPlatformFeatures(profileId="${profileId}");`,
+		);
+		if (result) setFeatures(result);
+	}
+
+	async function loadProfileUsers(profileId: string) {
+		// Reuse GetProfileUsers concept — platform profiles list users via a future admin API
+		// For now we fetch assigned users from the platform profile
+		const result = await runPixel<ProfileUser[]>(
+			`GetPlatformProfileUsers(profileId="${profileId}");`,
+		);
+		if (result) setProfileUsers(result);
+	}
+
+	async function handleSaveProfile() {
+		const name = sanitizeForPixel(profileFormName.trim());
+		if (!name) {
+			toast.error("Profile name is required.");
+			return;
+		}
+		const desc = sanitizeForPixel(profileFormDesc);
+		setLoading(true);
+		try {
+			if (editingProfile) {
+				await runPixel(
+					`UpdatePlatformProfile(profileId="${editingProfile.profileId}", name="${name}", description="${desc}");`,
+				);
+			} else {
+				await runPixel(
+					`CreatePlatformProfile(name="${name}", description="${desc}");`,
+				);
+			}
+			await loadProfiles();
+			setShowProfileForm(false);
+			setEditingProfile(null);
+			setProfileFormName("");
+			setProfileFormDesc("");
+		} finally {
+			setLoading(false);
+		}
+	}
+
+	async function handleDeleteProfile(profile: PlatformProfile) {
+		if (profile.userCount > 0) return;
+		if (!confirm(`Delete platform profile "${profile.profileName}"?`))
+			return;
+		await runPixel(
+			`DeletePlatformProfile(profileId="${profile.profileId}");`,
+		);
+		await loadProfiles();
+		if (selectedProfile?.profileId === profile.profileId)
+			setSelectedProfile(null);
+	}
+
+	async function handleToggleFeature(featureKey: string) {
+		if (!selectedProfile) return;
+		const current = features[featureKey] ?? false;
+		await runPixel(
+			`SetPlatformFeature(profileId="${selectedProfile.profileId}", featureKey="${featureKey}", enabled="${!current}");`,
+		);
+		await loadProfileFeatures(selectedProfile.profileId);
+	}
+
+	async function handleAssignUser() {
+		if (!selectedProfile || !assignUserId.trim()) return;
+		const uid = sanitizeForPixel(assignUserId.trim());
+		await runPixel(
+			`AssignUserPlatformProfile(userId="${uid}", profileId="${selectedProfile.profileId}");`,
+		);
+		await loadProfileUsers(selectedProfile.profileId);
+		setShowAssignUser(false);
+		setAssignUserId("");
+	}
+
+	async function handleRemoveUser(userId: string) {
+		if (!confirm(`Remove user ${userId} from this platform profile?`))
+			return;
+		await runPixel(`RemoveUserPlatformProfile(userId="${userId}");`);
+		if (selectedProfile) await loadProfileUsers(selectedProfile.profileId);
+	}
+
+	return (
+		<div className="flex h-full gap-4 p-4">
+			{/* Left panel */}
+			<div className="flex w-72 flex-shrink-0 flex-col gap-2">
+				<div className="mb-1 flex items-center justify-between">
+					<span className="font-semibold text-sm">
+						Platform Profiles
+					</span>
+					<Button
+						size="sm"
+						variant="outline"
+						onClick={() => {
+							setShowProfileForm(true);
+							setEditingProfile(null);
+							setProfileFormName("");
+							setProfileFormDesc("");
+						}}
+					>
+						New Profile
+					</Button>
+				</div>
+
+				{showProfileForm && (
+					<div className="flex flex-col gap-2 rounded-md border bg-card p-3">
+						<input
+							className="w-full rounded border px-2 py-1 text-sm"
+							placeholder="Profile name *"
+							value={profileFormName}
+							onChange={(e) => setProfileFormName(e.target.value)}
+						/>
+						<input
+							className="w-full rounded border px-2 py-1 text-sm"
+							placeholder="Description"
+							value={profileFormDesc}
+							onChange={(e) => setProfileFormDesc(e.target.value)}
+						/>
+						<div className="flex justify-end gap-2">
+							<Button
+								size="sm"
+								variant="ghost"
+								onClick={() => setShowProfileForm(false)}
+							>
+								Cancel
+							</Button>
+							<Button
+								size="sm"
+								onClick={handleSaveProfile}
+								disabled={loading}
+							>
+								Save
+							</Button>
+						</div>
+					</div>
+				)}
+
+				{profiles.length === 0 && (
+					<p className="text-muted-foreground text-sm">
+						No platform profiles defined yet.
+					</p>
+				)}
+
+				{profiles.map((p) => (
+					// biome-ignore lint/a11y/useSemanticElements: card contains nested interactive elements, cannot use button
+					<div
+						key={p.profileId}
+						role="button"
+						tabIndex={0}
+						className={`cursor-pointer rounded-md border p-3 transition-colors hover:bg-muted/50 ${selectedProfile?.profileId === p.profileId ? "border-primary bg-muted/30" : ""}`}
+						onClick={() => setSelectedProfile(p)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter" || e.key === " ")
+								setSelectedProfile(p);
+						}}
+					>
+						<div className="flex items-center justify-between">
+							<span className="font-medium text-sm">
+								{p.profileName}
+							</span>
+							<div className="flex items-center gap-1">
+								<span className="text-muted-foreground text-xs">
+									{p.userCount} users
+								</span>
+								<button
+									type="button"
+									className="ml-1 text-muted-foreground hover:text-foreground"
+									title="Edit"
+									onClick={(e) => {
+										e.stopPropagation();
+										setEditingProfile(p);
+										setProfileFormName(p.profileName);
+										setProfileFormDesc(p.description || "");
+										setShowProfileForm(true);
+									}}
+								>
+									✎
+								</button>
+								<button
+									type="button"
+									className={`ml-1 text-muted-foreground ${p.userCount > 0 ? "cursor-not-allowed opacity-30" : "hover:text-destructive"}`}
+									title={
+										p.userCount > 0
+											? `${p.userCount} users assigned — reassign first`
+											: "Delete"
+									}
+									onClick={(e) => {
+										e.stopPropagation();
+										handleDeleteProfile(p);
+									}}
+									disabled={p.userCount > 0}
+								>
+									🗑
+								</button>
+							</div>
+						</div>
+						{p.description && (
+							<p className="mt-1 text-muted-foreground text-xs">
+								{p.description}
+							</p>
+						)}
+					</div>
+				))}
+			</div>
+
+			{/* Right panel */}
+			{selectedProfile ? (
+				<div className="flex flex-1 flex-col gap-3">
+					<div className="flex items-center gap-3 border-b pb-2">
+						<h3 className="font-semibold">
+							{selectedProfile.profileName}
+						</h3>
+						<div className="flex gap-2">
+							<button
+								type="button"
+								className={`rounded-md px-3 py-1 text-sm ${activeTab === "features" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted"}`}
+								onClick={() => setActiveTab("features")}
+							>
+								Platform Features
+							</button>
+							<button
+								type="button"
+								className={`rounded-md px-3 py-1 text-sm ${activeTab === "members" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted"}`}
+								onClick={() => setActiveTab("members")}
+							>
+								Members
+							</button>
+						</div>
+					</div>
+
+					{activeTab === "features" && (
+						<div className="flex flex-col gap-2">
+							<p className="text-muted-foreground text-sm">
+								Toggle which platform navigation items are
+								visible to users assigned to this profile.
+							</p>
+							{PLATFORM_FEATURES.map((f) => (
+								<div
+									key={f.key}
+									className="flex items-center justify-between rounded-md border px-3 py-2"
+								>
+									<span className="text-sm">{f.label}</span>
+									<label className="relative inline-flex cursor-pointer items-center">
+										<input
+											type="checkbox"
+											className="peer sr-only"
+											checked={features[f.key] ?? false}
+											onChange={() =>
+												handleToggleFeature(f.key)
+											}
+										/>
+										<div className="peer h-5 w-9 rounded-full bg-gray-200 after:absolute after:top-[2px] after:left-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-primary peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none" />
+									</label>
+								</div>
+							))}
+						</div>
+					)}
+
+					{activeTab === "members" && (
+						<div className="flex flex-col gap-2">
+							<div className="flex items-center justify-between">
+								<span className="font-medium text-sm">
+									Members
+								</span>
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={() => setShowAssignUser(true)}
+								>
+									Assign User
+								</Button>
+							</div>
+
+							{showAssignUser && (
+								<div className="flex flex-col gap-2 rounded-md border bg-card p-3">
+									<input
+										className="w-full rounded border px-2 py-1 text-sm"
+										placeholder="User ID"
+										value={assignUserId}
+										onChange={(e) =>
+											setAssignUserId(e.target.value)
+										}
+									/>
+									<div className="flex justify-end gap-2">
+										<Button
+											size="sm"
+											variant="ghost"
+											onClick={() =>
+												setShowAssignUser(false)
+											}
+										>
+											Cancel
+										</Button>
+										<Button
+											size="sm"
+											onClick={handleAssignUser}
+										>
+											Assign
+										</Button>
+									</div>
+								</div>
+							)}
+
+							{profileUsers.length === 0 ? (
+								<p className="text-muted-foreground text-sm">
+									No users assigned to this platform profile.
+								</p>
+							) : (
+								<table className="w-full text-sm">
+									<thead>
+										<tr className="border-b">
+											<th className="py-1 text-left font-medium">
+												User ID
+											</th>
+											<th className="py-1 text-left font-medium">
+												Assigned By
+											</th>
+											<th className="py-1 text-left font-medium">
+												Assigned At
+											</th>
+											<th />
+										</tr>
+									</thead>
+									<tbody>
+										{profileUsers.map((u) => (
+											<tr
+												key={u.userId}
+												className="border-b hover:bg-muted/30"
+											>
+												<td className="py-1">
+													{u.userId}
+												</td>
+												<td className="py-1 text-muted-foreground">
+													{u.assignedBy}
+												</td>
+												<td className="py-1 text-muted-foreground">
+													{u.assignedAt
+														? new Date(
+																u.assignedAt,
+															).toLocaleDateString()
+														: "—"}
+												</td>
+												<td className="py-1">
+													<Button
+														size="sm"
+														variant="ghost"
+														onClick={() =>
+															handleRemoveUser(
+																u.userId,
+															)
+														}
+														className="text-destructive hover:text-destructive"
+													>
+														Remove
+													</Button>
+												</td>
+											</tr>
+										))}
+									</tbody>
+								</table>
+							)}
+						</div>
+					)}
+				</div>
+			) : (
+				<div className="flex flex-1 items-center justify-center text-muted-foreground text-sm">
+					Select a platform profile to view details.
+				</div>
+			)}
+		</div>
+	);
+};

--- a/packages/client/src/pages/settings/settings-router.tsx
+++ b/packages/client/src/pages/settings/settings-router.tsx
@@ -13,6 +13,7 @@ import { InsightSettingsPage } from "./insight-settings-page";
 import { LLMFeedbackPage } from "./llm-feedback-page";
 import { MemberSettingsPage } from "./MemberSettingsPage";
 import { MyProfilePage } from "./my-profile-page";
+import { PlatformProfilesPage } from "./platform-profiles-page";
 import { ProjectSettingsDetailsPage } from "./project-settings-details-page";
 import { ProjectSettingsPage } from "./project-settings-page";
 import { RDFMapPage } from "./rdf-map-page";
@@ -44,6 +45,7 @@ const SETTINGS_COMPONETS = {
 	"team-permissions/:type/:id": TeamSettingsDetailPage,
 	"view-rdf-map": RDFMapPage,
 	"llm-feedback": LLMFeedbackPage,
+	"platform-profiles": PlatformProfilesPage,
 
 	// engine
 	database: () => <EngineSettingsIndexPage type="DATABASE" />,

--- a/packages/client/src/pages/settings/settings.constants.ts
+++ b/packages/client/src/pages/settings/settings.constants.ts
@@ -10,6 +10,7 @@ import {
 	mdiDatabaseSearch,
 	mdiGithub,
 	mdiPalette,
+	mdiShieldAccount,
 	mdiTabletCellphone,
 } from "@mdi/js";
 
@@ -262,6 +263,14 @@ export const SETTINGS_ROUTES: {
 		path: "llm-feedback",
 		description: "Provide feedback on LLM's performance",
 		icon: mdiChatProcessingOutline,
+		history: ["settings/"],
+		admin: true,
+	},
+	{
+		title: "Platform Profiles",
+		path: "platform-profiles",
+		description: "Control which platform pages are visible to each user.",
+		icon: mdiShieldAccount,
 		history: ["settings/"],
 		admin: true,
 	},


### PR DESCRIPTION
## Description

Frontend implementation of the Role-Based Feature Visibility system. Provides two new UI surfaces:

- **App Profiles tab** (App Detail → Profiles): lets app authors/editors define feature flags per profile and assign users to profiles
- **Platform Profiles page** (Admin Settings → Platform Profiles): lets admins control which top-level nav items are visible to each user

Also wires `GetUserPlatformFeatures()` into `AuthenticatedLayout` so nav items are gated immediately at login.

---

## Changes Made

### New Files
- **`packages/client/src/pages/app/app-profiles-page.tsx`** — Thin wrapper page that passes `appId` and `permission` to the profiles component
- **`packages/client/src/pages/app/app-detail-tabs/profiles.tsx`** — Two-panel layout: left = profile list (create, edit, delete with confirmation), right = Features tab (toggle switches per feature key) and Members tab (assign/remove users with confirmation dialogs)
- **`packages/client/src/pages/settings/platform-profiles-page.tsx`** — Same two-panel layout for platform profiles; right panel shows the 5 predefined nav feature keys as labeled toggle switches

### Modified Files
- **`app-detail.constants.ts`** — Added `Profiles` tab (`restrict: ["author", "editor"]`) after Access Control
- **`settings-router.tsx`** — Added `platform-profiles` route component mapping
- **`settings.constants.ts`** — Added Platform Profiles settings entry (`admin: true`, `icon: mdiShieldAccount`)
- **`AuthenticatedLayout.tsx`** — Calls `GetUserPlatformFeatures()` once per authenticated session; stores result in `PlatformFeaturesContext` for nav gating

### UI Component Usage
All components from `@semoss/ui/next`:
- `Tabs` / `TabsList` / `TabsTrigger` / `TabsContent` — replaces raw button tabs
- `Switch` — replaces custom CSS toggle switches
- `Dialog` / `DialogContent` / `DialogHeader` / `DialogFooter` — replaces `confirm()` browser dialogs for delete/remove confirmations
- `Input` — replaces raw `<input>` elements
- `Label` + `Checkbox` — for the "Set as default" toggle in profile forms
- `Badge` — for Default profile badge and user count display
- `Table` / `TableHeader` / `TableBody` / `TableRow` / `TableCell` — for members list
- `Tooltip` / `TooltipTrigger` / `TooltipContent` — explains disabled delete buttons
- Lucide `Pencil`, `Trash2`, `UserPlus` icons — replaces raw emoji characters
- `useId()` — unique form element IDs (biome `useUniqueElementIds` compliance)

---

## How to Test

### Prerequisites
Start the app and create an app profile in the backend:
```
CreateAppProfile(app="<your-app-id>", name="beta", isDefault=false);
CreateAppProfile(app="<your-app-id>", name="standard", isDefault=true);
CreateAppFeature(app="<your-app-id>", key="export-csv");
```

### App Profiles Tab
1. Open any app you own → App Detail → **Profiles** tab (should appear between Access Control and Files)
2. Both profiles should appear in the left panel with user count badges
3. "standard" should show a "Default" badge
4. Click a profile → right panel shows Features and Members tabs
5. In Features: toggle the `export-csv` feature on/off — fires `SetProfileFeature` immediately
6. Click **Add Feature** → enter `new-feature` → verify key validates (alphanumeric+hyphens only)
7. Click **Add Feature** with invalid key like `bad key!` → inline validation error
8. In Members: click **Assign User** → enter a valid user ID → user appears in table
9. Click **Remove** on a user → confirmation dialog appears before removal
10. Click the trash icon on a profile with users → trash is disabled with tooltip
11. Click the trash icon on a profile with 0 users → confirmation dialog → profile deleted

### Platform Profiles (Admin only)
1. Login as admin → Settings → **Platform Profiles** (gear icon section)
2. Click **New Profile** → create "catalog-only"
3. Select the profile → Platform Features tab shows 5 toggles (App Catalog, Build, Skills, Settings, Engines) — all OFF by default
4. Toggle "App Catalog" ON — fires `SetPlatformFeature`
5. Members tab → assign a user → user appears in table
6. Log out and log back in as that user → only App Catalog nav item should be visible

### Platform feature gating
Users with no platform profile assigned see all nav items (fail-open — `GetUserPlatformFeatures` returns all keys = true for unassigned users).

### Input sanitization
All user-typed strings (profile names, descriptions, user IDs) pass through `sanitizeForPixel` before being included in Pixel expressions. Feature keys additionally validate against `^[a-zA-Z0-9-]+$` inline before submission.

---

## Notes

- The Profiles tab is only visible to users with `author` or `editor` access to the app (matches `restrict: ["author", "editor"]` in `app-detail.constants.ts`)
- Platform Profiles settings page is `admin: true` — only admins see it in the settings nav
- Platform profile enforcement is UI-only in Phase 1. Users who bookmark a URL can still navigate to it directly. Server-side enforcement is Phase 2.
- `GetPlatformProfileUsers` was added to the backend in the companion Semoss PR (PR #2668, latest commit). The Members tab in the platform profiles page depends on it.