### PR TITLE
Chat page feedback

### DIFF
--- a/libs/i18n/src/resources/locales/ar/playground/workspace.json
+++ b/libs/i18n/src/resources/locales/ar/playground/workspace.json
@@ -78,10 +78,7 @@
 		"pin": "إضافة إلى المفضلة",
 		"unpin": "إزالة من المفضلة",
 		"pinFailed": "فشل إضافة الدردشة إلى المفضلة",
-		"unpinFailed": "فشل إزالة الدردشة من المفضلة",
-		"dayToday": "اليوم",
-		"dayYesterday": "أمس",
-		"daysAgo": "قبل {{count}} يوم"
+		"unpinFailed": "فشل إزالة الدردشة من المفضلة"
 	},
 	"images": {
 		"agentIllustration": "توضيح الوكيل"
@@ -146,6 +143,8 @@
 		"title": "جميع الدردشات",
 		"subtitle": "تصفّح دردشاتك وابحث فيها ونظّفها.",
 		"selectAll": "تحديد الكل",
+		"deselectAll": "إلغاء تحديد الكل",
+		"favorites": "المفضلة",
 		"selectChat": "تحديد الدردشة {{name}}",
 		"selectedCount": "تم تحديد {{count}}",
 		"totalCount": "{{count}} دردشات",

--- a/libs/i18n/src/resources/locales/en/playground/workspace.json
+++ b/libs/i18n/src/resources/locales/en/playground/workspace.json
@@ -78,10 +78,7 @@
 		"pin": "Favorite",
 		"unpin": "Unfavorite",
 		"pinFailed": "Failed to favorite chat",
-		"unpinFailed": "Failed to unfavorite chat",
-		"dayToday": "Today",
-		"dayYesterday": "Yesterday",
-		"daysAgo": "{{count}} days ago"
+		"unpinFailed": "Failed to unfavorite chat"
 	},
 	"images": {
 		"agentIllustration": "Agent illustration"

--- a/libs/i18n/src/resources/locales/en/playground/workspace.json
+++ b/libs/i18n/src/resources/locales/en/playground/workspace.json
@@ -146,6 +146,8 @@
 		"title": "All chats",
 		"subtitle": "Browse, search, and clean up your chats.",
 		"selectAll": "Select all",
+		"deselectAll": "Deselect all",
+		"favorites": "Favorites",
 		"selectChat": "Select chat {{name}}",
 		"selectedCount": "{{count}} selected",
 		"totalCount": "{{count}} chats",

--- a/libs/i18n/src/resources/locales/es/playground/workspace.json
+++ b/libs/i18n/src/resources/locales/es/playground/workspace.json
@@ -78,10 +78,7 @@
 		"pin": "Marcar como favorito",
 		"unpin": "Quitar de favoritos",
 		"pinFailed": "Error al marcar como favorito",
-		"unpinFailed": "Error al quitar de favoritos",
-		"dayToday": "Hoy",
-		"dayYesterday": "Ayer",
-		"daysAgo": "Hace {{count}} días"
+		"unpinFailed": "Error al quitar de favoritos"
 	},
 	"images": {
 		"agentIllustration": "Ilustración del agente"
@@ -146,6 +143,8 @@
 		"title": "Todos los chats",
 		"subtitle": "Explora, busca y limpia tus chats.",
 		"selectAll": "Seleccionar todo",
+		"deselectAll": "Deseleccionar todo",
+		"favorites": "Favoritos",
 		"selectChat": "Seleccionar chat {{name}}",
 		"selectedCount": "{{count}} seleccionados",
 		"totalCount": "{{count}} chats",

--- a/libs/i18n/src/resources/locales/fr/playground/workspace.json
+++ b/libs/i18n/src/resources/locales/fr/playground/workspace.json
@@ -78,10 +78,7 @@
 		"pin": "Ajouter aux favoris",
 		"unpin": "Retirer des favoris",
 		"pinFailed": "Échec de l'ajout aux favoris",
-		"unpinFailed": "Échec du retrait des favoris",
-		"dayToday": "Aujourd'hui",
-		"dayYesterday": "Hier",
-		"daysAgo": "Il y a {{count}} jours"
+		"unpinFailed": "Échec du retrait des favoris"
 	},
 	"images": {
 		"agentIllustration": "Illustration de l'agent"
@@ -146,6 +143,8 @@
 		"title": "Toutes les discussions",
 		"subtitle": "Parcourez, recherchez et nettoyez vos discussions.",
 		"selectAll": "Tout sélectionner",
+		"deselectAll": "Tout désélectionner",
+		"favorites": "Favoris",
 		"selectChat": "Sélectionner la discussion {{name}}",
 		"selectedCount": "{{count}} sélectionnée(s)",
 		"totalCount": "{{count}} discussions",

--- a/libs/i18n/src/resources/locales/hi/playground/workspace.json
+++ b/libs/i18n/src/resources/locales/hi/playground/workspace.json
@@ -78,10 +78,7 @@
 		"pin": "पसंदीदा में जोड़ें",
 		"unpin": "पसंदीदा से हटाएं",
 		"pinFailed": "चैट को पसंदीदा बनाने में विफल",
-		"unpinFailed": "चैट को पसंदीदा से हटाने में विफल",
-		"dayToday": "आज",
-		"dayYesterday": "कल",
-		"daysAgo": "{{count}} दिन पहले"
+		"unpinFailed": "चैट को पसंदीदा से हटाने में विफल"
 	},
 	"images": {
 		"agentIllustration": "एजेंट चित्रण"
@@ -146,6 +143,8 @@
 		"title": "सभी चैट",
 		"subtitle": "अपनी चैट ब्राउज़ करें, खोजें और साफ़ करें।",
 		"selectAll": "सभी चुनें",
+		"deselectAll": "सभी अचयनित करें",
+		"favorites": "पसंदीदा",
 		"selectChat": "चैट {{name}} चुनें",
 		"selectedCount": "{{count}} चुनी गई",
 		"totalCount": "{{count}} चैट",

--- a/libs/i18n/src/resources/locales/ja/playground/workspace.json
+++ b/libs/i18n/src/resources/locales/ja/playground/workspace.json
@@ -78,10 +78,7 @@
 		"pin": "お気に入りに追加",
 		"unpin": "お気に入りから削除",
 		"pinFailed": "お気に入りの登録に失敗しました",
-		"unpinFailed": "お気に入りの解除に失敗しました",
-		"dayToday": "今日",
-		"dayYesterday": "昨日",
-		"daysAgo": "{{count}}日前"
+		"unpinFailed": "お気に入りの解除に失敗しました"
 	},
 	"images": {
 		"agentIllustration": "エージェントのイラスト"
@@ -146,6 +143,8 @@
 		"title": "すべてのチャット",
 		"subtitle": "チャットの閲覧・検索・整理ができます。",
 		"selectAll": "すべて選択",
+		"deselectAll": "すべて選択解除",
+		"favorites": "お気に入り",
 		"selectChat": "チャット「{{name}}」を選択",
 		"selectedCount": "{{count}} 件選択",
 		"totalCount": "{{count}} 件のチャット",

--- a/libs/i18n/src/resources/locales/nl/playground/workspace.json
+++ b/libs/i18n/src/resources/locales/nl/playground/workspace.json
@@ -78,10 +78,7 @@
 		"pin": "Favoriet",
 		"unpin": "Favoriet verwijderen",
 		"pinFailed": "Chat als favoriet markeren mislukt",
-		"unpinFailed": "Favoriet verwijderen van chat mislukt",
-		"dayToday": "Vandaag",
-		"dayYesterday": "Gisteren",
-		"daysAgo": "{{count}} dagen geleden"
+		"unpinFailed": "Favoriet verwijderen van chat mislukt"
 	},
 	"images": {
 		"agentIllustration": "Agentillustratie"
@@ -146,6 +143,8 @@
 		"title": "Alle chats",
 		"subtitle": "Blader door, zoek en ruim uw chats op.",
 		"selectAll": "Alles selecteren",
+		"deselectAll": "Alles deselecteren",
+		"favorites": "Favorieten",
 		"selectChat": "Chat {{name}} selecteren",
 		"selectedCount": "{{count}} geselecteerd",
 		"totalCount": "{{count}} chats",

--- a/packages/playground/src/components/chats/chat-row.tsx
+++ b/packages/playground/src/components/chats/chat-row.tsx
@@ -178,7 +178,6 @@ export const ChatRow = ({
 				tabIndex={-1}
 				aria-label={t("workspace:chats.selectChat", {
 					name: room.ROOM_NAME,
-					defaultValue: "Select chat {{name}}",
 				})}
 				onClick={(e) => {
 					e.preventDefault();
@@ -200,7 +199,6 @@ export const ChatRow = ({
 					onClick={(e) => e.stopPropagation()}
 					aria-label={t("workspace:chats.selectChat", {
 						name: room.ROOM_NAME,
-						defaultValue: "Select chat {{name}}",
 					})}
 					className={CHECKBOX_CLASS}
 				/>

--- a/packages/playground/src/components/chats/chat-row.tsx
+++ b/packages/playground/src/components/chats/chat-row.tsx
@@ -1,0 +1,278 @@
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import {
+	ArrowRightIcon,
+	CheckIcon,
+	PencilIcon,
+	StarIcon,
+	XIcon,
+} from "lucide-react";
+import { Link } from "react-router-dom";
+import {
+	Button,
+	Checkbox,
+	cn,
+	Input,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@semoss/ui/next";
+
+dayjs.extend(relativeTime);
+
+export interface RoomItem {
+	ROOM_ID: string;
+	ROOM_NAME: string;
+	DATE_CREATED: string;
+	WORKSPACE_ID?: string;
+	PINNED?: boolean;
+}
+
+export type TFn = (key: string, params?: Record<string, unknown>) => string;
+
+// Default-size checkbox with a slightly stronger border than the faint
+// default, so the selection affordance stays distinct against the card
+// without reading as a chunky form control.
+export const CHECKBOX_CLASS =
+	"border-muted-foreground/50 hover:border-muted-foreground";
+
+/** Parse a room timestamp, normalizing to UTC when no zone is present. */
+export const roomTime = (raw: string) =>
+	dayjs(raw.endsWith("Z") ? raw : `${raw}Z`);
+
+interface ChatRowProps {
+	t: TFn;
+	room: RoomItem;
+	isSelected: boolean;
+	isPinned: boolean;
+	isEditing: boolean;
+	editingName: string;
+	setEditingName: (next: string) => void;
+	isRenaming: boolean;
+	onToggleSelect: () => void;
+	onTogglePin: () => void;
+	onStartRename: () => void;
+	onCancelRename: () => void;
+	onSaveRename: () => void;
+}
+
+/**
+ * A single chat row on the all-chats page: select checkbox, name + date,
+ * favorite (pin) toggle, inline rename, and navigation to the room.
+ */
+export const ChatRow = ({
+	t,
+	room,
+	isSelected,
+	isPinned,
+	isEditing,
+	editingName,
+	setEditingName,
+	isRenaming,
+	onToggleSelect,
+	onTogglePin,
+	onStartRename,
+	onCancelRename,
+	onSaveRename,
+}: ChatRowProps) => {
+	const d = roomTime(room.DATE_CREATED);
+	const relative = d.isValid() ? d.fromNow() : room.DATE_CREATED;
+	const absolute = d.isValid()
+		? d.format("MMM D, YYYY h:mm A")
+		: room.DATE_CREATED;
+
+	if (isEditing) {
+		return (
+			<div className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2">
+				<Input
+					autoFocus
+					value={editingName}
+					disabled={isRenaming}
+					onChange={(e) => setEditingName(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter") {
+							e.preventDefault();
+							onSaveRename();
+						} else if (e.key === "Escape") {
+							onCancelRename();
+						}
+					}}
+					className="h-8 flex-1"
+				/>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon-sm"
+							disabled={isRenaming}
+							onClick={onSaveRename}
+							aria-label={t("workspace:chat.renameSave")}
+						>
+							<CheckIcon className="size-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>
+						{t("workspace:chat.renameSave")}
+					</TooltipContent>
+				</Tooltip>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon-sm"
+							disabled={isRenaming}
+							onClick={onCancelRename}
+							aria-label={t("workspace:chat.cancel")}
+						>
+							<XIcon className="size-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>
+						{t("workspace:chat.cancel")}
+					</TooltipContent>
+				</Tooltip>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className={cn(
+				"group/row relative flex min-w-0 items-center rounded-lg border border-border bg-card transition-colors hover:border-border/80 hover:bg-accent/40",
+				isSelected && "border-primary bg-accent/30",
+			)}
+		>
+			{/* Stretched link covers the WHOLE row but z-0, so anything with
+			    z-[1] above it intercepts clicks before the link does. */}
+			<Link
+				to={`/room/${room.ROOM_ID}`}
+				aria-label={t("workspace:chat.selectRoom")}
+				className="absolute inset-0 z-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+			/>
+
+			{/* Left select zone — wider hit area for the checkbox. Clicking
+			    anywhere here toggles selection instead of opening the room. */}
+			{/* biome-ignore lint/a11y/useSemanticElements: cannot use a real <button> here — it would wrap the interactive Checkbox component, which is itself a button (Radix renders <button role="checkbox">). Nested buttons are invalid HTML. The role + tabIndex + aria-label + onKeyDown gives equivalent a11y semantics. */}
+			<div
+				role="button"
+				tabIndex={-1}
+				aria-label={t("workspace:chats.selectChat", {
+					name: room.ROOM_NAME,
+					defaultValue: "Select chat {{name}}",
+				})}
+				onClick={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					onToggleSelect();
+				}}
+				onKeyDown={(e) => {
+					if (e.key === "Enter" || e.key === " ") {
+						e.preventDefault();
+						e.stopPropagation();
+						onToggleSelect();
+					}
+				}}
+				className="relative z-1 flex shrink-0 cursor-pointer items-center py-2.5 @md:ps-4 ps-3 @md:pe-3 pe-2.5"
+			>
+				<Checkbox
+					checked={isSelected}
+					onCheckedChange={onToggleSelect}
+					onClick={(e) => e.stopPropagation()}
+					aria-label={t("workspace:chats.selectChat", {
+						name: room.ROOM_NAME,
+						defaultValue: "Select chat {{name}}",
+					})}
+					className={CHECKBOX_CLASS}
+				/>
+			</div>
+
+			{/* Name + date — link covers this area for navigation */}
+			<div className="pointer-events-none relative z-1 flex min-w-0 flex-1 flex-col py-2.5">
+				<div
+					dir="auto"
+					className="truncate font-semibold text-foreground text-sm leading-tight"
+					title={room.ROOM_NAME}
+				>
+					{room.ROOM_NAME}
+				</div>
+				<div
+					className="text-muted-foreground text-xs leading-tight"
+					title={absolute}
+				>
+					{relative}
+				</div>
+			</div>
+
+			{/* Right actions: pin (always visible) + rename (always visible)
+			    + arrow. Wrapper is `pointer-events-none` so clicks on the
+			    arrow (purely visual) fall through to the stretched Link and
+			    navigate to the room. Each Button re-enables events on itself
+			    via `pointer-events-auto`. */}
+			<div className="pointer-events-none relative z-1 flex shrink-0 items-center gap-0.5 @md:pe-3 pe-2">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon-sm"
+							aria-label={
+								isPinned
+									? t("workspace:chat.unpin")
+									: t("workspace:chat.pin")
+							}
+							className={cn(
+								"pointer-events-auto hover:text-yellow-500",
+								isPinned
+									? "text-yellow-500"
+									: "text-muted-foreground",
+							)}
+							onClick={(e) => {
+								e.preventDefault();
+								e.stopPropagation();
+								onTogglePin();
+							}}
+							data-testid={`chats-page--pin-${room.ROOM_ID}`}
+						>
+							<StarIcon
+								className={cn(
+									"size-4",
+									isPinned && "fill-yellow-500",
+								)}
+							/>
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>
+						{isPinned
+							? t("workspace:chat.unpin")
+							: t("workspace:chat.pin")}
+					</TooltipContent>
+				</Tooltip>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon-sm"
+							aria-label={t("workspace:chat.rename")}
+							className="pointer-events-auto text-muted-foreground hover:text-foreground"
+							onClick={(e) => {
+								e.preventDefault();
+								e.stopPropagation();
+								onStartRename();
+							}}
+							data-testid={`chats-page--rename-${room.ROOM_ID}`}
+						>
+							<PencilIcon className="size-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>
+						{t("workspace:chat.rename")}
+					</TooltipContent>
+				</Tooltip>
+				<ArrowRightIcon className="rtl:-scale-x-100 ms-1 size-4 shrink-0 text-muted-foreground transition-colors group-hover/row:text-foreground" />
+			</div>
+		</div>
+	);
+};

--- a/packages/playground/src/components/chats/chat-row.tsx
+++ b/packages/playground/src/components/chats/chat-row.tsx
@@ -1,5 +1,3 @@
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
 import {
 	ArrowRightIcon,
 	CheckIcon,
@@ -8,6 +6,7 @@ import {
 	XIcon,
 } from "lucide-react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "@semoss/i18n";
 import {
 	Button,
 	Checkbox,
@@ -17,8 +16,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@semoss/ui/next";
-
-dayjs.extend(relativeTime);
+import { normalizeTimestamp } from "@/utility";
 
 export interface RoomItem {
 	ROOM_ID: string;
@@ -28,20 +26,13 @@ export interface RoomItem {
 	PINNED?: boolean;
 }
 
-export type TFn = (key: string, params?: Record<string, unknown>) => string;
-
 // Default-size checkbox with a slightly stronger border than the faint
 // default, so the selection affordance stays distinct against the card
 // without reading as a chunky form control.
 export const CHECKBOX_CLASS =
 	"border-muted-foreground/50 hover:border-muted-foreground";
 
-/** Parse a room timestamp, normalizing to UTC when no zone is present. */
-export const roomTime = (raw: string) =>
-	dayjs(raw.endsWith("Z") ? raw : `${raw}Z`);
-
 interface ChatRowProps {
-	t: TFn;
 	room: RoomItem;
 	isSelected: boolean;
 	isPinned: boolean;
@@ -61,7 +52,6 @@ interface ChatRowProps {
  * favorite (pin) toggle, inline rename, and navigation to the room.
  */
 export const ChatRow = ({
-	t,
 	room,
 	isSelected,
 	isPinned,
@@ -75,7 +65,8 @@ export const ChatRow = ({
 	onCancelRename,
 	onSaveRename,
 }: ChatRowProps) => {
-	const d = roomTime(room.DATE_CREATED);
+	const { t } = useTranslation("workspace");
+	const d = normalizeTimestamp(room.DATE_CREATED);
 	const relative = d.isValid() ? d.fromNow() : room.DATE_CREATED;
 	const absolute = d.isValid()
 		? d.format("MMM D, YYYY h:mm A")

--- a/packages/playground/src/components/chats/chat-row.tsx
+++ b/packages/playground/src/components/chats/chat-row.tsx
@@ -5,6 +5,7 @@ import {
 	StarIcon,
 	XIcon,
 } from "lucide-react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "@semoss/i18n";
 import {
@@ -15,7 +16,9 @@ import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
+	toast,
 } from "@semoss/ui/next";
+import { useChat } from "@/hooks";
 import { normalizeTimestamp } from "@/utility";
 
 export interface RoomItem {
@@ -36,36 +39,60 @@ interface ChatRowProps {
 	room: RoomItem;
 	isSelected: boolean;
 	isPinned: boolean;
-	isEditing: boolean;
-	editingName: string;
-	setEditingName: (next: string) => void;
-	isRenaming: boolean;
 	onToggleSelect: () => void;
 	onTogglePin: () => void;
-	onStartRename: () => void;
-	onCancelRename: () => void;
-	onSaveRename: () => void;
 }
 
 /**
  * A single chat row on the all-chats page: select checkbox, name + date,
  * favorite (pin) toggle, inline rename, and navigation to the room.
+ *
+ * Inline rename is owned here — it's per-row, ephemeral state. Saving runs
+ * `chat.renameRoom`, which bumps the room counter so any list watching it
+ * (the chats page, the sidebar) refetches on its own.
  */
 export const ChatRow = ({
 	room,
 	isSelected,
 	isPinned,
-	isEditing,
-	editingName,
-	setEditingName,
-	isRenaming,
 	onToggleSelect,
 	onTogglePin,
-	onStartRename,
-	onCancelRename,
-	onSaveRename,
 }: ChatRowProps) => {
 	const { t } = useTranslation("workspace");
+	const { chat } = useChat();
+
+	const [isEditing, setIsEditing] = useState(false);
+	const [editingName, setEditingName] = useState("");
+	const [isRenaming, setIsRenaming] = useState(false);
+
+	const handleStartRename = () => {
+		setEditingName(room.ROOM_NAME);
+		setIsEditing(true);
+	};
+
+	const handleCancelRename = () => {
+		setIsEditing(false);
+		setEditingName("");
+	};
+
+	const handleSaveRename = async () => {
+		const trimmed = editingName.trim();
+		if (!trimmed) {
+			toast.error(t("workspace:chat.renameEmpty"));
+			return;
+		}
+		setIsRenaming(true);
+		try {
+			await chat.renameRoom(room.ROOM_ID, trimmed);
+			toast.success(t("workspace:chat.renameSuccess"));
+			handleCancelRename();
+		} catch {
+			toast.error(t("workspace:chat.renameFailed"));
+		} finally {
+			setIsRenaming(false);
+		}
+	};
+
 	const d = normalizeTimestamp(room.DATE_CREATED);
 	const relative = d.isValid() ? d.fromNow() : room.DATE_CREATED;
 	const absolute = d.isValid()
@@ -74,7 +101,7 @@ export const ChatRow = ({
 
 	if (isEditing) {
 		return (
-			<div className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2">
+			<div className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2.5">
 				<Input
 					autoFocus
 					value={editingName}
@@ -83,9 +110,9 @@ export const ChatRow = ({
 					onKeyDown={(e) => {
 						if (e.key === "Enter") {
 							e.preventDefault();
-							onSaveRename();
+							handleSaveRename();
 						} else if (e.key === "Escape") {
-							onCancelRename();
+							handleCancelRename();
 						}
 					}}
 					className="h-8 flex-1"
@@ -97,7 +124,7 @@ export const ChatRow = ({
 							variant="ghost"
 							size="icon-sm"
 							disabled={isRenaming}
-							onClick={onSaveRename}
+							onClick={handleSaveRename}
 							aria-label={t("workspace:chat.renameSave")}
 						>
 							<CheckIcon className="size-4" />
@@ -114,7 +141,7 @@ export const ChatRow = ({
 							variant="ghost"
 							size="icon-sm"
 							disabled={isRenaming}
-							onClick={onCancelRename}
+							onClick={handleCancelRename}
 							aria-label={t("workspace:chat.cancel")}
 						>
 							<XIcon className="size-4" />
@@ -251,7 +278,7 @@ export const ChatRow = ({
 							onClick={(e) => {
 								e.preventDefault();
 								e.stopPropagation();
-								onStartRename();
+								handleStartRename();
 							}}
 							data-testid={`chats-page--rename-${room.ROOM_ID}`}
 						>

--- a/packages/playground/src/components/chats/index.ts
+++ b/packages/playground/src/components/chats/index.ts
@@ -1,0 +1,1 @@
+export * from "./chat-row";

--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -329,13 +329,10 @@ export const GlobalNav = observer(() => {
 		isFavorite: boolean,
 	) => {
 		try {
-			await runPixel(
-				`PinRoom(roomId=["${roomId}"], pinned=[${!isFavorite}]);`,
-			);
-
-			// Refetch rooms after toggling favorite
-			getRooms.reset();
-			getPinnedRooms.reset();
+			// pinRoom bumps roomCounter, which the effect above watches to
+			// refetch both room queries here — and keeps the chats page in
+			// sync, so pinning is bidirectional across the two views.
+			await chat.pinRoom(roomId, !isFavorite);
 		} catch {
 			toast.error(
 				isFavorite

--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import {
 	Bot,
 	HelpCircle,
@@ -53,6 +52,7 @@ import {
 	useSidebar,
 } from "@semoss/ui/next";
 import { useChat, useRoot, useTour } from "@/hooks";
+import { normalizeTimestamp } from "@/utility";
 import { AppLogo } from "./app-logo";
 import { GlobalNavItem } from "./global-nav-item";
 import { NavUser } from "./nav-user";
@@ -114,7 +114,7 @@ export const GlobalNav = observer(() => {
 
 	const [deletedSet, setDeletedSet] = useState(new Set<string>());
 
-	const systemDate = dayjs(`${system.config.systemDate}Z`);
+	const systemDate = normalizeTimestamp(system.config.systemDate);
 
 	const navigate = useNavigate();
 
@@ -289,7 +289,7 @@ export const GlobalNav = observer(() => {
 			// Skip rooms handled by the dedicated pinned query
 			if (val.PINNED || pinnedRoomIds.has(val.ROOM_ID)) return acc;
 
-			const d = dayjs(`${val.DATE_CREATED}Z`);
+			const d = normalizeTimestamp(val.DATE_CREATED);
 
 			if (systemDate.isSame(d, "day")) {
 				acc[t("buckets.today")].push(val);
@@ -553,19 +553,21 @@ export const GlobalNav = observer(() => {
 												t("messages.untitled");
 											const date = root.theme.sidebar
 												.chatHistoryDate
-												? new Date(
-														`${room.DATE_CREATED}Z`,
-													).toLocaleString(
-														undefined,
-														{
-															month: "numeric",
-															day: "numeric",
-															year: "numeric",
-															hour: "numeric",
-															minute: "2-digit",
-															hour12: true,
-														},
+												? normalizeTimestamp(
+														room.DATE_CREATED,
 													)
+														.toDate()
+														.toLocaleString(
+															undefined,
+															{
+																month: "numeric",
+																day: "numeric",
+																year: "numeric",
+																hour: "numeric",
+																minute: "2-digit",
+																hour12: true,
+															},
+														)
 												: null;
 											const isFavorite =
 												room.PINNED || false;

--- a/packages/playground/src/components/common/global-nav.tsx
+++ b/packages/playground/src/components/common/global-nav.tsx
@@ -20,7 +20,7 @@ import {
 	useParams,
 } from "react-router-dom";
 import { useTranslation } from "@semoss/i18n";
-import { runPixel, useInsight, useIteratorPixel } from "@semoss/sdk/react";
+import { runPixel, useIteratorPixel } from "@semoss/sdk/react";
 import {
 	Button,
 	DropdownMenu,
@@ -52,7 +52,7 @@ import {
 	useSidebar,
 } from "@semoss/ui/next";
 import { useChat, useRoot, useTour } from "@/hooks";
-import { normalizeTimestamp } from "@/utility";
+import { getDateBucket, normalizeTimestamp } from "@/utility";
 import { AppLogo } from "./app-logo";
 import { GlobalNavItem } from "./global-nav-item";
 import { NavUser } from "./nav-user";
@@ -70,7 +70,6 @@ try {
  * @component
  */
 export const GlobalNav = observer(() => {
-	const { system } = useInsight();
 	const { t } = useTranslation("sidebar");
 
 	const BUCKETS = [
@@ -113,8 +112,6 @@ export const GlobalNav = observer(() => {
 	const [editingName, setEditingName] = useState("");
 
 	const [deletedSet, setDeletedSet] = useState(new Set<string>());
-
-	const systemDate = normalizeTimestamp(system.config.systemDate);
 
 	const navigate = useNavigate();
 
@@ -290,22 +287,8 @@ export const GlobalNav = observer(() => {
 			if (val.PINNED || pinnedRoomIds.has(val.ROOM_ID)) return acc;
 
 			const d = normalizeTimestamp(val.DATE_CREATED);
-
-			if (systemDate.isSame(d, "day")) {
-				acc[t("buckets.today")].push(val);
-			} else if (systemDate.subtract(1, "day").isSame(d, "day")) {
-				acc[t("buckets.yesterday")].push(val);
-			} else if (d.isAfter(systemDate.subtract(3, "day"))) {
-				acc[t("buckets.fewDaysAgo")].push(val);
-			} else if (d.isAfter(systemDate.subtract(7, "day"))) {
-				acc[t("buckets.lastWeek")].push(val);
-			} else if (systemDate.isSame(d, "month")) {
-				acc[t("buckets.thisMonth")].push(val);
-			} else if (systemDate.subtract(1, "month").isSame(d, "month")) {
-				acc[t("buckets.lastMonth")].push(val);
-			} else {
-				acc[t("buckets.older")].push(val);
-			}
+			const bucket = getDateBucket(d);
+			acc[t(`buckets.${bucket}`)].push(val);
 
 			return acc;
 		},

--- a/packages/playground/src/components/index.ts
+++ b/packages/playground/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./chats";
 export * from "./common";
 export * from "./knowledge";
 export * from "./mcp";

--- a/packages/playground/src/components/workspace/workspace-card.tsx
+++ b/packages/playground/src/components/workspace/workspace-card.tsx
@@ -1,5 +1,3 @@
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
 import { PencilIcon, PlusIcon, Trash2Icon } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useState } from "react";
@@ -23,8 +21,7 @@ import {
 	TooltipTrigger,
 } from "@semoss/ui/next";
 import type { Workspace } from "@/types";
-
-dayjs.extend(relativeTime);
+import { normalizeTimestamp } from "@/utility";
 
 interface WorkspaceCardProps {
 	workspace: Pick<Workspace, "workspace_id" | "name" | "description">;
@@ -80,9 +77,7 @@ export const WorkspaceCard = observer(
 
 		const createdLabel = (() => {
 			if (!dateCreated) return null;
-			const d = dayjs(
-				dateCreated.endsWith("Z") ? dateCreated : `${dateCreated}Z`,
-			);
+			const d = normalizeTimestamp(dateCreated);
 			if (!d.isValid()) return null;
 			return t("workspace:card.createdAgo", { when: d.fromNow() });
 		})();

--- a/packages/playground/src/components/workspace/workspace-chat-list.tsx
+++ b/packages/playground/src/components/workspace/workspace-chat-list.tsx
@@ -1,5 +1,3 @@
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
 import {
 	ArrowRightIcon,
 	CheckIcon,
@@ -36,8 +34,7 @@ import {
 	useInfiniteScroll,
 } from "@semoss/ui/next";
 import { useChat } from "@/hooks";
-
-dayjs.extend(relativeTime);
+import { getDayLabel, normalizeTimestamp } from "@/utility";
 
 interface WorkspaceChatListProps {
 	/**
@@ -140,8 +137,7 @@ export const WorkspaceChatList = ({
 			{ label: string; ts: number; rooms: Room[] }
 		>();
 		for (const room of visibleRooms) {
-			const raw = room.date_updated;
-			const d = dayjs(raw.endsWith("Z") ? raw : `${raw}Z`);
+			const d = normalizeTimestamp(room.date_updated);
 			if (!d.isValid()) continue;
 			const startOfDay = d.startOf("day");
 			const key = startOfDay.format("YYYY-MM-DD");
@@ -623,16 +619,4 @@ function ChatRow({
 			</div>
 		</div>
 	);
-}
-
-function getDayLabel(
-	startOfDay: dayjs.Dayjs,
-	t: (key: string, params?: Record<string, unknown>) => string,
-): string {
-	const today = dayjs().startOf("day");
-	const days = today.diff(startOfDay, "day");
-	if (days <= 0) return t("chat.dayToday");
-	if (days === 1) return t("chat.dayYesterday");
-	if (days < 30) return t("chat.daysAgo", { count: days });
-	return startOfDay.format("MMM D, YYYY");
 }

--- a/packages/playground/src/components/workspace/workspace-chat-list.tsx
+++ b/packages/playground/src/components/workspace/workspace-chat-list.tsx
@@ -34,7 +34,11 @@ import {
 	useInfiniteScroll,
 } from "@semoss/ui/next";
 import { useChat } from "@/hooks";
-import { getDayLabel, normalizeTimestamp } from "@/utility";
+import {
+	DATE_BUCKET_ORDER,
+	getDateBucket,
+	normalizeTimestamp,
+} from "@/utility";
 
 interface WorkspaceChatListProps {
 	/**
@@ -67,8 +71,8 @@ interface PinnedRoom {
 }
 
 /**
- * Renders an agent's recent chats as a vertical timeline grouped by
- * calendar day. Each row supports favorite (pin), rename (inline),
+ * Renders an agent's recent chats as a vertical timeline grouped into
+ * date buckets. Each row supports favorite (pin), rename (inline),
  * and delete (confirmed).
  *
  * @component
@@ -78,7 +82,7 @@ export const WorkspaceChatList = ({
 	limit,
 	maxHeightClassName = "max-h-96",
 }: WorkspaceChatListProps) => {
-	const { t } = useTranslation("workspace");
+	const { t } = useTranslation(["workspace", "sidebar"]);
 	const { chat } = useChat();
 
 	const [search, setSearch] = useState("");
@@ -130,27 +134,24 @@ export const WorkspaceChatList = ({
 		[getWorkspaceRooms.data, deletedSet],
 	);
 
-	// Group rooms by calendar day (descending)
+	// Group rooms into date buckets, matching the sidebar.
 	const groups = useMemo(() => {
-		const map = new Map<
-			string,
-			{ label: string; ts: number; rooms: Room[] }
-		>();
+		const byBucket = new Map<string, Room[]>();
 		for (const room of visibleRooms) {
 			const d = normalizeTimestamp(room.date_updated);
 			if (!d.isValid()) continue;
-			const startOfDay = d.startOf("day");
-			const key = startOfDay.format("YYYY-MM-DD");
-			if (!map.has(key)) {
-				map.set(key, {
-					label: getDayLabel(startOfDay, t),
-					ts: startOfDay.valueOf(),
-					rooms: [],
-				});
-			}
-			map.get(key)?.rooms.push(room);
+			const bucket = getDateBucket(d);
+			const rooms = byBucket.get(bucket);
+			if (rooms) rooms.push(room);
+			else byBucket.set(bucket, [room]);
 		}
-		return Array.from(map.values()).sort((a, b) => b.ts - a.ts);
+		return DATE_BUCKET_ORDER.filter((bucket) => byBucket.has(bucket)).map(
+			(bucket) => ({
+				bucket,
+				label: t(`sidebar:buckets.${bucket}`),
+				rooms: byBucket.get(bucket) ?? [],
+			}),
+		);
 	}, [visibleRooms, t]);
 
 	/* Handlers */
@@ -291,7 +292,7 @@ export const WorkspaceChatList = ({
 							{groups.map((g, gi) => {
 								const isLast = gi === groups.length - 1;
 								return (
-									<div key={g.ts} className="flex gap-4">
+									<div key={g.bucket} className="flex gap-4">
 										{/* Timeline column */}
 										<div className="relative flex w-3 shrink-0 flex-col items-center pt-2">
 											<div

--- a/packages/playground/src/pages/chats-page.tsx
+++ b/packages/playground/src/pages/chats-page.tsx
@@ -1,59 +1,56 @@
 import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-import {
-	ArrowRightIcon,
-	CheckIcon,
-	MessagesSquareIcon,
-	PencilIcon,
-	SearchIcon,
-	StarIcon,
-	Trash2Icon,
-	XIcon,
-} from "lucide-react";
+import { SearchIcon, StarIcon, Trash2Icon } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Link } from "react-router-dom";
 import { useTranslation } from "@semoss/i18n";
-import { useIteratorPixel } from "@semoss/sdk/react";
+import { useIteratorPixel, usePixel } from "@semoss/sdk/react";
 import {
 	Button,
 	Checkbox,
-	cn,
 	Dialog,
 	DialogContent,
 	DialogDescription,
 	DialogFooter,
 	DialogHeader,
 	DialogTitle,
-	Input,
 	InputGroup,
 	InputGroupAddon,
 	InputGroupInput,
 	Muted,
-	Separator,
 	Spinner,
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
 	toast,
 	useDebouncedValue,
 	useInfiniteScroll,
 } from "@semoss/ui/next";
+import {
+	CHECKBOX_CLASS,
+	ChatRow,
+	type RoomItem,
+	roomTime,
+	type TFn,
+} from "@/components";
 import { useChat, useGlobalBreadcrumbs } from "@/hooks";
 
-dayjs.extend(relativeTime);
-
-interface RoomItem {
-	ROOM_ID: string;
-	ROOM_NAME: string;
-	DATE_CREATED: string;
-	WORKSPACE_ID?: string;
-	PINNED?: boolean;
-}
+const getDayLabel = (startOfDay: dayjs.Dayjs, t: TFn): string => {
+	const today = dayjs().startOf("day");
+	const days = today.diff(startOfDay, "day");
+	if (days <= 0)
+		return t("workspace:chat.dayToday", { defaultValue: "Today" });
+	if (days === 1)
+		return t("workspace:chat.dayYesterday", { defaultValue: "Yesterday" });
+	if (days < 30)
+		return t("workspace:chat.daysAgo", {
+			count: days,
+			defaultValue: "{{count}} days ago",
+		});
+	return startOfDay.format("MMM D, YYYY");
+};
 
 /**
  * All-chats page.
- * Lists every chat (across all workspaces) with multi-select + bulk delete.
+ * Lists every chat (across all workspaces) grouped into a pinned
+ * section plus calendar-day sections, with multi-select + bulk delete,
+ * inline rename, and pin/unpin.
  */
 export const ChatsPage = observer(() => {
 	const { t } = useTranslation(["workspace", "common"]);
@@ -63,6 +60,7 @@ export const ChatsPage = observer(() => {
 	const debouncedSearch = useDebouncedValue(search);
 	const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 	const [deletedSet, setDeletedSet] = useState<Set<string>>(new Set());
+	const [pinnedIds, setPinnedIds] = useState<Set<string>>(new Set());
 	const [confirmOpen, setConfirmOpen] = useState(false);
 	const [isDeleting, setIsDeleting] = useState(false);
 	const [editingId, setEditingId] = useState<string | null>(null);
@@ -91,6 +89,14 @@ export const ChatsPage = observer(() => {
 		[debouncedSearch],
 	);
 
+	// Full set of pinned rooms across every workspace, independent of the
+	// paginated list above — so the pinned section shows every pinned chat
+	// even before the user scrolls it into view.
+	const getPinnedRooms = usePixel<RoomItem[]>(
+		`META | GetPlaygroundRooms(pinned=[true], sort=["DESC"]);`,
+		{ data: [] },
+	);
+
 	const { setScroll } = useInfiniteScroll({
 		disabled: getRooms.isLoading || !getRooms.hasMore,
 		onNext: () => {
@@ -98,22 +104,90 @@ export const ChatsPage = observer(() => {
 		},
 	});
 
+	// Seed pinned ids from the dedicated pinned query. Toggles update
+	// `pinnedIds` optimistically and never refetch this query, so this
+	// effect won't clobber an in-flight optimistic change.
+	useEffect(() => {
+		if (getPinnedRooms.status !== "SUCCESS" || !getPinnedRooms.data) return;
+		setPinnedIds(new Set(getPinnedRooms.data.map((r) => r.ROOM_ID)));
+	}, [getPinnedRooms.status, getPinnedRooms.data]);
+
+	// Lookup of room metadata, preferring the freshest (paginated) data but
+	// falling back to the pinned query for pinned rooms not yet paged in.
+	const roomById = useMemo(() => {
+		const map = new Map<string, RoomItem>();
+		for (const r of getPinnedRooms.data ?? []) map.set(r.ROOM_ID, r);
+		for (const r of getRooms.data) map.set(r.ROOM_ID, r);
+		return map;
+	}, [getPinnedRooms.data, getRooms.data]);
+
 	const visibleRooms = useMemo(
 		() => getRooms.data.filter((r) => !deletedSet.has(r.ROOM_ID)),
 		[getRooms.data, deletedSet],
 	);
 
+	// While searching, drop the dedicated pinned section so results aren't
+	// split confusingly — matches still show their star inline.
+	const isSearching = debouncedSearch.length > 0;
+
+	const pinnedRooms = useMemo(() => {
+		if (isSearching) return [];
+		return Array.from(pinnedIds)
+			.filter((id) => !deletedSet.has(id))
+			.map((id) => roomById.get(id))
+			.filter((r): r is RoomItem => Boolean(r))
+			.sort(
+				(a, b) =>
+					roomTime(b.DATE_CREATED).valueOf() -
+					roomTime(a.DATE_CREATED).valueOf(),
+			);
+	}, [pinnedIds, deletedSet, roomById, isSearching]);
+
+	// Date-grouped, non-pinned rooms (descending by day).
+	const groups = useMemo(() => {
+		const map = new Map<
+			string,
+			{ label: string; ts: number; rooms: RoomItem[] }
+		>();
+		for (const room of visibleRooms) {
+			if (!isSearching && pinnedIds.has(room.ROOM_ID)) continue;
+			const d = roomTime(room.DATE_CREATED);
+			if (!d.isValid()) continue;
+			const startOfDay = d.startOf("day");
+			const key = startOfDay.format("YYYY-MM-DD");
+			if (!map.has(key)) {
+				map.set(key, {
+					label: getDayLabel(startOfDay, t),
+					ts: startOfDay.valueOf(),
+					rooms: [],
+				});
+			}
+			map.get(key)?.rooms.push(room);
+		}
+		return Array.from(map.values()).sort((a, b) => b.ts - a.ts);
+	}, [visibleRooms, pinnedIds, isSearching, t]);
+
+	const allVisibleIds = useMemo(() => {
+		const ids: string[] = [];
+		for (const r of pinnedRooms) ids.push(r.ROOM_ID);
+		for (const g of groups) for (const r of g.rooms) ids.push(r.ROOM_ID);
+		return ids;
+	}, [pinnedRooms, groups]);
+
+	const hasRooms = allVisibleIds.length > 0;
 	const hasSelection = selectedIds.size > 0;
 	const allSelected =
-		visibleRooms.length > 0 &&
-		selectedIds.size >= visibleRooms.length &&
-		visibleRooms.every((r) => selectedIds.has(r.ROOM_ID));
+		hasRooms && allVisibleIds.every((id) => selectedIds.has(id));
 
 	const clearSelection = useCallback(() => setSelectedIds(new Set()), []);
 	const selectAll = useCallback(
-		() => setSelectedIds(new Set(visibleRooms.map((r) => r.ROOM_ID))),
-		[visibleRooms],
+		() => setSelectedIds(new Set(allVisibleIds)),
+		[allVisibleIds],
 	);
+	const toggleSelectAll = useCallback(() => {
+		if (allSelected) clearSelection();
+		else selectAll();
+	}, [allSelected, clearSelection, selectAll]);
 
 	// Re-fetch when roomCounter increments (create / rename / delete from
 	// anywhere in the app) without clearing the list first. reset()
@@ -126,7 +200,8 @@ export const ChatsPage = observer(() => {
 			return;
 		}
 		getRooms.reset();
-	}, [getRooms.reset, chat.keys.roomCounter]);
+		getPinnedRooms.refresh();
+	}, [getRooms.reset, getPinnedRooms.refresh, chat.keys.roomCounter]);
 
 	// Keyboard shortcuts: Esc clears the current selection;
 	// Cmd/Ctrl+A selects all visible chats (only when focus isn't
@@ -154,7 +229,7 @@ export const ChatsPage = observer(() => {
 				(e.metaKey || e.ctrlKey) &&
 				e.key.toLowerCase() === "a" &&
 				!inEditableField &&
-				visibleRooms.length > 0
+				hasRooms
 			) {
 				e.preventDefault();
 				selectAll();
@@ -162,7 +237,7 @@ export const ChatsPage = observer(() => {
 		};
 		window.addEventListener("keydown", onKey);
 		return () => window.removeEventListener("keydown", onKey);
-	}, [hasSelection, editingId, visibleRooms, clearSelection, selectAll]);
+	}, [hasSelection, editingId, hasRooms, clearSelection, selectAll]);
 
 	const toggleSelectOne = (roomId: string) => {
 		setSelectedIds((prev) => {
@@ -171,6 +246,31 @@ export const ChatsPage = observer(() => {
 			else next.add(roomId);
 			return next;
 		});
+	};
+
+	const handleTogglePin = async (roomId: string) => {
+		const wasPinned = pinnedIds.has(roomId);
+		setPinnedIds((prev) => {
+			const next = new Set(prev);
+			if (wasPinned) next.delete(roomId);
+			else next.add(roomId);
+			return next;
+		});
+		try {
+			await chat.pinRoom(roomId, !wasPinned);
+		} catch {
+			setPinnedIds((prev) => {
+				const next = new Set(prev);
+				if (wasPinned) next.add(roomId);
+				else next.delete(roomId);
+				return next;
+			});
+			toast.error(
+				wasPinned
+					? t("workspace:chat.unpinFailed")
+					: t("workspace:chat.pinFailed"),
+			);
+		}
 	};
 
 	const handleConfirmDelete = async () => {
@@ -215,6 +315,7 @@ export const ChatsPage = observer(() => {
 		setConfirmOpen(false);
 		setIsDeleting(false);
 		getRooms.reset();
+		getPinnedRooms.refresh();
 	};
 
 	const handleStartRename = (room: RoomItem) => {
@@ -241,12 +342,32 @@ export const ChatsPage = observer(() => {
 			setEditingId(null);
 			setEditingName("");
 			getRooms.reset();
+			getPinnedRooms.refresh();
 		} catch {
 			toast.error(t("workspace:chat.renameFailed"));
 		} finally {
 			setIsRenaming(false);
 		}
 	};
+
+	const renderRow = (room: RoomItem) => (
+		<ChatRow
+			key={room.ROOM_ID}
+			t={t}
+			room={room}
+			isSelected={selectedIds.has(room.ROOM_ID)}
+			isPinned={pinnedIds.has(room.ROOM_ID)}
+			isEditing={editingId === room.ROOM_ID}
+			editingName={editingName}
+			setEditingName={setEditingName}
+			isRenaming={isRenaming}
+			onToggleSelect={() => toggleSelectOne(room.ROOM_ID)}
+			onTogglePin={() => handleTogglePin(room.ROOM_ID)}
+			onStartRename={() => handleStartRename(room)}
+			onCancelRename={handleCancelRename}
+			onSaveRename={handleSaveRename}
+		/>
+	);
 
 	return (
 		<div
@@ -287,13 +408,77 @@ export const ChatsPage = observer(() => {
 					</InputGroupAddon>
 				</InputGroup>
 
+				{/* Select-all toolbar — always visible so the user can select
+				    every chat without first selecting one. */}
+				{hasRooms && (
+					<div className="flex h-8 items-center gap-3 px-1">
+						<Checkbox
+							checked={allSelected}
+							onCheckedChange={toggleSelectAll}
+							aria-label={t("workspace:chats.selectAll", {
+								defaultValue: "Select all",
+							})}
+							className={CHECKBOX_CLASS}
+							data-testid="chats-page--select-all-checkbox"
+						/>
+						<button
+							type="button"
+							onClick={toggleSelectAll}
+							className="font-medium text-foreground text-sm hover:text-foreground/80"
+						>
+							{allSelected
+								? t("workspace:chats.deselectAll", {
+										defaultValue: "Deselect all",
+									})
+								: t("workspace:chats.selectAll", {
+										defaultValue: "Select all",
+									})}
+						</button>
+						{hasSelection && (
+							<>
+								<span className="text-muted-foreground text-sm">
+									{t("workspace:chats.selectedCount", {
+										count: selectedIds.size,
+										defaultValue: "{{count}} selected",
+									})}
+								</span>
+								<div className="ms-auto flex items-center gap-1">
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={() => setConfirmOpen(true)}
+										disabled={isDeleting}
+										className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+										data-testid="chats-page--delete-selected-btn"
+									>
+										<Trash2Icon />
+										{t("workspace:chat.delete", {
+											defaultValue: "Delete",
+										})}
+									</Button>
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={clearSelection}
+										disabled={isDeleting}
+									>
+										{t("workspace:chat.cancel", {
+											defaultValue: "Cancel",
+										})}
+									</Button>
+								</div>
+							</>
+						)}
+					</div>
+				)}
+
 				{/* Body */}
 				<div>
 					{getRooms.isLoading && getRooms.data.length === 0 ? (
 						<div className="flex w-full items-center justify-center py-12">
 							<Spinner />
 						</div>
-					) : visibleRooms.length === 0 ? (
+					) : !hasRooms ? (
 						<div className="flex w-full items-center justify-center py-12">
 							<Muted>
 								{t("workspace:chat.noChats", {
@@ -302,244 +487,33 @@ export const ChatsPage = observer(() => {
 							</Muted>
 						</div>
 					) : (
-						<div className="flex w-full flex-col gap-2">
-							{visibleRooms.map((r) => {
-								const isSelected = selectedIds.has(r.ROOM_ID);
-								const isEditing = editingId === r.ROOM_ID;
-								const dateInput = r.DATE_CREATED.endsWith("Z")
-									? r.DATE_CREATED
-									: `${r.DATE_CREATED}Z`;
-								const d = dayjs(dateInput);
-								const relative = d.isValid()
-									? d.fromNow()
-									: r.DATE_CREATED;
-								const absolute = d.isValid()
-									? d.format("MMM D, YYYY h:mm A")
-									: r.DATE_CREATED;
-
-								if (isEditing) {
-									return (
-										<div
-											key={r.ROOM_ID}
-											className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2"
-										>
-											<Input
-												autoFocus
-												value={editingName}
-												disabled={isRenaming}
-												onChange={(e) =>
-													setEditingName(
-														e.target.value,
-													)
-												}
-												onKeyDown={(e) => {
-													if (e.key === "Enter") {
-														e.preventDefault();
-														handleSaveRename();
-													} else if (
-														e.key === "Escape"
-													) {
-														handleCancelRename();
-													}
-												}}
-												className="h-8 flex-1"
-											/>
-											<Tooltip>
-												<TooltipTrigger asChild>
-													<Button
-														type="button"
-														variant="ghost"
-														size="icon-sm"
-														disabled={isRenaming}
-														onClick={
-															handleSaveRename
-														}
-														aria-label={t(
-															"workspace:chat.renameSave",
-														)}
-													>
-														<CheckIcon className="size-4" />
-													</Button>
-												</TooltipTrigger>
-												<TooltipContent>
-													{t(
-														"workspace:chat.renameSave",
-													)}
-												</TooltipContent>
-											</Tooltip>
-											<Tooltip>
-												<TooltipTrigger asChild>
-													<Button
-														type="button"
-														variant="ghost"
-														size="icon-sm"
-														disabled={isRenaming}
-														onClick={
-															handleCancelRename
-														}
-														aria-label={t(
-															"workspace:chat.cancel",
-														)}
-													>
-														<XIcon className="size-4" />
-													</Button>
-												</TooltipTrigger>
-												<TooltipContent>
-													{t("workspace:chat.cancel")}
-												</TooltipContent>
-											</Tooltip>
-										</div>
-									);
-								}
-
-								return (
-									<div
-										key={r.ROOM_ID}
-										className={cn(
-											"group/row relative flex min-w-0 items-center rounded-lg border border-border bg-card transition-colors hover:border-border/80 hover:bg-accent/40",
-											isSelected &&
-												"border-primary bg-accent/30",
-										)}
-									>
-										{/* Stretched link covers the WHOLE row but z-0,
-										    so anything with z-[1] above it intercepts
-										    clicks before the link does. */}
-										<Link
-											to={`/room/${r.ROOM_ID}`}
-											aria-label={t(
-												"workspace:chat.selectRoom",
-											)}
-											className="absolute inset-0 z-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-										/>
-
-										{/* Left select zone — wider hit area for the
-										    checkbox. Clicking anywhere here toggles
-										    selection instead of opening the room.
-										    Keyboard users tab to the inner Checkbox
-										    directly, so this zone is mouse-only
-										    (tabIndex={-1}) but still gets a `button`
-										    role so AT announces its purpose. */}
-										{/* biome-ignore lint/a11y/useSemanticElements: cannot use a real <button> here — it would wrap the interactive Checkbox component, which is itself a button (Radix renders <button role="checkbox">). Nested buttons are invalid HTML. The role + tabIndex + aria-label + onKeyDown gives equivalent a11y semantics. */}
-										<div
-											role="button"
-											tabIndex={-1}
-											aria-label={t(
-												"workspace:chats.selectChat",
-												{
-													name: r.ROOM_NAME,
-													defaultValue:
-														"Select chat {{name}}",
-												},
-											)}
-											onClick={(e) => {
-												e.preventDefault();
-												e.stopPropagation();
-												toggleSelectOne(r.ROOM_ID);
-											}}
-											onKeyDown={(e) => {
-												if (
-													e.key === "Enter" ||
-													e.key === " "
-												) {
-													e.preventDefault();
-													e.stopPropagation();
-													toggleSelectOne(r.ROOM_ID);
-												}
-											}}
-											className="relative z-1 flex shrink-0 cursor-pointer items-center @md:gap-3 gap-2 py-2.5 @md:ps-3 ps-2 @md:pe-2 pe-1"
-										>
-											<Checkbox
-												checked={isSelected}
-												onCheckedChange={() =>
-													toggleSelectOne(r.ROOM_ID)
-												}
-												onClick={(e) =>
-													e.stopPropagation()
-												}
-												aria-label={t(
-													"workspace:chats.selectChat",
-													{
-														name: r.ROOM_NAME,
-														defaultValue:
-															"Select chat {{name}}",
-													},
-												)}
-												className={cn(
-													!hasSelection &&
-														"invisible focus-visible:visible group-hover/row:visible",
-												)}
-											/>
-											<div className="@md:flex hidden size-9 items-center justify-center rounded-md bg-muted text-muted-foreground">
-												<MessagesSquareIcon className="size-4" />
-											</div>
-										</div>
-
-										{/* Name + date — link covers this area for navigation */}
-										<div className="pointer-events-none relative z-1 flex min-w-0 flex-1 flex-col py-2.5">
-											<div className="flex min-w-0 items-center gap-1.5">
-												<div
-													dir="auto"
-													className="truncate font-semibold text-foreground text-sm leading-tight"
-													title={r.ROOM_NAME}
-												>
-													{r.ROOM_NAME}
-												</div>
-												{r.PINNED ? (
-													<StarIcon
-														className="size-3.5 shrink-0 fill-yellow-500 text-yellow-500"
-														aria-label={t(
-															"workspace:chat.pin",
-														)}
-													/>
-												) : null}
-											</div>
-											<div
-												className="text-muted-foreground text-xs leading-tight"
-												title={absolute}
-											>
-												{relative}
-											</div>
-										</div>
-
-										{/* Right actions: rename (hover-revealed) + arrow */}
-										{/* Right actions: rename (hover-revealed) + arrow.
-										    Wrapper is `pointer-events-none` so clicks
-										    on the arrow (purely visual) fall through
-										    to the stretched Link and navigate to the
-										    room. The rename Button re-enables events
-										    on itself via `pointer-events-auto`. */}
-										<div className="pointer-events-none relative z-1 flex shrink-0 items-center gap-1 @md:pe-3 pe-2">
-											<Tooltip>
-												<TooltipTrigger asChild>
-													<Button
-														type="button"
-														variant="ghost"
-														size="icon-sm"
-														aria-label={t(
-															"workspace:chat.rename",
-														)}
-														className="pointer-events-auto hidden text-muted-foreground hover:text-foreground focus-visible:inline-flex group-hover/row:inline-flex"
-														onClick={(e) => {
-															e.preventDefault();
-															e.stopPropagation();
-															handleStartRename(
-																r,
-															);
-														}}
-														data-testid={`chats-page--rename-${r.ROOM_ID}`}
-													>
-														<PencilIcon className="size-4" />
-													</Button>
-												</TooltipTrigger>
-												<TooltipContent>
-													{t("workspace:chat.rename")}
-												</TooltipContent>
-											</Tooltip>
-											<ArrowRightIcon className="rtl:-scale-x-100 size-4 shrink-0 text-muted-foreground transition-colors group-hover/row:text-foreground" />
-										</div>
+						<div className="flex w-full flex-col gap-6">
+							{/* Pinned section */}
+							{pinnedRooms.length > 0 && (
+								<div className="flex flex-col gap-2">
+									<div className="flex items-center gap-1.5 px-1 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+										<StarIcon className="size-3.5 fill-yellow-500 text-yellow-500" />
+										{t("workspace:chats.favorites", {
+											defaultValue: "Favorites",
+										})}
 									</div>
-								);
-							})}
+									<div className="flex flex-col gap-2">
+										{pinnedRooms.map(renderRow)}
+									</div>
+								</div>
+							)}
+
+							{/* Date-grouped sections */}
+							{groups.map((g) => (
+								<div key={g.ts} className="flex flex-col gap-2">
+									<div className="px-1 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+										{g.label}
+									</div>
+									<div className="flex flex-col gap-2">
+										{g.rooms.map(renderRow)}
+									</div>
+								</div>
+							))}
 
 							{getRooms.isLoading && getRooms.data.length > 0 && (
 								<div className="flex items-center justify-center p-4">
@@ -550,67 +524,6 @@ export const ChatsPage = observer(() => {
 					)}
 				</div>
 			</div>
-
-			{/* Floating action bar — appears when ≥1 chat is selected.
-			    Fixed to viewport bottom so it follows the user as they
-			    scroll the list. Esc and the Cancel button both clear
-			    the selection. */}
-			{hasSelection && (
-				<div className="-translate-x-1/2 fade-in-0 slide-in-from-bottom-4 fixed bottom-6 left-1/2 z-30 animate-in">
-					<div className="flex items-center gap-1 rounded-full border border-border bg-card/95 px-2 py-1.5 shadow-lg backdrop-blur supports-backdrop-filter:bg-card/80">
-						<span className="px-3 font-medium text-foreground text-sm">
-							{t("workspace:chats.selectedCount", {
-								count: selectedIds.size,
-								defaultValue: "{{count}} selected",
-							})}
-						</span>
-						{!allSelected && (
-							<>
-								<Separator
-									orientation="vertical"
-									className="h-6"
-								/>
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={selectAll}
-									disabled={isDeleting}
-									data-testid="chats-page--select-all-btn"
-								>
-									{t("workspace:chats.selectAll", {
-										defaultValue: "Select all",
-									})}
-								</Button>
-							</>
-						)}
-						<Separator orientation="vertical" className="h-6" />
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => setConfirmOpen(true)}
-							disabled={isDeleting}
-							className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-							data-testid="chats-page--delete-selected-btn"
-						>
-							<Trash2Icon />
-							{t("workspace:chat.delete", {
-								defaultValue: "Delete",
-							})}
-						</Button>
-						<Separator orientation="vertical" className="h-6" />
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={clearSelection}
-							disabled={isDeleting}
-						>
-							{t("workspace:chat.cancel", {
-								defaultValue: "Cancel",
-							})}
-						</Button>
-					</div>
-				</div>
-			)}
 
 			{/* Bulk delete confirmation */}
 			<Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>

--- a/packages/playground/src/pages/chats-page.tsx
+++ b/packages/playground/src/pages/chats-page.tsx
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { SearchIcon, StarIcon, Trash2Icon } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -22,29 +21,9 @@ import {
 	useDebouncedValue,
 	useInfiniteScroll,
 } from "@semoss/ui/next";
-import {
-	CHECKBOX_CLASS,
-	ChatRow,
-	type RoomItem,
-	roomTime,
-	type TFn,
-} from "@/components";
+import { CHECKBOX_CLASS, ChatRow, type RoomItem } from "@/components";
 import { useChat, useGlobalBreadcrumbs } from "@/hooks";
-
-const getDayLabel = (startOfDay: dayjs.Dayjs, t: TFn): string => {
-	const today = dayjs().startOf("day");
-	const days = today.diff(startOfDay, "day");
-	if (days <= 0)
-		return t("workspace:chat.dayToday", { defaultValue: "Today" });
-	if (days === 1)
-		return t("workspace:chat.dayYesterday", { defaultValue: "Yesterday" });
-	if (days < 30)
-		return t("workspace:chat.daysAgo", {
-			count: days,
-			defaultValue: "{{count}} days ago",
-		});
-	return startOfDay.format("MMM D, YYYY");
-};
+import { getDayLabel, normalizeTimestamp } from "@/utility";
 
 /**
  * All-chats page.
@@ -138,8 +117,8 @@ export const ChatsPage = observer(() => {
 			.filter((r): r is RoomItem => Boolean(r))
 			.sort(
 				(a, b) =>
-					roomTime(b.DATE_CREATED).valueOf() -
-					roomTime(a.DATE_CREATED).valueOf(),
+					normalizeTimestamp(b.DATE_CREATED).valueOf() -
+					normalizeTimestamp(a.DATE_CREATED).valueOf(),
 			);
 	}, [pinnedIds, deletedSet, roomById, isSearching]);
 
@@ -151,7 +130,7 @@ export const ChatsPage = observer(() => {
 		>();
 		for (const room of visibleRooms) {
 			if (!isSearching && pinnedIds.has(room.ROOM_ID)) continue;
-			const d = roomTime(room.DATE_CREATED);
+			const d = normalizeTimestamp(room.DATE_CREATED);
 			if (!d.isValid()) continue;
 			const startOfDay = d.startOf("day");
 			const key = startOfDay.format("YYYY-MM-DD");
@@ -353,7 +332,6 @@ export const ChatsPage = observer(() => {
 	const renderRow = (room: RoomItem) => (
 		<ChatRow
 			key={room.ROOM_ID}
-			t={t}
 			room={room}
 			isSelected={selectedIds.has(room.ROOM_ID)}
 			isPinned={pinnedIds.has(room.ROOM_ID)}

--- a/packages/playground/src/pages/chats-page.tsx
+++ b/packages/playground/src/pages/chats-page.tsx
@@ -51,7 +51,7 @@ export const ChatsPage = observer(() => {
 		breadcrumbs: [
 			{ name: t("workspace:breadcrumbs.home"), path: "/" },
 			{
-				name: t("workspace:chats.title", { defaultValue: "All chats" }),
+				name: t("workspace:chats.title"),
 				path: "/chats",
 			},
 		],
@@ -263,7 +263,6 @@ export const ChatsPage = observer(() => {
 			toast.success(
 				t("workspace:chats.bulkDeleteSuccess", {
 					count: ids.length,
-					defaultValue: "Deleted {{count}} chats",
 				}),
 			);
 		} else {
@@ -277,8 +276,6 @@ export const ChatsPage = observer(() => {
 				t("workspace:chats.bulkDeletePartialFail", {
 					failed: failed.length,
 					total: ids.length,
-					defaultValue:
-						"Failed to delete {{failed}} of {{total}} chats",
 				}),
 			);
 		}
@@ -313,15 +310,10 @@ export const ChatsPage = observer(() => {
 				<div className="-mx-4 -mt-8 @md:-mx-6 @3xl:-mx-12 sticky top-0 z-20 flex flex-row items-center gap-3 border-border border-b bg-background/95 @3xl:px-12 @md:px-6 px-4 py-4 backdrop-blur supports-backdrop-filter:bg-background/80">
 					<div className="min-w-0 flex-1">
 						<div className="truncate font-semibold @md:text-2xl text-foreground text-xl leading-tight">
-							{t("workspace:chats.title", {
-								defaultValue: "All chats",
-							})}
+							{t("workspace:chats.title")}
 						</div>
 						<div className="@md:block hidden text-muted-foreground text-sm">
-							{t("workspace:chats.subtitle", {
-								defaultValue:
-									"Browse, search, and clean up your chats.",
-							})}
+							{t("workspace:chats.subtitle")}
 						</div>
 					</div>
 				</div>
@@ -329,9 +321,7 @@ export const ChatsPage = observer(() => {
 				{/* Search */}
 				<InputGroup className="bg-background">
 					<InputGroupInput
-						placeholder={t("common:buttons.search", {
-							defaultValue: "Search",
-						})}
+						placeholder={t("common:buttons.search")}
 						value={search}
 						onChange={(e) => setSearch(e.target.value)}
 					/>
@@ -347,9 +337,7 @@ export const ChatsPage = observer(() => {
 						<Checkbox
 							checked={allSelected}
 							onCheckedChange={toggleSelectAll}
-							aria-label={t("workspace:chats.selectAll", {
-								defaultValue: "Select all",
-							})}
+							aria-label={t("workspace:chats.selectAll")}
 							className={CHECKBOX_CLASS}
 							data-testid="chats-page--select-all-checkbox"
 						/>
@@ -359,19 +347,14 @@ export const ChatsPage = observer(() => {
 							className="font-medium text-foreground text-sm hover:text-foreground/80"
 						>
 							{allSelected
-								? t("workspace:chats.deselectAll", {
-										defaultValue: "Deselect all",
-									})
-								: t("workspace:chats.selectAll", {
-										defaultValue: "Select all",
-									})}
+								? t("workspace:chats.deselectAll")
+								: t("workspace:chats.selectAll")}
 						</button>
 						{hasSelection && (
 							<>
 								<span className="text-muted-foreground text-sm">
 									{t("workspace:chats.selectedCount", {
 										count: selectedIds.size,
-										defaultValue: "{{count}} selected",
 									})}
 								</span>
 								<div className="ms-auto flex items-center gap-1">
@@ -384,9 +367,7 @@ export const ChatsPage = observer(() => {
 										data-testid="chats-page--delete-selected-btn"
 									>
 										<Trash2Icon />
-										{t("workspace:chat.delete", {
-											defaultValue: "Delete",
-										})}
+										{t("workspace:chat.delete")}
 									</Button>
 									<Button
 										variant="ghost"
@@ -394,9 +375,7 @@ export const ChatsPage = observer(() => {
 										onClick={clearSelection}
 										disabled={isDeleting}
 									>
-										{t("workspace:chat.cancel", {
-											defaultValue: "Cancel",
-										})}
+										{t("workspace:chat.cancel")}
 									</Button>
 								</div>
 							</>
@@ -412,11 +391,7 @@ export const ChatsPage = observer(() => {
 						</div>
 					) : !hasRooms ? (
 						<div className="flex w-full items-center justify-center py-12">
-							<Muted>
-								{t("workspace:chat.noChats", {
-									defaultValue: "No chats found",
-								})}
-							</Muted>
+							<Muted>{t("workspace:chat.noChats")}</Muted>
 						</div>
 					) : (
 						<div className="flex w-full flex-col gap-6">
@@ -425,9 +400,7 @@ export const ChatsPage = observer(() => {
 								<div className="flex flex-col gap-2">
 									<div className="flex items-center gap-1.5 px-1 font-medium text-muted-foreground text-xs">
 										<StarIcon className="size-3.5 fill-yellow-500 text-yellow-500" />
-										{t("workspace:chats.favorites", {
-											defaultValue: "Favorites",
-										})}
+										{t("workspace:chats.favorites")}
 									</div>
 									<div className="flex flex-col gap-2">
 										{pinnedRooms.map(renderRow)}
@@ -467,14 +440,11 @@ export const ChatsPage = observer(() => {
 						<DialogTitle>
 							{t("workspace:chats.bulkDeleteConfirmTitle", {
 								count: selectedIds.size,
-								defaultValue: "Delete {{count}} chats?",
 							})}
 						</DialogTitle>
 						<DialogDescription>
 							{t("workspace:chats.bulkDeleteConfirmDescription", {
 								count: selectedIds.size,
-								defaultValue:
-									"This will permanently delete {{count}} chats. This action cannot be undone.",
 							})}
 						</DialogDescription>
 					</DialogHeader>

--- a/packages/playground/src/pages/chats-page.tsx
+++ b/packages/playground/src/pages/chats-page.tsx
@@ -305,7 +305,7 @@ export const ChatsPage = observer(() => {
 			}}
 			className="@container h-full w-full overflow-y-auto"
 		>
-			<div className="mx-auto flex w-full max-w-5xl flex-col gap-6 @3xl:px-12 @md:px-6 px-4 pt-8 pb-4">
+			<div className="mx-auto flex w-full max-w-5xl flex-col gap-4 @3xl:px-12 @md:px-6 px-4 pt-8 pb-4">
 				{/* Sticky header */}
 				<div className="-mx-4 -mt-8 @md:-mx-6 @3xl:-mx-12 sticky top-0 z-20 flex flex-row items-center gap-3 border-border border-b bg-background/95 @3xl:px-12 @md:px-6 px-4 py-4 backdrop-blur supports-backdrop-filter:bg-background/80">
 					<div className="min-w-0 flex-1">

--- a/packages/playground/src/pages/chats-page.tsx
+++ b/packages/playground/src/pages/chats-page.tsx
@@ -23,16 +23,20 @@ import {
 } from "@semoss/ui/next";
 import { CHECKBOX_CLASS, ChatRow, type RoomItem } from "@/components";
 import { useChat, useGlobalBreadcrumbs } from "@/hooks";
-import { getDayLabel, normalizeTimestamp } from "@/utility";
+import {
+	DATE_BUCKET_ORDER,
+	getDateBucket,
+	normalizeTimestamp,
+} from "@/utility";
 
 /**
  * All-chats page.
- * Lists every chat (across all workspaces) grouped into a pinned
- * section plus calendar-day sections, with multi-select + bulk delete,
- * inline rename, and pin/unpin.
+ * Lists every chat (across all workspaces) grouped into a favorites
+ * section plus date buckets, with multi-select + bulk delete, inline
+ * rename, and pin/unpin.
  */
 export const ChatsPage = observer(() => {
-	const { t } = useTranslation(["workspace", "common"]);
+	const { t } = useTranslation(["workspace", "common", "sidebar"]);
 	const { chat } = useChat();
 
 	const [search, setSearch] = useState("");
@@ -42,9 +46,6 @@ export const ChatsPage = observer(() => {
 	const [pinnedIds, setPinnedIds] = useState<Set<string>>(new Set());
 	const [confirmOpen, setConfirmOpen] = useState(false);
 	const [isDeleting, setIsDeleting] = useState(false);
-	const [editingId, setEditingId] = useState<string | null>(null);
-	const [editingName, setEditingName] = useState("");
-	const [isRenaming, setIsRenaming] = useState(false);
 
 	useGlobalBreadcrumbs({
 		breadcrumbs: [
@@ -122,28 +123,25 @@ export const ChatsPage = observer(() => {
 			);
 	}, [pinnedIds, deletedSet, roomById, isSearching]);
 
-	// Date-grouped, non-pinned rooms (descending by day).
+	// Non-pinned rooms grouped into date buckets, matching the sidebar.
 	const groups = useMemo(() => {
-		const map = new Map<
-			string,
-			{ label: string; ts: number; rooms: RoomItem[] }
-		>();
+		const byBucket = new Map<string, RoomItem[]>();
 		for (const room of visibleRooms) {
 			if (!isSearching && pinnedIds.has(room.ROOM_ID)) continue;
 			const d = normalizeTimestamp(room.DATE_CREATED);
 			if (!d.isValid()) continue;
-			const startOfDay = d.startOf("day");
-			const key = startOfDay.format("YYYY-MM-DD");
-			if (!map.has(key)) {
-				map.set(key, {
-					label: getDayLabel(startOfDay, t),
-					ts: startOfDay.valueOf(),
-					rooms: [],
-				});
-			}
-			map.get(key)?.rooms.push(room);
+			const bucket = getDateBucket(d);
+			const rooms = byBucket.get(bucket);
+			if (rooms) rooms.push(room);
+			else byBucket.set(bucket, [room]);
 		}
-		return Array.from(map.values()).sort((a, b) => b.ts - a.ts);
+		return DATE_BUCKET_ORDER.filter((bucket) => byBucket.has(bucket)).map(
+			(bucket) => ({
+				bucket,
+				label: t(`sidebar:buckets.${bucket}`),
+				rooms: byBucket.get(bucket) ?? [],
+			}),
+		);
 	}, [visibleRooms, pinnedIds, isSearching, t]);
 
 	const allVisibleIds = useMemo(() => {
@@ -194,12 +192,7 @@ export const ChatsPage = observer(() => {
 					target.tagName === "TEXTAREA" ||
 					target.isContentEditable);
 
-			if (
-				e.key === "Escape" &&
-				hasSelection &&
-				!editingId &&
-				!inEditableField
-			) {
+			if (e.key === "Escape" && hasSelection && !inEditableField) {
 				clearSelection();
 				return;
 			}
@@ -216,7 +209,7 @@ export const ChatsPage = observer(() => {
 		};
 		window.addEventListener("keydown", onKey);
 		return () => window.removeEventListener("keydown", onKey);
-	}, [hasSelection, editingId, hasRooms, clearSelection, selectAll]);
+	}, [hasSelection, hasRooms, clearSelection, selectAll]);
 
 	const toggleSelectOne = (roomId: string) => {
 		setSelectedIds((prev) => {
@@ -297,53 +290,14 @@ export const ChatsPage = observer(() => {
 		getPinnedRooms.refresh();
 	};
 
-	const handleStartRename = (room: RoomItem) => {
-		setEditingId(room.ROOM_ID);
-		setEditingName(room.ROOM_NAME);
-	};
-
-	const handleCancelRename = () => {
-		setEditingId(null);
-		setEditingName("");
-	};
-
-	const handleSaveRename = async () => {
-		if (!editingId) return;
-		const trimmed = editingName.trim();
-		if (!trimmed) {
-			toast.error(t("workspace:chat.renameEmpty"));
-			return;
-		}
-		setIsRenaming(true);
-		try {
-			await chat.renameRoom(editingId, trimmed);
-			toast.success(t("workspace:chat.renameSuccess"));
-			setEditingId(null);
-			setEditingName("");
-			getRooms.reset();
-			getPinnedRooms.refresh();
-		} catch {
-			toast.error(t("workspace:chat.renameFailed"));
-		} finally {
-			setIsRenaming(false);
-		}
-	};
-
 	const renderRow = (room: RoomItem) => (
 		<ChatRow
 			key={room.ROOM_ID}
 			room={room}
 			isSelected={selectedIds.has(room.ROOM_ID)}
 			isPinned={pinnedIds.has(room.ROOM_ID)}
-			isEditing={editingId === room.ROOM_ID}
-			editingName={editingName}
-			setEditingName={setEditingName}
-			isRenaming={isRenaming}
 			onToggleSelect={() => toggleSelectOne(room.ROOM_ID)}
 			onTogglePin={() => handleTogglePin(room.ROOM_ID)}
-			onStartRename={() => handleStartRename(room)}
-			onCancelRename={handleCancelRename}
-			onSaveRename={handleSaveRename}
 		/>
 	);
 
@@ -469,7 +423,7 @@ export const ChatsPage = observer(() => {
 							{/* Pinned section */}
 							{pinnedRooms.length > 0 && (
 								<div className="flex flex-col gap-2">
-									<div className="flex items-center gap-1.5 px-1 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+									<div className="flex items-center gap-1.5 px-1 font-medium text-muted-foreground text-xs">
 										<StarIcon className="size-3.5 fill-yellow-500 text-yellow-500" />
 										{t("workspace:chats.favorites", {
 											defaultValue: "Favorites",
@@ -483,8 +437,11 @@ export const ChatsPage = observer(() => {
 
 							{/* Date-grouped sections */}
 							{groups.map((g) => (
-								<div key={g.ts} className="flex flex-col gap-2">
-									<div className="px-1 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+								<div
+									key={g.bucket}
+									className="flex flex-col gap-2"
+								>
+									<div className="px-1 font-medium text-muted-foreground text-xs">
 										{g.label}
 									</div>
 									<div className="flex flex-col gap-2">

--- a/packages/playground/src/stores/chat/chat.store.ts
+++ b/packages/playground/src/stores/chat/chat.store.ts
@@ -364,6 +364,20 @@ export class ChatStore {
 	};
 
 	/**
+	 * Pin or unpin a room. Runs the PinRoom pixel and bumps the
+	 * roomCounter so any room lists elsewhere in the app (sidebar,
+	 * chats page, per-agent timeline) refetch and stay in sync.
+	 */
+	pinRoom = async (roomId: string, pinned: boolean): Promise<void> => {
+		await this._actions.run<[boolean]>(
+			`PinRoom(roomId=["${roomId}"], pinned=[${pinned}]);`,
+		);
+		runInAction(() => {
+			this._store.keys.roomCounter++;
+		});
+	};
+
+	/**
 	 * Load a room from the store or create a new one
 	 * @param roomId - Room to remove
 	 */

--- a/packages/playground/src/stores/message/abstract-message.store.ts
+++ b/packages/playground/src/stores/message/abstract-message.store.ts
@@ -1,6 +1,7 @@
 import { action, computed, makeObservable, observable } from "mobx";
 import type { RoomStore } from "@/stores";
 import type { AbstractPixelMessage, PixelMessage } from "@/types";
+import { normalizeTimestamp } from "@/utility";
 
 /**
  * Abstract Message Store
@@ -173,13 +174,7 @@ export abstract class AbstractMessageStore {
 	 * Sync store properties from the pixel message
 	 */
 	sync(message: PixelMessage) {
-		this.dateCreated = (() => {
-			const raw = message.dateCreated;
-			const normalized = /Z|[+-]\d{2}:?\d{2}$/.test(raw)
-				? raw
-				: `${raw.replace(" ", "T")}Z`;
-			return new Date(normalized);
-		})();
+		this.dateCreated = normalizeTimestamp(message.dateCreated).toDate();
 	}
 
 	/**

--- a/packages/playground/src/utility/date.ts
+++ b/packages/playground/src/utility/date.ts
@@ -3,8 +3,6 @@ import relativeTime from "dayjs/plugin/relativeTime";
 
 dayjs.extend(relativeTime);
 
-type TranslateFn = (key: string, params?: Record<string, unknown>) => string;
-
 /**
  * Parse a Semoss timestamp into a dayjs instance, normalizing to UTC.
  *
@@ -22,25 +20,42 @@ export const normalizeTimestamp = (raw: string): dayjs.Dayjs => {
 };
 
 /**
- * Human day-bucket label for a start-of-day timestamp: "Today",
- * "Yesterday", "N days ago", or an absolute date once older than a month.
- *
- * Expects a `t` whose default namespace is `workspace` (uses the unprefixed
- * `chat.*` keys).
+ * Date buckets used to group chat lists. Values double as the `buckets.*`
+ * i18n keys in the `sidebar` namespace, so callers can label a bucket with
+ * `t(\`buckets.${bucket}\`)`.
  */
-export const getDayLabel = (
-	startOfDay: dayjs.Dayjs,
-	t: TranslateFn,
-): string => {
-	const today = dayjs().startOf("day");
-	const days = today.diff(startOfDay, "day");
-	if (days <= 0) return t("chat.dayToday", { defaultValue: "Today" });
-	if (days === 1)
-		return t("chat.dayYesterday", { defaultValue: "Yesterday" });
-	if (days < 30)
-		return t("chat.daysAgo", {
-			count: days,
-			defaultValue: "{{count}} days ago",
-		});
-	return startOfDay.format("MMM D, YYYY");
+export type DateBucket =
+	| "today"
+	| "yesterday"
+	| "fewDaysAgo"
+	| "lastWeek"
+	| "thisMonth"
+	| "lastMonth"
+	| "older";
+
+/** Buckets in the order they should be rendered (most to least recent). */
+export const DATE_BUCKET_ORDER: DateBucket[] = [
+	"today",
+	"yesterday",
+	"fewDaysAgo",
+	"lastWeek",
+	"thisMonth",
+	"lastMonth",
+	"older",
+];
+
+/**
+ * Assign a date to one of the {@link DATE_BUCKET_ORDER} buckets, relative to
+ * now. Shared by the sidebar and the chat-list pages so they group dates
+ * identically.
+ */
+export const getDateBucket = (date: dayjs.Dayjs): DateBucket => {
+	const now = dayjs();
+	if (now.isSame(date, "day")) return "today";
+	if (now.subtract(1, "day").isSame(date, "day")) return "yesterday";
+	if (date.isAfter(now.subtract(3, "day"))) return "fewDaysAgo";
+	if (date.isAfter(now.subtract(7, "day"))) return "lastWeek";
+	if (now.isSame(date, "month")) return "thisMonth";
+	if (now.subtract(1, "month").isSame(date, "month")) return "lastMonth";
+	return "older";
 };

--- a/packages/playground/src/utility/date.ts
+++ b/packages/playground/src/utility/date.ts
@@ -1,0 +1,46 @@
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+
+dayjs.extend(relativeTime);
+
+type TranslateFn = (key: string, params?: Record<string, unknown>) => string;
+
+/**
+ * Parse a Semoss timestamp into a dayjs instance, normalizing to UTC.
+ *
+ * Platform timestamps frequently arrive without a timezone suffix
+ * (e.g. `2026-06-22 17:48:07`), which dayjs would otherwise interpret as
+ * local time. This appends `Z` (and converts the date/time separator)
+ * only when no zone is already present, so values that already carry a
+ * `Z` or numeric offset are left untouched.
+ */
+export const normalizeTimestamp = (raw: string): dayjs.Dayjs => {
+	const normalized = /Z|[+-]\d{2}:?\d{2}$/.test(raw)
+		? raw
+		: `${raw.replace(" ", "T")}Z`;
+	return dayjs(normalized);
+};
+
+/**
+ * Human day-bucket label for a start-of-day timestamp: "Today",
+ * "Yesterday", "N days ago", or an absolute date once older than a month.
+ *
+ * Expects a `t` whose default namespace is `workspace` (uses the unprefixed
+ * `chat.*` keys).
+ */
+export const getDayLabel = (
+	startOfDay: dayjs.Dayjs,
+	t: TranslateFn,
+): string => {
+	const today = dayjs().startOf("day");
+	const days = today.diff(startOfDay, "day");
+	if (days <= 0) return t("chat.dayToday", { defaultValue: "Today" });
+	if (days === 1)
+		return t("chat.dayYesterday", { defaultValue: "Yesterday" });
+	if (days < 30)
+		return t("chat.daysAgo", {
+			count: days,
+			defaultValue: "{{count}} days ago",
+		});
+	return startOfDay.format("MMM D, YYYY");
+};

--- a/packages/playground/src/utility/index.ts
+++ b/packages/playground/src/utility/index.ts
@@ -1,2 +1,3 @@
+export * from "./date";
 export * from "./template";
 export * from "./utils";


### PR DESCRIPTION
## Description
Redesigns the Playground all-chats page into a scannable, organized view: chats are grouped into a Favorites section plus date buckets, selection and bulk actions are surfaced up front, and pin/rename work inline. Along the way, timestamp parsing and date-bucketing logic that had been copy-pasted across the sidebar and chat lists is consolidated into shared utilities so every surface groups and renders dates identically.

## Changes Made

**chats-page.tsx:**
- Group chats into a **Favorites** section (backed by a dedicated `pinned=[true]` query so it shows every pinned chat, not just paged-in ones) plus date buckets matching the sidebar.
- Always-visible selection checkboxes and an always-visible **Select all / Deselect all** toolbar; bulk **Delete** and **Cancel** live in that toolbar with a fixed height so the list doesn't jump when actions appear.
- Inline rename and per-row pin/unpin (star always visible, reflecting pinned state).
- Search, infinite scroll, and keyboard shortcuts (Esc to clear selection, Cmd/Ctrl+A to select all).

**chat-row.tsx (new):**
- Extracted the chat row into its own component under `components/chats/`. Owns its inline-rename state and calls `chat.renameRoom` directly; reads copy via `useTranslation` rather than prop-drilling.

**utility/date.ts (new):**
- `normalizeTimestamp` — single source for parsing platform timestamps (handles values with/without a timezone suffix), replacing five inline copies.
- `getDateBucket` / `DATE_BUCKET_ORDER` — shared date bucketing (Today / Yesterday / Few Days Ago / …) used by the chats page, workspace chat list, and sidebar.

**chat.store.ts:**
- Added `pinRoom`, which runs `PinRoom` and bumps `roomCounter` so the sidebar and chats page stay in sync — pinning is now bidirectional across both views.

**global-nav.tsx / workspace-chat-list.tsx / workspace-card.tsx / abstract-message.store.ts:**
- Migrated to the shared date utilities; the sidebar's inline bucketing now routes through `getDateBucket`.

**i18n (all 7 locales):**
- Added `chats.favorites` and `chats.deselectAll`; removed orphaned `chat.dayToday/dayYesterday/daysAgo` keys; dropped redundant `defaultValue` fallbacks now that keys exist.

## How to Test
1. Open the Playground chats page — chats should appear under a Favorites section (if any) and date buckets (Today, Yesterday, Few Days Ago, etc.).
2. Star/unstar a chat from the chats page and from the sidebar — the change should reflect in both places.
3. Rename a chat inline — it should save and update in the sidebar too.
4. Select chats (checkboxes, Select all, Cmd/Ctrl+A) and bulk delete; Esc or Cancel clears the selection.
5. Search and scroll to confirm filtering and infinite scroll still work.

## Notes
- Rename state is now owned per-row, so the page no longer enforces only one row in edit mode at a time — a minor, intentional change from extracting the row component.