### PR TITLE
WIP its not ready neel feat feat: Visual Pixel Workflow Builder — frontend canvas

### DIFF
--- a/packages/client/src/components/app/NewAppModal.tsx
+++ b/packages/client/src/components/app/NewAppModal.tsx
@@ -29,7 +29,10 @@ type NewAppForm = {
 
 interface NewAppModalProps {
 	open: boolean;
-	options: { type: "blocks"; state: SerializedState } | { type: "code" };
+	options:
+		| { type: "blocks"; state: SerializedState }
+		| { type: "code" }
+		| { type: "workflow" };
 	onClose: (appId?: string) => void;
 }
 
@@ -169,6 +172,42 @@ export const NewAppModal = (props: NewAppModalProps) => {
 
 					if (operationType.indexOf("ERROR") > -1) {
 						toast.error(output);
+					}
+				}
+			} else if (type === "workflow") {
+				const pixel = `CreateProject(project=["${data.APP_NAME}"], portal=[true], projectType=["WORKFLOW"]);`;
+				const { errors, pixelReturn } =
+					await monolithStore.runQuery<[AppMetadata]>(pixel);
+
+				if (errors.length > 0) throw new Error(errors.join(","));
+
+				appId = pixelReturn[0].output.project_id;
+
+				if (data.APP_IMG && appId) {
+					await uploadImage(
+						data.APP_IMG,
+						appId,
+						configStore.store.insightID,
+					);
+				}
+
+				if (data.APP_TAGS.length || data.APP_DESCRIPTION) {
+					const setProjectMetadataResponse =
+						await monolithStore.runQuery(
+							`SetProjectMetadata(project=["${appId}"], meta=[${JSON.stringify(
+								{
+									tag: data.APP_TAGS,
+									description: data.APP_DESCRIPTION,
+								},
+							)}])`,
+						);
+					const output =
+						setProjectMetadataResponse.pixelReturn[0].output;
+					const operationType =
+						setProjectMetadataResponse.pixelReturn[0].operationType;
+					if (operationType.indexOf("ERROR") > -1) {
+						toast.error(output);
+						return;
 					}
 				}
 			} else {

--- a/packages/client/src/components/app/app.types.ts
+++ b/packages/client/src/components/app/app.types.ts
@@ -7,6 +7,7 @@ export type AppType =
 	| "INSIGHT"
 	| "SKILL"
 	| "WORKSPACE"
+	| "WORKFLOW"
 	| "";
 
 /**

--- a/packages/client/src/components/landing/developer-user-screen.tsx
+++ b/packages/client/src/components/landing/developer-user-screen.tsx
@@ -123,6 +123,10 @@ export const DeveloperUserScreen = observer(() => {
 							});
 						} else if (type === "agent") {
 							navigate("/app/new/prompt");
+						} else if (type === "workflow") {
+							setNewAppOptions({
+								type: "workflow",
+							});
 						}
 					}}
 				/>

--- a/packages/client/src/components/landing/landing-header.tsx
+++ b/packages/client/src/components/landing/landing-header.tsx
@@ -36,18 +36,26 @@ const CARDS = [
 		type: "agent",
 		testId: "new-app-agent-btn",
 	},
+	{
+		title: "Build a workflow",
+		description:
+			"Connect engines, models, and data sources into a visual pipeline. Design, save, and execute multi-step workflows with drag-and-drop nodes.",
+		image: Appagent,
+		type: "workflow",
+		testId: "new-app-workflow-btn",
+	},
 ] as const;
 
 interface LandingHeaderProps {
 	/** Trigger creation of a new app */
-	onCreate: (type: "blocks" | "code" | "agent") => void;
+	onCreate: (type: "blocks" | "code" | "agent" | "workflow") => void;
 }
 
 export const LandingHeader: React.FC<LandingHeaderProps> = ({
 	onCreate = () => null,
 }) => {
 	return (
-		<div className="grid w-full grid-cols-1 gap-4 md:grid-cols-3">
+		<div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
 			{CARDS.map((card) => (
 				<Card
 					key={card.title}

--- a/packages/client/src/components/workflow-workspace/index.ts
+++ b/packages/client/src/components/workflow-workspace/index.ts
@@ -1,0 +1,2 @@
+export type { WorkflowNodeData } from "./nodes/node-card";
+export { WorkflowWorkspace } from "./workflow-workspace";

--- a/packages/client/src/components/workflow-workspace/nodes/node-card.tsx
+++ b/packages/client/src/components/workflow-workspace/nodes/node-card.tsx
@@ -1,0 +1,411 @@
+import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
+import { ChevronDown, ChevronUp, Settings, Trash2 } from "lucide-react";
+import type { FC } from "react";
+import {
+	Input,
+	Label,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	Textarea,
+} from "@semoss/ui/next";
+import type { WorkflowNode, WorkflowNodeConfig } from "../workflow.types";
+import { NODE_PALETTE } from "../workflow.types";
+import { useWorkflowWorkspaceContext } from "../workflow-workspace-context";
+
+/** Data shape stored on each ReactFlow node */
+export interface WorkflowNodeData {
+	wfNode: WorkflowNode;
+}
+
+type RFWorkflowNode = Node<WorkflowNodeData>;
+
+function getNodeMeta(type: string) {
+	return NODE_PALETTE.find((m) => m.type === type);
+}
+
+/**
+ * Engine select dropdown — loaded from WorkflowWorkspaceContext.enginesByType.
+ * engineTypeKey is the SEMOSS engine type string (e.g. "MODEL", "DATABASE").
+ */
+const EngineSelect: FC<{
+	engineTypeKey: string;
+	value: string;
+	onChange: (id: string) => void;
+}> = ({ engineTypeKey, value, onChange }) => {
+	const { enginesByType } = useWorkflowWorkspaceContext();
+	const options = enginesByType[engineTypeKey] ?? [];
+
+	return (
+		<div className="nodrag nopan flex flex-col gap-1">
+			<Label className="text-xs">Engine</Label>
+			<Select value={value} onValueChange={onChange}>
+				<SelectTrigger className="h-7 text-xs">
+					<SelectValue placeholder="Select engine…" />
+				</SelectTrigger>
+				<SelectContent>
+					{options.length === 0 && (
+						<SelectItem value="__none__" disabled>
+							No engines available
+						</SelectItem>
+					)}
+					{options.map((opt) => (
+						<SelectItem key={opt.engine_id} value={opt.engine_id}>
+							{opt.engine_display_name ?? opt.engine_name}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+		</div>
+	);
+};
+
+/** Inline form rendered when a node is expanded. Per-type form fields. */
+const InlineNodeForm: FC<{
+	wfNode: WorkflowNode;
+	onUpdate: (cfg: WorkflowNodeConfig) => void;
+}> = ({ wfNode, onUpdate }) => {
+	const cfg = wfNode.config as Record<string, string>;
+	const set = (key: string, val: string) =>
+		onUpdate({ ...cfg, [key]: val } as WorkflowNodeConfig);
+
+	switch (wfNode.type) {
+		case "trigger":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Mode</Label>
+						<Select
+							value={cfg.mode ?? "manual"}
+							onValueChange={(v) => set("mode", v)}
+						>
+							<SelectTrigger className="h-7 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="manual">Manual</SelectItem>
+								<SelectItem value="schedule">
+									Schedule
+								</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					{cfg.mode === "schedule" && (
+						<div className="flex flex-col gap-1">
+							<Label className="text-xs">Cron expression</Label>
+							<Input
+								className="nodrag nopan h-7 text-xs"
+								placeholder="0 * * * *"
+								value={cfg.cronExpression ?? ""}
+								onChange={(e) =>
+									set("cronExpression", e.target.value)
+								}
+							/>
+						</div>
+					)}
+				</div>
+			);
+
+		case "model-engine":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<EngineSelect
+						engineTypeKey="MODEL"
+						value={cfg.engineId ?? ""}
+						onChange={(v) => set("engineId", v)}
+					/>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Prompt</Label>
+						<Textarea
+							className="nodrag nopan text-xs"
+							rows={3}
+							placeholder="Prompt… use ${nodeId} for upstream output"
+							value={cfg.promptTemplate ?? ""}
+							onChange={(e) =>
+								set("promptTemplate", e.target.value)
+							}
+						/>
+					</div>
+				</div>
+			);
+
+		case "database-engine":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<EngineSelect
+						engineTypeKey="DATABASE"
+						value={cfg.engineId ?? ""}
+						onChange={(v) => set("engineId", v)}
+					/>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Operation</Label>
+						<Select
+							value={cfg.operation ?? "query"}
+							onValueChange={(v) => set("operation", v)}
+						>
+							<SelectTrigger className="h-7 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="query">Query</SelectItem>
+								<SelectItem value="update">Update</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">SQL expression</Label>
+						<Textarea
+							className="nodrag nopan text-xs"
+							rows={3}
+							placeholder="SELECT * FROM …"
+							value={cfg.expression ?? ""}
+							onChange={(e) => set("expression", e.target.value)}
+						/>
+					</div>
+				</div>
+			);
+
+		case "vector-engine":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<EngineSelect
+						engineTypeKey="VECTOR"
+						value={cfg.engineId ?? ""}
+						onChange={(v) => set("engineId", v)}
+					/>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Operation</Label>
+						<Select
+							value={cfg.operation ?? "query"}
+							onValueChange={(v) => set("operation", v)}
+						>
+							<SelectTrigger className="h-7 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="query">Query</SelectItem>
+								<SelectItem value="embed">
+									Embed document
+								</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Expression</Label>
+						<Input
+							className="nodrag nopan h-7 text-xs"
+							placeholder="Search query or file path…"
+							value={cfg.expression ?? ""}
+							onChange={(e) => set("expression", e.target.value)}
+						/>
+					</div>
+				</div>
+			);
+
+		case "storage-engine":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<EngineSelect
+						engineTypeKey="STORAGE"
+						value={cfg.engineId ?? ""}
+						onChange={(v) => set("engineId", v)}
+					/>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Operation</Label>
+						<Select
+							value={cfg.operation ?? "list"}
+							onValueChange={(v) => set("operation", v)}
+						>
+							<SelectTrigger className="h-7 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="list">List</SelectItem>
+								<SelectItem value="read">Read</SelectItem>
+								<SelectItem value="write">Write</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Path</Label>
+						<Input
+							className="nodrag nopan h-7 text-xs"
+							placeholder="/folder/file.txt"
+							value={cfg.path ?? ""}
+							onChange={(e) => set("path", e.target.value)}
+						/>
+					</div>
+				</div>
+			);
+
+		case "function-engine":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<EngineSelect
+						engineTypeKey="FUNCTION"
+						value={cfg.engineId ?? ""}
+						onChange={(v) => set("engineId", v)}
+					/>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Parameters</Label>
+						<Textarea
+							className="nodrag nopan text-xs"
+							rows={2}
+							placeholder='{"key": "value"}'
+							value={cfg.paramsExpression ?? ""}
+							onChange={(e) =>
+								set("paramsExpression", e.target.value)
+							}
+						/>
+					</div>
+				</div>
+			);
+
+		case "custom-pixel":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Pixel expression</Label>
+						<Textarea
+							className="nodrag nopan font-mono text-xs"
+							rows={4}
+							placeholder="MyReactor(param=[${upstreamNode}]);"
+							value={cfg.pixel ?? ""}
+							onChange={(e) => set("pixel", e.target.value)}
+						/>
+					</div>
+				</div>
+			);
+
+		case "transform":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Operation</Label>
+						<Select
+							value={cfg.operation ?? "map"}
+							onValueChange={(v) => set("operation", v)}
+						>
+							<SelectTrigger className="h-7 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="map">Map</SelectItem>
+								<SelectItem value="filter">Filter</SelectItem>
+								<SelectItem value="reduce">Reduce</SelectItem>
+								<SelectItem value="flatten">Flatten</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Expression</Label>
+						<Textarea
+							className="nodrag nopan font-mono text-xs"
+							rows={3}
+							placeholder="item => item.value"
+							value={cfg.expression ?? ""}
+							onChange={(e) => set("expression", e.target.value)}
+						/>
+					</div>
+				</div>
+			);
+
+		default:
+			return (
+				<div className="p-2 text-muted-foreground text-xs">
+					No configuration for this node type.
+				</div>
+			);
+	}
+};
+
+/**
+ * Custom ReactFlow node — clicking the header toggles inline expansion.
+ * Config updates go through onNodeUpdate; expansion through toggleExpand.
+ */
+export const WorkflowNodeCard: FC<NodeProps<RFWorkflowNode>> = ({ data }) => {
+	const { wfNode } = data;
+	const {
+		expandedNodeId,
+		onNodeUpdate,
+		deleteNode,
+		openSettings,
+		toggleExpand,
+	} = useWorkflowWorkspaceContext();
+
+	const meta = getNodeMeta(wfNode.type);
+	const isExpanded = expandedNodeId === wfNode.id;
+
+	const handleUpdate = (cfg: WorkflowNodeConfig) => {
+		onNodeUpdate({ ...wfNode, config: cfg });
+	};
+
+	return (
+		<div
+			className="min-w-52 rounded-lg border border-border bg-card shadow-md"
+			style={{
+				borderTopWidth: 3,
+				borderTopColor: meta?.color ?? "#475569",
+			}}
+		>
+			<Handle
+				type="target"
+				position={Position.Top}
+				className="!bg-muted-foreground"
+			/>
+
+			{/* Header: label button (expands) + action buttons (siblings, not nested) */}
+			<div className="flex items-center gap-2 px-3 py-2">
+				<button
+					type="button"
+					className="nodrag nopan flex min-w-0 flex-1 cursor-pointer flex-col text-left"
+					onClick={() => toggleExpand(wfNode.id)}
+				>
+					<span className="truncate font-semibold text-sm">
+						{wfNode.label}
+					</span>
+					<span className="text-muted-foreground text-xs">
+						{meta?.label ?? wfNode.type}
+					</span>
+				</button>
+				<div className="flex shrink-0 items-center gap-1">
+					<button
+						type="button"
+						className="nodrag nopan rounded p-0.5 text-muted-foreground hover:text-foreground"
+						onClick={() => openSettings(wfNode.id)}
+						title="Full settings"
+					>
+						<Settings className="size-3.5" />
+					</button>
+					<button
+						type="button"
+						className="nodrag nopan rounded p-0.5 text-muted-foreground hover:text-destructive"
+						onClick={() => deleteNode(wfNode.id)}
+						title="Delete node"
+					>
+						<Trash2 className="size-3.5" />
+					</button>
+					{isExpanded ? (
+						<ChevronUp className="size-3.5 text-muted-foreground" />
+					) : (
+						<ChevronDown className="size-3.5 text-muted-foreground" />
+					)}
+				</div>
+			</div>
+
+			{isExpanded && (
+				<div className="border-border border-t">
+					<InlineNodeForm wfNode={wfNode} onUpdate={handleUpdate} />
+				</div>
+			)}
+
+			<Handle
+				type="source"
+				position={Position.Bottom}
+				className="!bg-muted-foreground"
+			/>
+		</div>
+	);
+};

--- a/packages/client/src/components/workflow-workspace/nodes/node-card.tsx
+++ b/packages/client/src/components/workflow-workspace/nodes/node-card.tsx
@@ -1,6 +1,14 @@
 import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
-import { ChevronDown, ChevronUp, Settings, Trash2 } from "lucide-react";
-import type { FC } from "react";
+import {
+	ChevronDown,
+	ChevronUp,
+	ClipboardCopy,
+	Loader2,
+	Play,
+	Settings,
+	Trash2,
+} from "lucide-react";
+import { type FC, useState } from "react";
 import {
 	Input,
 	Label,
@@ -15,8 +23,8 @@ import type { WorkflowNode, WorkflowNodeConfig } from "../workflow.types";
 import { NODE_PALETTE } from "../workflow.types";
 import { useWorkflowWorkspaceContext } from "../workflow-workspace-context";
 
-/** Data shape stored on each ReactFlow node */
-export interface WorkflowNodeData {
+/** Data shape stored on each ReactFlow node — must extend Record<string, unknown> for @xyflow/react v12 */
+export interface WorkflowNodeData extends Record<string, unknown> {
 	wfNode: WorkflowNode;
 }
 
@@ -28,7 +36,6 @@ function getNodeMeta(type: string) {
 
 /**
  * Engine select dropdown — loaded from WorkflowWorkspaceContext.enginesByType.
- * engineTypeKey is the SEMOSS engine type string (e.g. "MODEL", "DATABASE").
  */
 const EngineSelect: FC<{
 	engineTypeKey: string;
@@ -62,14 +69,17 @@ const EngineSelect: FC<{
 	);
 };
 
-/** Inline form rendered when a node is expanded. Per-type form fields. */
+/** Inline form per node type. Fields map to what WorkflowExecutorReactor.buildPixel expects. */
 const InlineNodeForm: FC<{
 	wfNode: WorkflowNode;
 	onUpdate: (cfg: WorkflowNodeConfig) => void;
 }> = ({ wfNode, onUpdate }) => {
-	const cfg = wfNode.config as Record<string, string>;
-	const set = (key: string, val: string) =>
-		onUpdate({ ...cfg, [key]: val } as WorkflowNodeConfig);
+	const cfg = wfNode.config as unknown as Record<
+		string,
+		string | number | undefined
+	>;
+	const set = (key: string, val: string | number) =>
+		onUpdate({ ...cfg, [key]: val } as unknown as WorkflowNodeConfig);
 
 	switch (wfNode.type) {
 		case "trigger":
@@ -78,7 +88,7 @@ const InlineNodeForm: FC<{
 					<div className="flex flex-col gap-1">
 						<Label className="text-xs">Mode</Label>
 						<Select
-							value={cfg.mode ?? "manual"}
+							value={(cfg.mode as string) ?? "manual"}
 							onValueChange={(v) => set("mode", v)}
 						>
 							<SelectTrigger className="h-7 text-xs">
@@ -98,7 +108,7 @@ const InlineNodeForm: FC<{
 							<Input
 								className="nodrag nopan h-7 text-xs"
 								placeholder="0 * * * *"
-								value={cfg.cronExpression ?? ""}
+								value={(cfg.cronExpression as string) ?? ""}
 								onChange={(e) =>
 									set("cronExpression", e.target.value)
 								}
@@ -113,7 +123,7 @@ const InlineNodeForm: FC<{
 				<div className="nodrag nopan flex flex-col gap-2 p-2">
 					<EngineSelect
 						engineTypeKey="MODEL"
-						value={cfg.engineId ?? ""}
+						value={(cfg.engineId as string) ?? ""}
 						onChange={(v) => set("engineId", v)}
 					/>
 					<div className="flex flex-col gap-1">
@@ -121,11 +131,42 @@ const InlineNodeForm: FC<{
 						<Textarea
 							className="nodrag nopan text-xs"
 							rows={3}
-							placeholder="Prompt… use ${nodeId} for upstream output"
-							value={cfg.promptTemplate ?? ""}
+							placeholder={`Enter prompt… use \${nodeId} for upstream output`}
+							value={(cfg.promptTemplate as string) ?? ""}
 							onChange={(e) =>
 								set("promptTemplate", e.target.value)
 							}
+						/>
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">
+							System message{" "}
+							<span className="text-muted-foreground">
+								(optional)
+							</span>
+						</Label>
+						<Textarea
+							className="nodrag nopan text-xs"
+							rows={2}
+							placeholder="You are a helpful assistant…"
+							value={(cfg.systemMessage as string) ?? ""}
+							onChange={(e) =>
+								set("systemMessage", e.target.value)
+							}
+						/>
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">
+							Parameters{" "}
+							<span className="text-muted-foreground">
+								(optional JSON)
+							</span>
+						</Label>
+						<Input
+							className="nodrag nopan h-7 font-mono text-xs"
+							placeholder='{"temperature": 0.7, "max_tokens": 512}'
+							value={(cfg.paramValues as string) ?? ""}
+							onChange={(e) => set("paramValues", e.target.value)}
 						/>
 					</div>
 				</div>
@@ -136,31 +177,16 @@ const InlineNodeForm: FC<{
 				<div className="nodrag nopan flex flex-col gap-2 p-2">
 					<EngineSelect
 						engineTypeKey="DATABASE"
-						value={cfg.engineId ?? ""}
+						value={(cfg.engineId as string) ?? ""}
 						onChange={(v) => set("engineId", v)}
 					/>
 					<div className="flex flex-col gap-1">
-						<Label className="text-xs">Operation</Label>
-						<Select
-							value={cfg.operation ?? "query"}
-							onValueChange={(v) => set("operation", v)}
-						>
-							<SelectTrigger className="h-7 text-xs">
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value="query">Query</SelectItem>
-								<SelectItem value="update">Update</SelectItem>
-							</SelectContent>
-						</Select>
-					</div>
-					<div className="flex flex-col gap-1">
-						<Label className="text-xs">SQL expression</Label>
+						<Label className="text-xs">SQL Query</Label>
 						<Textarea
-							className="nodrag nopan text-xs"
-							rows={3}
-							placeholder="SELECT * FROM …"
-							value={cfg.expression ?? ""}
+							className="nodrag nopan font-mono text-xs"
+							rows={4}
+							placeholder={`SELECT * FROM table WHERE col = '\${upstreamNode}'`}
+							value={(cfg.expression as string) ?? ""}
 							onChange={(e) => set("expression", e.target.value)}
 						/>
 					</div>
@@ -172,20 +198,22 @@ const InlineNodeForm: FC<{
 				<div className="nodrag nopan flex flex-col gap-2 p-2">
 					<EngineSelect
 						engineTypeKey="VECTOR"
-						value={cfg.engineId ?? ""}
+						value={(cfg.engineId as string) ?? ""}
 						onChange={(v) => set("engineId", v)}
 					/>
 					<div className="flex flex-col gap-1">
 						<Label className="text-xs">Operation</Label>
 						<Select
-							value={cfg.operation ?? "query"}
+							value={(cfg.operation as string) ?? "query"}
 							onValueChange={(v) => set("operation", v)}
 						>
 							<SelectTrigger className="h-7 text-xs">
 								<SelectValue />
 							</SelectTrigger>
 							<SelectContent>
-								<SelectItem value="query">Query</SelectItem>
+								<SelectItem value="query">
+									Semantic search
+								</SelectItem>
 								<SelectItem value="embed">
 									Embed document
 								</SelectItem>
@@ -193,12 +221,35 @@ const InlineNodeForm: FC<{
 						</Select>
 					</div>
 					<div className="flex flex-col gap-1">
-						<Label className="text-xs">Expression</Label>
+						<Label className="text-xs">Search query</Label>
 						<Input
 							className="nodrag nopan h-7 text-xs"
-							placeholder="Search query or file path…"
-							value={cfg.expression ?? ""}
+							placeholder={`Search term or \${upstreamNode}`}
+							value={(cfg.expression as string) ?? ""}
 							onChange={(e) => set("expression", e.target.value)}
+						/>
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">
+							Result limit{" "}
+							<span className="text-muted-foreground">
+								(optional)
+							</span>
+						</Label>
+						<Input
+							className="nodrag nopan h-7 text-xs"
+							type="number"
+							min={1}
+							placeholder="10"
+							value={(cfg.limit as number) ?? ""}
+							onChange={(e) =>
+								set(
+									"limit",
+									e.target.value
+										? Number(e.target.value)
+										: "",
+								)
+							}
 						/>
 					</div>
 				</div>
@@ -209,22 +260,21 @@ const InlineNodeForm: FC<{
 				<div className="nodrag nopan flex flex-col gap-2 p-2">
 					<EngineSelect
 						engineTypeKey="STORAGE"
-						value={cfg.engineId ?? ""}
+						value={(cfg.engineId as string) ?? ""}
 						onChange={(v) => set("engineId", v)}
 					/>
 					<div className="flex flex-col gap-1">
 						<Label className="text-xs">Operation</Label>
 						<Select
-							value={cfg.operation ?? "list"}
+							value={(cfg.operation as string) ?? "list"}
 							onValueChange={(v) => set("operation", v)}
 						>
 							<SelectTrigger className="h-7 text-xs">
 								<SelectValue />
 							</SelectTrigger>
 							<SelectContent>
-								<SelectItem value="list">List</SelectItem>
-								<SelectItem value="read">Read</SelectItem>
-								<SelectItem value="write">Write</SelectItem>
+								<SelectItem value="list">List files</SelectItem>
+								<SelectItem value="read">Read file</SelectItem>
 							</SelectContent>
 						</Select>
 					</div>
@@ -233,7 +283,7 @@ const InlineNodeForm: FC<{
 						<Input
 							className="nodrag nopan h-7 text-xs"
 							placeholder="/folder/file.txt"
-							value={cfg.path ?? ""}
+							value={(cfg.path as string) ?? ""}
 							onChange={(e) => set("path", e.target.value)}
 						/>
 					</div>
@@ -245,16 +295,21 @@ const InlineNodeForm: FC<{
 				<div className="nodrag nopan flex flex-col gap-2 p-2">
 					<EngineSelect
 						engineTypeKey="FUNCTION"
-						value={cfg.engineId ?? ""}
+						value={(cfg.engineId as string) ?? ""}
 						onChange={(v) => set("engineId", v)}
 					/>
 					<div className="flex flex-col gap-1">
-						<Label className="text-xs">Parameters</Label>
+						<Label className="text-xs">
+							Parameters{" "}
+							<span className="text-muted-foreground">
+								(optional JSON)
+							</span>
+						</Label>
 						<Textarea
-							className="nodrag nopan text-xs"
-							rows={2}
+							className="nodrag nopan font-mono text-xs"
+							rows={3}
 							placeholder='{"key": "value"}'
-							value={cfg.paramsExpression ?? ""}
+							value={(cfg.paramsExpression as string) ?? ""}
 							onChange={(e) =>
 								set("paramsExpression", e.target.value)
 							}
@@ -271,8 +326,8 @@ const InlineNodeForm: FC<{
 						<Textarea
 							className="nodrag nopan font-mono text-xs"
 							rows={4}
-							placeholder="MyReactor(param=[${upstreamNode}]);"
-							value={cfg.pixel ?? ""}
+							placeholder={`MyReactor(param=["\${upstreamNode}"]);`}
+							value={(cfg.pixel as string) ?? ""}
 							onChange={(e) => set("pixel", e.target.value)}
 						/>
 					</div>
@@ -285,7 +340,7 @@ const InlineNodeForm: FC<{
 					<div className="flex flex-col gap-1">
 						<Label className="text-xs">Operation</Label>
 						<Select
-							value={cfg.operation ?? "map"}
+							value={(cfg.operation as string) ?? "map"}
 							onValueChange={(v) => set("operation", v)}
 						>
 							<SelectTrigger className="h-7 text-xs">
@@ -300,12 +355,12 @@ const InlineNodeForm: FC<{
 						</Select>
 					</div>
 					<div className="flex flex-col gap-1">
-						<Label className="text-xs">Expression</Label>
+						<Label className="text-xs">Pixel expression</Label>
 						<Textarea
 							className="nodrag nopan font-mono text-xs"
 							rows={3}
-							placeholder="item => item.value"
-							value={cfg.expression ?? ""}
+							placeholder="CollectAll()"
+							value={(cfg.expression as string) ?? ""}
 							onChange={(e) => set("expression", e.target.value)}
 						/>
 					</div>
@@ -322,29 +377,92 @@ const InlineNodeForm: FC<{
 };
 
 /**
- * Custom ReactFlow node — clicking the header toggles inline expansion.
- * Config updates go through onNodeUpdate; expansion through toggleExpand.
+ * Output ref chip + output preview — shown when a node is expanded.
+ * The ref chip copies ${nodeId} to clipboard for pasting into downstream nodes.
+ */
+const NodeOutputSection: FC<{ nodeId: string; output?: string }> = ({
+	nodeId,
+	output,
+}) => {
+	const ref = `\${${nodeId}}`;
+	const [copied, setCopied] = useState(false);
+
+	const copy = () => {
+		navigator.clipboard.writeText(ref).then(() => {
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1500);
+		});
+	};
+
+	return (
+		<div className="nodrag nopan border-border border-t px-2 pt-1.5 pb-2">
+			<div className="mb-1 flex items-center gap-1.5">
+				<span className="text-muted-foreground text-xs">
+					Output ref:
+				</span>
+				<button
+					type="button"
+					onClick={copy}
+					className="flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] hover:bg-muted/80"
+					title="Copy reference to clipboard"
+				>
+					<code>{ref}</code>
+					<ClipboardCopy className="size-2.5" />
+				</button>
+				{copied && (
+					<span className="text-[10px] text-green-600">Copied!</span>
+				)}
+			</div>
+			{output && (
+				<pre className="max-h-28 overflow-y-auto whitespace-pre-wrap break-words rounded bg-muted p-1.5 text-[10px] leading-relaxed">
+					{output}
+				</pre>
+			)}
+		</div>
+	);
+};
+
+/**
+ * Custom ReactFlow node.
+ * Header: label (expand toggle) + Run button + Settings + Delete.
+ * Expanded: inline form + output ref chip + output preview.
  */
 export const WorkflowNodeCard: FC<NodeProps<RFWorkflowNode>> = ({ data }) => {
 	const { wfNode } = data;
 	const {
 		expandedNodeId,
+		nodeOutputs,
 		onNodeUpdate,
 		deleteNode,
 		openSettings,
 		toggleExpand,
+		runNode,
 	} = useWorkflowWorkspaceContext();
+
+	const [isRunning, setIsRunning] = useState(false);
 
 	const meta = getNodeMeta(wfNode.type);
 	const isExpanded = expandedNodeId === wfNode.id;
+	const output = nodeOutputs[wfNode.id];
+	const isTrigger = wfNode.type === "trigger";
 
 	const handleUpdate = (cfg: WorkflowNodeConfig) => {
 		onNodeUpdate({ ...wfNode, config: cfg });
 	};
 
+	const handleRun = async (e: React.MouseEvent) => {
+		e.stopPropagation();
+		setIsRunning(true);
+		try {
+			await runNode(wfNode.id);
+		} finally {
+			setIsRunning(false);
+		}
+	};
+
 	return (
 		<div
-			className="min-w-52 rounded-lg border border-border bg-card shadow-md"
+			className="min-w-56 rounded-lg border border-border bg-card shadow-md"
 			style={{
 				borderTopWidth: 3,
 				borderTopColor: meta?.color ?? "#475569",
@@ -356,8 +474,8 @@ export const WorkflowNodeCard: FC<NodeProps<RFWorkflowNode>> = ({ data }) => {
 				className="!bg-muted-foreground"
 			/>
 
-			{/* Header: label button (expands) + action buttons (siblings, not nested) */}
-			<div className="flex items-center gap-2 px-3 py-2">
+			{/* Header */}
+			<div className="flex items-center gap-1.5 px-3 py-2">
 				<button
 					type="button"
 					className="nodrag nopan flex min-w-0 flex-1 cursor-pointer flex-col text-left"
@@ -370,34 +488,78 @@ export const WorkflowNodeCard: FC<NodeProps<RFWorkflowNode>> = ({ data }) => {
 						{meta?.label ?? wfNode.type}
 					</span>
 				</button>
-				<div className="flex shrink-0 items-center gap-1">
+
+				{/* Run button — hidden for trigger nodes */}
+				{!isTrigger && (
 					<button
 						type="button"
-						className="nodrag nopan rounded p-0.5 text-muted-foreground hover:text-foreground"
-						onClick={() => openSettings(wfNode.id)}
-						title="Full settings"
+						aria-label="Run node"
+						disabled={isRunning}
+						onClick={handleRun}
+						className="nodrag nopan flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-green-600 disabled:opacity-50"
 					>
-						<Settings className="size-3.5" />
+						{isRunning ? (
+							<Loader2 className="size-3.5 animate-spin" />
+						) : (
+							<Play className="size-3.5" />
+						)}
 					</button>
-					<button
-						type="button"
-						className="nodrag nopan rounded p-0.5 text-muted-foreground hover:text-destructive"
-						onClick={() => deleteNode(wfNode.id)}
-						title="Delete node"
-					>
-						<Trash2 className="size-3.5" />
-					</button>
+				)}
+
+				<button
+					type="button"
+					aria-label="Node settings"
+					onClick={(e) => {
+						e.stopPropagation();
+						openSettings(wfNode.id);
+					}}
+					className="nodrag nopan flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+				>
+					<Settings className="size-3.5" />
+				</button>
+
+				<button
+					type="button"
+					aria-label="Delete node"
+					onClick={(e) => {
+						e.stopPropagation();
+						deleteNode(wfNode.id);
+					}}
+					className="nodrag nopan flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-destructive"
+				>
+					<Trash2 className="size-3.5" />
+				</button>
+
+				<span className="ml-0.5 shrink-0 text-muted-foreground">
 					{isExpanded ? (
-						<ChevronUp className="size-3.5 text-muted-foreground" />
+						<ChevronUp className="size-3.5" />
 					) : (
-						<ChevronDown className="size-3.5 text-muted-foreground" />
+						<ChevronDown className="size-3.5" />
 					)}
-				</div>
+				</span>
 			</div>
 
+			{/* Inline expanded content */}
 			{isExpanded && (
-				<div className="border-border border-t">
-					<InlineNodeForm wfNode={wfNode} onUpdate={handleUpdate} />
+				<>
+					<div className="border-border border-t">
+						<InlineNodeForm
+							wfNode={wfNode}
+							onUpdate={handleUpdate}
+						/>
+					</div>
+					{!isTrigger && (
+						<NodeOutputSection nodeId={wfNode.id} output={output} />
+					)}
+				</>
+			)}
+
+			{/* Collapsed output indicator */}
+			{!isExpanded && output && (
+				<div className="border-border border-t px-3 py-1">
+					<span className="text-[10px] text-green-600">
+						✓ output ready
+					</span>
 				</div>
 			)}
 

--- a/packages/client/src/components/workflow-workspace/nodes/node-palette.tsx
+++ b/packages/client/src/components/workflow-workspace/nodes/node-palette.tsx
@@ -1,0 +1,36 @@
+import type { DragEvent, FC } from "react";
+import { NODE_PALETTE } from "../workflow.types";
+
+/**
+ * Left sidebar palette — each item can be dragged onto the ReactFlow canvas.
+ * Sets dataTransfer with the node type so the canvas drop handler can read it.
+ */
+export const NodePalette: FC = () => {
+	const onDragStart = (event: DragEvent<HTMLButtonElement>, type: string) => {
+		event.dataTransfer.setData("application/workflow-node-type", type);
+		event.dataTransfer.effectAllowed = "move";
+	};
+
+	return (
+		<div className="flex h-full w-52 shrink-0 flex-col gap-1 overflow-y-auto border-border border-r bg-background p-2">
+			<p className="px-1 py-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+				Nodes
+			</p>
+			{NODE_PALETTE.map((meta) => (
+				<button
+					key={meta.type}
+					type="button"
+					draggable
+					onDragStart={(e) => onDragStart(e, meta.type)}
+					className="flex cursor-grab flex-col gap-0.5 rounded-md border border-border bg-card px-3 py-2 text-left shadow-sm transition-shadow hover:shadow-md active:cursor-grabbing"
+					style={{ borderLeftWidth: 3, borderLeftColor: meta.color }}
+				>
+					<span className="font-medium text-sm">{meta.label}</span>
+					<span className="line-clamp-2 text-muted-foreground text-xs">
+						{meta.description}
+					</span>
+				</button>
+			))}
+		</div>
+	);
+};

--- a/packages/client/src/components/workflow-workspace/workflow-workspace-context.tsx
+++ b/packages/client/src/components/workflow-workspace/workflow-workspace-context.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext } from "react";
+import type { EngineOption, WorkflowNode } from "./workflow.types";
+
+interface WorkflowWorkspaceContextValue {
+	/** Engines indexed by type string (e.g. "MODEL", "DATABASE") */
+	enginesByType: Record<string, EngineOption[]>;
+	/** ID of the node currently expanded inline on the canvas (or null) */
+	expandedNodeId: string | null;
+	/** Look up a workflow node by its id */
+	getWfNode: (id: string) => WorkflowNode | undefined;
+	/** Persist an updated node's config/label without toggling expansion */
+	onNodeUpdate: (updated: WorkflowNode) => void;
+	/** Toggle inline expansion for a node */
+	toggleExpand: (id: string) => void;
+	/** Remove a node from the canvas */
+	deleteNode: (id: string) => void;
+	/** Open the full settings panel for a node */
+	openSettings: (id: string) => void;
+}
+
+export const WorkflowWorkspaceContext =
+	createContext<WorkflowWorkspaceContextValue | null>(null);
+
+export function useWorkflowWorkspaceContext(): WorkflowWorkspaceContextValue {
+	const ctx = useContext(WorkflowWorkspaceContext);
+	if (!ctx) {
+		throw new Error(
+			"useWorkflowWorkspaceContext must be used inside WorkflowWorkspaceContext.Provider",
+		);
+	}
+	return ctx;
+}

--- a/packages/client/src/components/workflow-workspace/workflow-workspace-context.tsx
+++ b/packages/client/src/components/workflow-workspace/workflow-workspace-context.tsx
@@ -6,6 +6,8 @@ interface WorkflowWorkspaceContextValue {
 	enginesByType: Record<string, EngineOption[]>;
 	/** ID of the node currently expanded inline on the canvas (or null) */
 	expandedNodeId: string | null;
+	/** Last known string output keyed by node id */
+	nodeOutputs: Record<string, string>;
 	/** Look up a workflow node by its id */
 	getWfNode: (id: string) => WorkflowNode | undefined;
 	/** Persist an updated node's config/label without toggling expansion */
@@ -16,6 +18,8 @@ interface WorkflowWorkspaceContextValue {
 	deleteNode: (id: string) => void;
 	/** Open the full settings panel for a node */
 	openSettings: (id: string) => void;
+	/** Run a single node's pixel and store its output */
+	runNode: (nodeId: string) => Promise<void>;
 }
 
 export const WorkflowWorkspaceContext =

--- a/packages/client/src/components/workflow-workspace/workflow-workspace.tsx
+++ b/packages/client/src/components/workflow-workspace/workflow-workspace.tsx
@@ -73,6 +73,112 @@ function wfEdgeToRF(wfEdge: WorkflowEdge): Edge {
 	};
 }
 
+/** Escape double-quotes and backslashes for embedding in a Pixel string literal */
+function escapePixel(s: string): string {
+	return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/** Replace ${nodeId} tokens with known outputs */
+function substituteVars(
+	template: string,
+	outputs: Record<string, string>,
+): string {
+	return template.replace(/\$\{([^}]+)\}/g, (_, key) => outputs[key] ?? "");
+}
+
+/**
+ * Build the executable pixel for a node using the same logic as
+ * WorkflowExecutorReactor.buildPixel, substituting ${nodeId} vars from
+ * already-known outputs before sending to the server.
+ */
+function assembleNodePixel(
+	wfNode: WorkflowNode,
+	nodeOutputs: Record<string, string>,
+): string | null {
+	const cfg = wfNode.config as unknown as Record<
+		string,
+		string | number | undefined
+	>;
+	let pixel: string | null = null;
+
+	switch (wfNode.type) {
+		case "trigger":
+			return null;
+
+		case "custom-pixel": {
+			const p = (cfg.pixel as string) || "";
+			pixel = p || null;
+			break;
+		}
+
+		case "model-engine": {
+			const engineId = cfg.engineId as string;
+			const prompt = cfg.promptTemplate as string;
+			if (!engineId || !prompt) return null;
+			let px = `LLMChat(engine=["${engineId}"], command=["${escapePixel(prompt)}"]`;
+			if (cfg.systemMessage) {
+				px += `, systemMessage=["${escapePixel(cfg.systemMessage as string)}"]`;
+			}
+			if (cfg.paramValues) {
+				px += `, paramValues=[${cfg.paramValues}]`;
+			}
+			px += ");";
+			pixel = px;
+			break;
+		}
+
+		case "database-engine": {
+			const engineId = cfg.engineId as string;
+			const query = cfg.expression as string;
+			if (!engineId || !query) return null;
+			pixel = `DatabaseQuery(engine=["${engineId}"], query=["${escapePixel(query)}"]);`;
+			break;
+		}
+
+		case "vector-engine": {
+			const engineId = cfg.engineId as string;
+			const expression = cfg.expression as string;
+			if (!engineId || !expression) return null;
+			const limit = cfg.limit ? `, limit=[${cfg.limit}]` : "";
+			pixel = `VectorDatabaseQuery(engine=["${engineId}"], command=["${escapePixel(expression)}"]${limit});`;
+			break;
+		}
+
+		case "storage-engine": {
+			const engineId = cfg.engineId as string;
+			const operation = (cfg.operation as string) || "list";
+			const path = (cfg.path as string) || "/";
+			if (!engineId) return null;
+			if (operation === "read") {
+				pixel = `StorageGet(engine=["${engineId}"], path=["${escapePixel(path)}"]);`;
+			} else {
+				pixel = `StorageList(engine=["${engineId}"], path=["${escapePixel(path)}"]);`;
+			}
+			break;
+		}
+
+		case "function-engine": {
+			const engineId = cfg.engineId as string;
+			if (!engineId) return null;
+			const params = cfg.paramsExpression as string;
+			pixel = `FunctionEngine(engine=["${engineId}"]${params ? `, parameters=[${params}]` : ""});`;
+			break;
+		}
+
+		case "transform": {
+			const expression = cfg.expression as string;
+			pixel = expression || null;
+			break;
+		}
+
+		default:
+			return null;
+	}
+
+	if (!pixel) return null;
+	return substituteVars(pixel, nodeOutputs);
+}
+
 /** Inner canvas — must be inside ReactFlowProvider */
 const WorkflowCanvas: FC = () => {
 	const insight = useInsight();
@@ -94,10 +200,11 @@ const WorkflowCanvas: FC = () => {
 		string | null
 	>(null);
 	const [runDetail, setRunDetail] = useState<WorkflowRunDetail | null>(null);
+	const [nodeOutputs, setNodeOutputs] = useState<Record<string, string>>({});
 	const [isSaving, setIsSaving] = useState(false);
 	const [isRunning, setIsRunning] = useState(false);
 
-	// Derived: keep wfNodes in sync with rfNodes (source of truth is rfNodes after drops/moves)
+	// Derived: keep wfNodes in sync with rfNodes
 	const [wfNodes, setWfNodes] = useState<WorkflowNode[]>([]);
 	useEffect(() => {
 		setWfNodes(rfNodes.map((rf) => rfNodeToWf(rf)));
@@ -109,7 +216,7 @@ const WorkflowCanvas: FC = () => {
 		monolithStore
 			.runQuery<[string]>(
 				`GetWorkflow(project=["${appId}"]);`,
-				insight.insightId,
+				workspace.insightId,
 			)
 			.then(({ errors, pixelReturn }) => {
 				if (errors.length > 0) return;
@@ -122,17 +229,20 @@ const WorkflowCanvas: FC = () => {
 				} catch (_) {
 					// empty / malformed JSON — start fresh
 				}
+			})
+			.catch((err) => {
+				console.error("Failed to load workflow:", err);
 			});
 	}, [
 		insight.isReady,
 		appId,
-		insight.insightId,
+		workspace.insightId,
 		monolithStore,
 		setRfNodes,
 		setRfEdges,
 	]);
 
-	// Load engines on mount
+	// Load all engine types in a single batched pixel call
 	useEffect(() => {
 		if (!insight.isReady) return;
 		const engineTypes = [
@@ -142,27 +252,24 @@ const WorkflowCanvas: FC = () => {
 			"STORAGE",
 			"FUNCTION",
 		];
-		Promise.all(
-			engineTypes.map((et) =>
-				monolithStore
-					.runQuery<[EngineOption[]]>(
-						`MyEngines(engineTypes=["${et}"]);`,
-						insight.insightId,
-					)
-					.then(({ errors, pixelReturn }) => {
-						if (errors.length > 0)
-							return [et, [] as EngineOption[]] as const;
-						const list = pixelReturn[0]?.output ?? [];
-						return [et, list] as const;
-					})
-					.catch(() => [et, [] as EngineOption[]] as const),
-			),
-		).then((results) => {
-			const map: Record<string, EngineOption[]> = {};
-			for (const [et, list] of results) map[et] = list;
-			setEnginesByType(map);
-		});
-	}, [insight.isReady, insight.insightId, monolithStore]);
+		const batchPixel = engineTypes
+			.map((et) => `MyEngines(engineTypes=["${et}"]);`)
+			.join("");
+
+		monolithStore
+			.runQuery(batchPixel, workspace.insightId)
+			.then(({ pixelReturn }) => {
+				const map: Record<string, EngineOption[]> = {};
+				engineTypes.forEach((et, i) => {
+					const out = pixelReturn[i]?.output;
+					map[et] = Array.isArray(out) ? (out as EngineOption[]) : [];
+				});
+				setEnginesByType(map);
+			})
+			.catch((err) => {
+				console.error("Failed to load engines:", err);
+			});
+	}, [insight.isReady, workspace.insightId, monolithStore]);
 
 	const onConnect = useCallback(
 		(connection: Connection) =>
@@ -186,7 +293,6 @@ const WorkflowCanvas: FC = () => {
 			);
 			if (!type) return;
 
-			// screenToFlowPosition takes raw client coords (not canvas-relative)
 			const position = rfInstance.screenToFlowPosition({
 				x: event.clientX,
 				y: event.clientY,
@@ -214,7 +320,6 @@ const WorkflowCanvas: FC = () => {
 		event.dataTransfer.dropEffect = "move";
 	}, []);
 
-	// Context callbacks — keep these stable
 	const getWfNode = useCallback(
 		(id: string) => wfNodes.find((n) => n.id === id),
 		[wfNodes],
@@ -244,6 +349,11 @@ const WorkflowCanvas: FC = () => {
 				prev.filter((e) => e.source !== id && e.target !== id),
 			);
 			setExpandedNodeId((cur) => (cur === id ? null : cur));
+			setNodeOutputs((prev) => {
+				const next = { ...prev };
+				delete next[id];
+				return next;
+			});
 		},
 		[setRfNodes, setRfEdges],
 	);
@@ -251,6 +361,48 @@ const WorkflowCanvas: FC = () => {
 	const openSettings = useCallback((id: string) => {
 		setSettingsPanelNodeId(id);
 	}, []);
+
+	/** Run a single node by assembling + executing its pixel */
+	const runNode = useCallback(
+		async (nodeId: string) => {
+			const wfNode = wfNodes.find((n) => n.id === nodeId);
+			if (!wfNode) return;
+
+			const pixel = assembleNodePixel(wfNode, nodeOutputs);
+			if (!pixel) {
+				toast.error(
+					`Node "${wfNode.label}": fill in all required fields before running`,
+				);
+				return;
+			}
+
+			try {
+				const { errors, pixelReturn } = await monolithStore.runQuery(
+					pixel,
+					workspace.insightId,
+				);
+
+				if (errors.length > 0) {
+					toast.error(
+						`Node "${wfNode.label}" error: ${errors.join(", ")}`,
+					);
+					return;
+				}
+
+				const raw = pixelReturn[0]?.output;
+				const output =
+					typeof raw === "string"
+						? raw
+						: JSON.stringify(raw, null, 2);
+
+				setNodeOutputs((prev) => ({ ...prev, [nodeId]: output }));
+			} catch (e) {
+				toast.error(`Node run failed: ${(e as Error).message}`);
+				throw e;
+			}
+		},
+		[wfNodes, nodeOutputs, monolithStore, workspace.insightId],
+	);
 
 	const saveWorkflow = async () => {
 		setIsSaving(true);
@@ -267,7 +419,7 @@ const WorkflowCanvas: FC = () => {
 			const encoded = encodeURIComponent(JSON.stringify(doc));
 			const { errors } = await monolithStore.runQuery(
 				`SaveWorkflow(project=["${appId}"], json=["<encode>${encoded}</encode>"]);`,
-				insight.insightId,
+				workspace.insightId,
 			);
 			if (errors.length > 0) throw new Error(errors.join(", "));
 			toast.success("Workflow saved");
@@ -285,11 +437,21 @@ const WorkflowCanvas: FC = () => {
 		try {
 			const { errors, pixelReturn } = await monolithStore.runQuery<
 				[WorkflowRunDetail]
-			>(`WorkflowExecutor(project=["${appId}"]);`, insight.insightId);
+			>(`WorkflowExecutor(project=["${appId}"]);`, workspace.insightId);
 			if (errors.length > 0) throw new Error(errors.join(", "));
 			const result = pixelReturn[0]
 				.output as unknown as WorkflowRunDetail;
 			setRunDetail(result);
+
+			// Populate nodeOutputs from the run so per-node output refs work
+			if (result?.nodeResults) {
+				const outputs: Record<string, string> = {};
+				for (const nr of result.nodeResults) {
+					if (nr.output) outputs[nr.nodeId] = nr.output;
+				}
+				setNodeOutputs((prev) => ({ ...prev, ...outputs }));
+			}
+
 			const hasErrors = result?.nodeResults?.some(
 				(r) => r.status === "error",
 			);
@@ -314,11 +476,13 @@ const WorkflowCanvas: FC = () => {
 			value={{
 				enginesByType,
 				expandedNodeId,
+				nodeOutputs,
 				getWfNode,
 				onNodeUpdate,
 				deleteNode,
 				openSettings,
 				toggleExpand,
+				runNode,
 			}}
 		>
 			<div className="flex h-full w-full flex-col">
@@ -351,7 +515,7 @@ const WorkflowCanvas: FC = () => {
 							) : (
 								<Play className="mr-1.5 size-3.5" />
 							)}
-							Run
+							Run All
 						</Button>
 					</div>
 				</div>
@@ -426,7 +590,7 @@ const SettingsPanel: FC<{
 	wfNode: WorkflowNode;
 	onUpdate: (updated: WorkflowNode) => void;
 }> = ({ wfNode, onUpdate }) => {
-	const cfg = wfNode.config as Record<string, string>;
+	const cfg = wfNode.config as unknown as Record<string, string>;
 	const [label, setLabel] = useState(wfNode.label);
 	const [localCfg, setLocalCfg] = useState<Record<string, string>>(cfg);
 
@@ -506,7 +670,7 @@ const SettingsPanel: FC<{
 					onUpdate({
 						...wfNode,
 						label,
-						config: localCfg as WorkflowNodeConfig,
+						config: localCfg as unknown as WorkflowNodeConfig,
 					})
 				}
 			>
@@ -516,7 +680,7 @@ const SettingsPanel: FC<{
 	);
 };
 
-/** Panel showing per-node run results */
+/** Panel showing per-node run results from a full workflow run */
 const RunResultsPanel: FC<{
 	detail: WorkflowRunDetail;
 	onClose: () => void;

--- a/packages/client/src/components/workflow-workspace/workflow-workspace.tsx
+++ b/packages/client/src/components/workflow-workspace/workflow-workspace.tsx
@@ -1,0 +1,586 @@
+import {
+	addEdge,
+	Background,
+	type Connection,
+	Controls,
+	type Edge,
+	MiniMap,
+	type Node,
+	ReactFlow,
+	ReactFlowProvider,
+	useEdgesState,
+	useNodesState,
+	useReactFlow,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import {
+	CheckCircle,
+	Loader2,
+	Play,
+	Save,
+	Settings,
+	XCircle,
+} from "lucide-react";
+import { type FC, useCallback, useEffect, useId, useState } from "react";
+import { useInsight } from "@semoss/sdk/react";
+import {
+	Button,
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+	Textarea,
+	toast,
+} from "@semoss/ui/next";
+import { useRootStore, useWorkspace } from "@/hooks";
+import { WorkflowNodeCard, type WorkflowNodeData } from "./nodes/node-card";
+import { NodePalette } from "./nodes/node-palette";
+import type {
+	EngineOption,
+	WorkflowDocument,
+	WorkflowEdge,
+	WorkflowNode,
+	WorkflowNodeConfig,
+	WorkflowRunDetail,
+} from "./workflow.types";
+import { WorkflowWorkspaceContext } from "./workflow-workspace-context";
+
+const NODE_TYPES = { workflowNode: WorkflowNodeCard };
+
+type RFWorkflowNode = Node<WorkflowNodeData>;
+
+function wfNodeToRF(wfNode: WorkflowNode): RFWorkflowNode {
+	return {
+		id: wfNode.id,
+		type: "workflowNode",
+		position: wfNode.position ?? { x: 200, y: 200 },
+		data: { wfNode },
+	};
+}
+
+function rfNodeToWf(rfNode: RFWorkflowNode): WorkflowNode {
+	return {
+		...rfNode.data.wfNode,
+		position: rfNode.position,
+	};
+}
+
+function wfEdgeToRF(wfEdge: WorkflowEdge): Edge {
+	return {
+		id: wfEdge.id,
+		source: wfEdge.source,
+		target: wfEdge.target,
+	};
+}
+
+/** Inner canvas — must be inside ReactFlowProvider */
+const WorkflowCanvas: FC = () => {
+	const insight = useInsight();
+	const { monolithStore } = useRootStore();
+	const { workspace } = useWorkspace();
+	const appId = workspace.appId;
+	const rfInstance = useReactFlow();
+
+	const [rfNodes, setRfNodes, onNodesChange] = useNodesState<RFWorkflowNode>(
+		[],
+	);
+	const [rfEdges, setRfEdges, onEdgesChange] = useEdgesState<Edge>([]);
+
+	const [enginesByType, setEnginesByType] = useState<
+		Record<string, EngineOption[]>
+	>({});
+	const [expandedNodeId, setExpandedNodeId] = useState<string | null>(null);
+	const [settingsPanelNodeId, setSettingsPanelNodeId] = useState<
+		string | null
+	>(null);
+	const [runDetail, setRunDetail] = useState<WorkflowRunDetail | null>(null);
+	const [isSaving, setIsSaving] = useState(false);
+	const [isRunning, setIsRunning] = useState(false);
+
+	// Derived: keep wfNodes in sync with rfNodes (source of truth is rfNodes after drops/moves)
+	const [wfNodes, setWfNodes] = useState<WorkflowNode[]>([]);
+	useEffect(() => {
+		setWfNodes(rfNodes.map((rf) => rfNodeToWf(rf)));
+	}, [rfNodes]);
+
+	// Load workflow on mount
+	useEffect(() => {
+		if (!insight.isReady || !appId) return;
+		monolithStore
+			.runQuery<[string]>(
+				`GetWorkflow(project=["${appId}"]);`,
+				insight.insightId,
+			)
+			.then(({ errors, pixelReturn }) => {
+				if (errors.length > 0) return;
+				try {
+					const doc: WorkflowDocument = JSON.parse(
+						pixelReturn[0].output,
+					);
+					setRfNodes((doc.nodes ?? []).map((n) => wfNodeToRF(n)));
+					setRfEdges((doc.edges ?? []).map((e) => wfEdgeToRF(e)));
+				} catch (_) {
+					// empty / malformed JSON — start fresh
+				}
+			});
+	}, [
+		insight.isReady,
+		appId,
+		insight.insightId,
+		monolithStore,
+		setRfNodes,
+		setRfEdges,
+	]);
+
+	// Load engines on mount
+	useEffect(() => {
+		if (!insight.isReady) return;
+		const engineTypes = [
+			"MODEL",
+			"DATABASE",
+			"VECTOR",
+			"STORAGE",
+			"FUNCTION",
+		];
+		Promise.all(
+			engineTypes.map((et) =>
+				monolithStore
+					.runQuery<[EngineOption[]]>(
+						`MyEngines(engineTypes=["${et}"]);`,
+						insight.insightId,
+					)
+					.then(({ errors, pixelReturn }) => {
+						if (errors.length > 0)
+							return [et, [] as EngineOption[]] as const;
+						const list = pixelReturn[0]?.output ?? [];
+						return [et, list] as const;
+					})
+					.catch(() => [et, [] as EngineOption[]] as const),
+			),
+		).then((results) => {
+			const map: Record<string, EngineOption[]> = {};
+			for (const [et, list] of results) map[et] = list;
+			setEnginesByType(map);
+		});
+	}, [insight.isReady, insight.insightId, monolithStore]);
+
+	const onConnect = useCallback(
+		(connection: Connection) =>
+			setRfEdges((eds) =>
+				addEdge(
+					{
+						...connection,
+						id: `e-${connection.source}-${connection.target}`,
+					},
+					eds,
+				),
+			),
+		[setRfEdges],
+	);
+
+	const onDrop = useCallback(
+		(event: React.DragEvent<HTMLDivElement>) => {
+			event.preventDefault();
+			const type = event.dataTransfer.getData(
+				"application/workflow-node-type",
+			);
+			if (!type) return;
+
+			// screenToFlowPosition takes raw client coords (not canvas-relative)
+			const position = rfInstance.screenToFlowPosition({
+				x: event.clientX,
+				y: event.clientY,
+			});
+
+			const id = crypto.randomUUID();
+			const newWfNode: WorkflowNode = {
+				id,
+				type: type as WorkflowNode["type"],
+				label: type
+					.split("-")
+					.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+					.join(" "),
+				config: {} as WorkflowNodeConfig,
+				position,
+			};
+
+			setRfNodes((prev) => [...prev, wfNodeToRF(newWfNode)]);
+		},
+		[rfInstance, setRfNodes],
+	);
+
+	const onDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+		event.preventDefault();
+		event.dataTransfer.dropEffect = "move";
+	}, []);
+
+	// Context callbacks — keep these stable
+	const getWfNode = useCallback(
+		(id: string) => wfNodes.find((n) => n.id === id),
+		[wfNodes],
+	);
+
+	const onNodeUpdate = useCallback(
+		(updated: WorkflowNode) => {
+			setRfNodes((prev) =>
+				prev.map((rf) =>
+					rf.id === updated.id
+						? { ...rf, data: { wfNode: updated } }
+						: rf,
+				),
+			);
+		},
+		[setRfNodes],
+	);
+
+	const toggleExpand = useCallback((id: string) => {
+		setExpandedNodeId((cur) => (cur === id ? null : id));
+	}, []);
+
+	const deleteNode = useCallback(
+		(id: string) => {
+			setRfNodes((prev) => prev.filter((rf) => rf.id !== id));
+			setRfEdges((prev) =>
+				prev.filter((e) => e.source !== id && e.target !== id),
+			);
+			setExpandedNodeId((cur) => (cur === id ? null : cur));
+		},
+		[setRfNodes, setRfEdges],
+	);
+
+	const openSettings = useCallback((id: string) => {
+		setSettingsPanelNodeId(id);
+	}, []);
+
+	const saveWorkflow = async () => {
+		setIsSaving(true);
+		try {
+			const doc: WorkflowDocument = {
+				version: "1.0",
+				nodes: wfNodes,
+				edges: rfEdges.map((e) => ({
+					id: e.id,
+					source: e.source,
+					target: e.target,
+				})),
+			};
+			const encoded = encodeURIComponent(JSON.stringify(doc));
+			const { errors } = await monolithStore.runQuery(
+				`SaveWorkflow(project=["${appId}"], json=["<encode>${encoded}</encode>"]);`,
+				insight.insightId,
+			);
+			if (errors.length > 0) throw new Error(errors.join(", "));
+			toast.success("Workflow saved");
+		} catch (e) {
+			toast.error(`Save failed: ${(e as Error).message}`);
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const runWorkflow = async () => {
+		await saveWorkflow();
+		setIsRunning(true);
+		setRunDetail(null);
+		try {
+			const { errors, pixelReturn } = await monolithStore.runQuery<
+				[WorkflowRunDetail]
+			>(`WorkflowExecutor(project=["${appId}"]);`, insight.insightId);
+			if (errors.length > 0) throw new Error(errors.join(", "));
+			const result = pixelReturn[0]
+				.output as unknown as WorkflowRunDetail;
+			setRunDetail(result);
+			const hasErrors = result?.nodeResults?.some(
+				(r) => r.status === "error",
+			);
+			if (hasErrors) {
+				toast.error("Workflow completed with errors — check run panel");
+			} else {
+				toast.success("Workflow run complete");
+			}
+		} catch (e) {
+			toast.error(`Run failed: ${(e as Error).message}`);
+		} finally {
+			setIsRunning(false);
+		}
+	};
+
+	const settingNode = settingsPanelNodeId
+		? wfNodes.find((n) => n.id === settingsPanelNodeId)
+		: null;
+
+	return (
+		<WorkflowWorkspaceContext.Provider
+			value={{
+				enginesByType,
+				expandedNodeId,
+				getWfNode,
+				onNodeUpdate,
+				deleteNode,
+				openSettings,
+				toggleExpand,
+			}}
+		>
+			<div className="flex h-full w-full flex-col">
+				{/* Toolbar */}
+				<div className="flex shrink-0 items-center gap-2 border-border border-b bg-background px-4 py-2">
+					<span className="font-semibold text-sm">
+						Workflow Builder
+					</span>
+					<div className="ml-auto flex items-center gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={isSaving || isRunning}
+							onClick={saveWorkflow}
+						>
+							{isSaving ? (
+								<Loader2 className="mr-1.5 size-3.5 animate-spin" />
+							) : (
+								<Save className="mr-1.5 size-3.5" />
+							)}
+							Save
+						</Button>
+						<Button
+							size="sm"
+							disabled={isRunning || isSaving}
+							onClick={runWorkflow}
+						>
+							{isRunning ? (
+								<Loader2 className="mr-1.5 size-3.5 animate-spin" />
+							) : (
+								<Play className="mr-1.5 size-3.5" />
+							)}
+							Run
+						</Button>
+					</div>
+				</div>
+
+				{/* Main area: palette + canvas + optional run panel */}
+				<div className="flex min-h-0 flex-1">
+					<NodePalette />
+
+					<section
+						aria-label="Workflow canvas"
+						className="flex-1"
+						onDrop={onDrop}
+						onDragOver={onDragOver}
+					>
+						<ReactFlow
+							nodes={rfNodes}
+							edges={rfEdges}
+							nodeTypes={NODE_TYPES}
+							onNodesChange={onNodesChange}
+							onEdgesChange={onEdgesChange}
+							onConnect={onConnect}
+							fitView
+							deleteKeyCode="Delete"
+						>
+							<Background />
+							<Controls />
+							<MiniMap />
+						</ReactFlow>
+					</section>
+
+					{runDetail && (
+						<RunResultsPanel
+							detail={runDetail}
+							onClose={() => setRunDetail(null)}
+						/>
+					)}
+				</div>
+			</div>
+
+			{/* Settings side sheet */}
+			<Sheet
+				open={!!settingNode}
+				onOpenChange={(open) => {
+					if (!open) setSettingsPanelNodeId(null);
+				}}
+			>
+				<SheetContent side="right" className="w-96 overflow-y-auto">
+					<SheetHeader>
+						<SheetTitle className="flex items-center gap-2">
+							<Settings className="size-4" />
+							{settingNode?.label ?? "Node Settings"}
+						</SheetTitle>
+					</SheetHeader>
+					{settingNode && (
+						<SettingsPanel
+							key={settingNode.id}
+							wfNode={settingNode}
+							onUpdate={(updated) => {
+								onNodeUpdate(updated);
+								setSettingsPanelNodeId(null);
+							}}
+						/>
+					)}
+				</SheetContent>
+			</Sheet>
+		</WorkflowWorkspaceContext.Provider>
+	);
+};
+
+/** Full settings panel — standalone component, only mounted when settingNode exists */
+const SettingsPanel: FC<{
+	wfNode: WorkflowNode;
+	onUpdate: (updated: WorkflowNode) => void;
+}> = ({ wfNode, onUpdate }) => {
+	const cfg = wfNode.config as Record<string, string>;
+	const [label, setLabel] = useState(wfNode.label);
+	const [localCfg, setLocalCfg] = useState<Record<string, string>>(cfg);
+
+	const nodeLabelId = useId();
+	const pixelId = useId();
+	const promptId = useId();
+	const expressionId = useId();
+
+	const set = (key: string, val: string) =>
+		setLocalCfg((prev) => ({ ...prev, [key]: val }));
+
+	return (
+		<div className="flex flex-col gap-4 p-4">
+			<div className="flex flex-col gap-1">
+				<label htmlFor={nodeLabelId} className="font-medium text-xs">
+					Node label
+				</label>
+				<input
+					id={nodeLabelId}
+					className="rounded border border-border px-2 py-1 text-sm"
+					value={label}
+					onChange={(e) => setLabel(e.target.value)}
+				/>
+			</div>
+			<div className="flex flex-col gap-1">
+				<span className="text-muted-foreground text-xs">
+					Type: {wfNode.type}
+				</span>
+			</div>
+			{"pixel" in localCfg && (
+				<div className="flex flex-col gap-1">
+					<label htmlFor={pixelId} className="font-medium text-xs">
+						Custom Pixel
+					</label>
+					<Textarea
+						id={pixelId}
+						className="font-mono text-xs"
+						rows={6}
+						value={localCfg.pixel ?? ""}
+						onChange={(e) => set("pixel", e.target.value)}
+					/>
+				</div>
+			)}
+			{"promptTemplate" in localCfg && (
+				<div className="flex flex-col gap-1">
+					<label htmlFor={promptId} className="font-medium text-xs">
+						Prompt template
+					</label>
+					<Textarea
+						id={promptId}
+						className="font-mono text-xs"
+						rows={6}
+						value={localCfg.promptTemplate ?? ""}
+						onChange={(e) => set("promptTemplate", e.target.value)}
+					/>
+				</div>
+			)}
+			{"expression" in localCfg && (
+				<div className="flex flex-col gap-1">
+					<label
+						htmlFor={expressionId}
+						className="font-medium text-xs"
+					>
+						Expression
+					</label>
+					<Textarea
+						id={expressionId}
+						className="font-mono text-xs"
+						rows={4}
+						value={localCfg.expression ?? ""}
+						onChange={(e) => set("expression", e.target.value)}
+					/>
+				</div>
+			)}
+			<Button
+				onClick={() =>
+					onUpdate({
+						...wfNode,
+						label,
+						config: localCfg as WorkflowNodeConfig,
+					})
+				}
+			>
+				Apply
+			</Button>
+		</div>
+	);
+};
+
+/** Panel showing per-node run results */
+const RunResultsPanel: FC<{
+	detail: WorkflowRunDetail;
+	onClose: () => void;
+}> = ({ detail, onClose }) => (
+	<div className="flex w-80 shrink-0 flex-col border-border border-l bg-background">
+		<div className="flex items-center justify-between border-border border-b px-3 py-2">
+			<span className="font-semibold text-sm">Run Results</span>
+			<button
+				type="button"
+				onClick={onClose}
+				className="text-muted-foreground text-xs hover:text-foreground"
+			>
+				✕
+			</button>
+		</div>
+		<div className="flex-1 overflow-y-auto p-2">
+			<div className="mb-2 flex items-center gap-1.5">
+				{detail.status === "success" ? (
+					<CheckCircle className="size-4 text-green-600" />
+				) : (
+					<XCircle className="size-4 text-destructive" />
+				)}
+				<span className="text-muted-foreground text-xs">
+					Run {detail.runId} · {detail.startedAt}
+				</span>
+			</div>
+			<div className="flex flex-col gap-2">
+				{(detail.nodeResults ?? []).map((nr) => (
+					<div
+						key={nr.nodeId}
+						className="rounded border border-border p-2 text-xs"
+					>
+						<div className="flex items-center justify-between">
+							<span className="font-medium">{nr.nodeId}</span>
+							<span
+								className={
+									nr.status === "success"
+										? "text-green-600"
+										: nr.status === "error"
+											? "text-destructive"
+											: "text-muted-foreground"
+								}
+							>
+								{nr.status} · {nr.elapsedMs}ms
+							</span>
+						</div>
+						{nr.error && (
+							<p className="mt-1 text-destructive">{nr.error}</p>
+						)}
+						{nr.output && (
+							<pre className="mt-1 max-h-24 overflow-y-auto whitespace-pre-wrap break-words rounded bg-muted p-1 text-[10px]">
+								{nr.output}
+							</pre>
+						)}
+					</div>
+				))}
+			</div>
+		</div>
+	</div>
+);
+
+/** Public export — wraps canvas in ReactFlowProvider */
+export const WorkflowWorkspace: FC = () => (
+	<ReactFlowProvider>
+		<WorkflowCanvas />
+	</ReactFlowProvider>
+);

--- a/packages/client/src/components/workflow-workspace/workflow.types.ts
+++ b/packages/client/src/components/workflow-workspace/workflow.types.ts
@@ -32,11 +32,14 @@ export interface VectorEngineConfig {
 	engineId: string;
 	operation: "query" | "embed";
 	expression?: string;
+	limit?: number;
 }
 
 export interface ModelEngineConfig {
 	engineId: string;
 	promptTemplate: string;
+	systemMessage?: string;
+	paramValues?: string; // JSON object string e.g. {"temperature": 0.7}
 }
 
 export interface FunctionEngineConfig {

--- a/packages/client/src/components/workflow-workspace/workflow.types.ts
+++ b/packages/client/src/components/workflow-workspace/workflow.types.ts
@@ -1,0 +1,213 @@
+/** All node types supported by the workflow builder */
+export type WorkflowNodeType =
+	| "trigger"
+	| "database-engine"
+	| "storage-engine"
+	| "vector-engine"
+	| "model-engine"
+	| "function-engine"
+	| "custom-pixel"
+	| "transform"
+	| "conditional"
+	| "fan-out";
+
+export interface TriggerConfig {
+	mode: "manual" | "schedule";
+	cronExpression?: string;
+}
+
+export interface DatabaseEngineConfig {
+	engineId: string;
+	operation: "query" | "update";
+	expression: string;
+}
+
+export interface StorageEngineConfig {
+	engineId: string;
+	operation: "list" | "read" | "write";
+	path?: string;
+}
+
+export interface VectorEngineConfig {
+	engineId: string;
+	operation: "query" | "embed";
+	expression?: string;
+}
+
+export interface ModelEngineConfig {
+	engineId: string;
+	promptTemplate: string;
+}
+
+export interface FunctionEngineConfig {
+	engineId: string;
+	paramsExpression?: string;
+}
+
+export interface CustomPixelConfig {
+	pixel: string;
+}
+
+export interface TransformConfig {
+	operation: "map" | "filter" | "reduce" | "flatten";
+	expression: string;
+}
+
+export interface ConditionalConfig {
+	condition: string;
+}
+
+export interface FanOutConfig {
+	inputVar: string;
+	itemAlias: string;
+	parallelism?: number;
+}
+
+export type WorkflowNodeConfig =
+	| TriggerConfig
+	| DatabaseEngineConfig
+	| StorageEngineConfig
+	| VectorEngineConfig
+	| ModelEngineConfig
+	| FunctionEngineConfig
+	| CustomPixelConfig
+	| TransformConfig
+	| ConditionalConfig
+	| FanOutConfig;
+
+export interface WorkflowNode {
+	id: string;
+	type: WorkflowNodeType;
+	label: string;
+	config: WorkflowNodeConfig;
+	position?: { x: number; y: number };
+}
+
+export interface WorkflowEdge {
+	id: string;
+	source: string;
+	target: string;
+}
+
+export interface WorkflowDocument {
+	version: string;
+	nodes: WorkflowNode[];
+	edges: WorkflowEdge[];
+}
+
+export interface EngineOption {
+	engine_id: string;
+	engine_name: string;
+	engine_display_name?: string;
+	engine_type: string;
+}
+
+export interface WorkflowRunNodeResult {
+	nodeId: string;
+	nodeType: string;
+	status: "success" | "error" | "skipped";
+	output?: string;
+	error?: string;
+	elapsedMs: number;
+}
+
+export interface WorkflowRunSummary {
+	runId: string;
+	projectId: string;
+	startedAt: string;
+	status: "success" | "error";
+	nodeCount: number;
+}
+
+export interface WorkflowRunDetail extends WorkflowRunSummary {
+	nodeResults: WorkflowRunNodeResult[];
+}
+
+/** Palette entry — one card per node type in the left sidebar */
+export interface NodePaletteMeta {
+	type: WorkflowNodeType;
+	label: string;
+	description: string;
+	color: string;
+	defaultConfig: WorkflowNodeConfig;
+}
+
+export const NODE_PALETTE: NodePaletteMeta[] = [
+	{
+		type: "trigger",
+		label: "Trigger",
+		description: "Start the workflow manually or on a schedule",
+		color: "#7c3aed",
+		defaultConfig: { mode: "manual" } as TriggerConfig,
+	},
+	{
+		type: "model-engine",
+		label: "Model Engine",
+		description: "Call an LLM with a prompt template",
+		color: "#2563eb",
+		defaultConfig: {
+			engineId: "",
+			promptTemplate: "",
+		} as ModelEngineConfig,
+	},
+	{
+		type: "database-engine",
+		label: "Database Engine",
+		description: "Query or update a database engine",
+		color: "#059669",
+		defaultConfig: {
+			engineId: "",
+			operation: "query",
+			expression: "",
+		} as DatabaseEngineConfig,
+	},
+	{
+		type: "vector-engine",
+		label: "Vector Engine",
+		description: "Query a vector database or embed documents",
+		color: "#d97706",
+		defaultConfig: {
+			engineId: "",
+			operation: "query",
+			expression: "",
+		} as VectorEngineConfig,
+	},
+	{
+		type: "storage-engine",
+		label: "Storage Engine",
+		description: "Read or write files in a storage engine",
+		color: "#db2777",
+		defaultConfig: {
+			engineId: "",
+			operation: "list",
+			path: "",
+		} as StorageEngineConfig,
+	},
+	{
+		type: "function-engine",
+		label: "Function Engine",
+		description: "Call a function engine with parameters",
+		color: "#0891b2",
+		defaultConfig: {
+			engineId: "",
+			paramsExpression: "",
+		} as FunctionEngineConfig,
+	},
+	{
+		type: "custom-pixel",
+		label: "Custom Pixel",
+		description: "Execute any Pixel expression",
+		color: "#475569",
+		defaultConfig: { pixel: "" } as CustomPixelConfig,
+	},
+	{
+		type: "transform",
+		label: "Transform",
+		description: "Map, filter, or reduce data between nodes",
+		color: "#9333ea",
+		defaultConfig: {
+			operation: "map",
+			expression: "",
+		} as TransformConfig,
+	},
+];

--- a/packages/client/src/components/workspace/workspace.tsx
+++ b/packages/client/src/components/workspace/workspace.tsx
@@ -24,6 +24,11 @@ const AgentWorkspace = lazy(() =>
 		default: m.AgentWorkspace,
 	})),
 );
+const WorkflowWorkspace = lazy(() =>
+	import("@/components/workflow-workspace").then((m) => ({
+		default: m.WorkflowWorkspace,
+	})),
+);
 
 import { useRootStore } from "@/hooks";
 import type { WorkspaceStore } from "@/stores";
@@ -123,6 +128,7 @@ export const Workspace: React.FC<WorkspaceProps> = ({ app }) => {
 				{workspace.type === "BLOCKS" && <BlocksWorkspace />}
 				{workspace.type === "SKILL" && <SkillWorkspace />}
 				{workspace.type === "WORKSPACE" && <AgentWorkspace />}
+				{workspace.type === "WORKFLOW" && <WorkflowWorkspace />}
 			</Suspense>
 		</WorkspaceContext.Provider>
 	);

--- a/packages/client/src/stores/config/config.store.ts
+++ b/packages/client/src/stores/config/config.store.ts
@@ -816,6 +816,8 @@ export class ConfigStore {
 			workspace.type = "SKILL";
 		} else if (metadata.project_type === "WORKSPACE") {
 			workspace.type = "WORKSPACE";
+		} else if (metadata.project_type === "WORKFLOW") {
+			workspace.type = "WORKFLOW";
 		}
 
 		// create the newly loaded workspace

--- a/packages/client/src/stores/workspace/workspace.store.ts
+++ b/packages/client/src/stores/workspace/workspace.store.ts
@@ -39,7 +39,7 @@ export interface WorkspaceStoreInterface {
 	/**
 	 * Type of the app
 	 */
-	type: "BLOCKS" | "CODE" | "SKILL" | "WORKSPACE";
+	type: "BLOCKS" | "CODE" | "SKILL" | "WORKSPACE" | "WORKFLOW";
 
 	/**
 	 * Model associated with the layout
@@ -120,7 +120,7 @@ export interface WorkspaceConfigInterface {
 	/**
 	 * Type of the app
 	 */
-	type: "BLOCKS" | "CODE" | "SKILL" | "WORKSPACE";
+	type: "BLOCKS" | "CODE" | "SKILL" | "WORKSPACE" | "WORKFLOW";
 
 	/**
 	 * Metadata associated with the loaded app


### PR DESCRIPTION
## Description

Adds a Visual Pixel Workflow Builder as a new app workspace type in semoss-ui. Users can create a new "Workflow" app from the landing page, then use a drag-and-drop ReactFlow canvas to compose, configure, save, and execute multi-node Pixel pipelines.

## Changes Made

**New app type plumbing:**
- `packages/client/src/components/app/app.types.ts` — added `"WORKFLOW"` to `AppType` union
- `packages/client/src/stores/workspace/workspace.store.ts` — added `"WORKFLOW"` to workspace type union
- `packages/client/src/stores/config/config.store.ts` — added `WORKFLOW` branch in `createWorkspace()` to set `workspace.type = "WORKFLOW"`
- `packages/client/src/components/workspace/workspace.tsx` — lazy-imports and renders `<WorkflowWorkspace />` when `workspace.type === "WORKFLOW"`
- `packages/client/src/components/landing/landing-header.tsx` — added 4th "Build a workflow" card; updated grid to `lg:grid-cols-4`
- `packages/client/src/components/landing/developer-user-screen.tsx` — added `workflow` case calling `setNewAppOptions({ type: "workflow" })`
- `packages/client/src/components/app/NewAppModal.tsx` — added `workflow` branch that calls `CreateProject(projectType=["WORKFLOW"])`

**New workflow-workspace components (`packages/client/src/components/workflow-workspace/`):**
- `workflow.types.ts` — TypeScript types: `WorkflowNodeType`, per-type config interfaces, `WorkflowDocument`, `EngineOption`, `WorkflowRunDetail`, `NODE_PALETTE` metadata array
- `workflow-workspace-context.tsx` — React context providing `enginesByType`, `expandedNodeId`, `onNodeUpdate`, `toggleExpand`, `deleteNode`, `openSettings` to all child components
- `nodes/node-palette.tsx` — left sidebar with draggable node type cards (8 node types)
- `nodes/node-card.tsx` — custom ReactFlow node with inline expand/collapse form per node type, engine dropdowns loaded from context, settings and delete buttons
- `workflow-workspace.tsx` — main canvas component wrapping ReactFlow, toolbar (Save/Run), settings side-sheet (`Sheet`), run results panel, and the `WorkflowWorkspaceContext.Provider`
- `index.ts` — barrel export

## How to Test

1. Start SEMOSS: `make status` should return HTTP 200/302
2. Open http://localhost:9092/SemossWeb/packages/client/dist/#/login and log in
3. From the landing page, click **"Build a workflow"** → name it → confirm creation
4. The workspace should load showing the Workflow Builder toolbar, a left node palette, and an empty ReactFlow canvas
5. Drag a **Trigger** node from the palette onto the canvas
6. Drag a **Custom Pixel** node onto the canvas, click its label to expand inline, enter a pixel expression
7. Connect the Trigger → Custom Pixel by dragging from the source handle (bottom) to the target handle (top)
8. Click **Save** — should show "Workflow saved" toast
9. Click **Run** — should show "Workflow run complete" toast and open the Run Results panel on the right
10. Click the Settings icon (⚙) on any node to open the full settings side-sheet and edit the node label

## Notes

- Uses `@xyflow/react` v12 (`useReactFlow()` hook, `screenToFlowPosition` takes raw `clientX/clientY`)
- Node IDs use `crypto.randomUUID()` to avoid HMR counter stale-state bugs
- The `SettingsPanel` uses `useId()` for all label/input pairs to avoid duplicate DOM IDs
- Canvas drop target uses `<section aria-label="Workflow canvas">` for semantic accessibility
- Node palette items are `<button draggable>` for proper interactive semantics per Biome a11y rules