### PR TITLE
feat: role-based feature visibility UI (App Profiles + Platform Profiles)

### DIFF
--- a/packages/client/src/components/app/NewAppModal.tsx
+++ b/packages/client/src/components/app/NewAppModal.tsx
@@ -29,7 +29,10 @@ type NewAppForm = {
 
 interface NewAppModalProps {
 	open: boolean;
-	options: { type: "blocks"; state: SerializedState } | { type: "code" };
+	options:
+		| { type: "blocks"; state: SerializedState }
+		| { type: "code" }
+		| { type: "workflow" };
 	onClose: (appId?: string) => void;
 }
 
@@ -169,6 +172,42 @@ export const NewAppModal = (props: NewAppModalProps) => {
 
 					if (operationType.indexOf("ERROR") > -1) {
 						toast.error(output);
+					}
+				}
+			} else if (type === "workflow") {
+				const pixel = `CreateProject(project=["${data.APP_NAME}"], portal=[true], projectType=["WORKFLOW"]);`;
+				const { errors, pixelReturn } =
+					await monolithStore.runQuery<[AppMetadata]>(pixel);
+
+				if (errors.length > 0) throw new Error(errors.join(","));
+
+				appId = pixelReturn[0].output.project_id;
+
+				if (data.APP_IMG && appId) {
+					await uploadImage(
+						data.APP_IMG,
+						appId,
+						configStore.store.insightID,
+					);
+				}
+
+				if (data.APP_TAGS.length || data.APP_DESCRIPTION) {
+					const setProjectMetadataResponse =
+						await monolithStore.runQuery(
+							`SetProjectMetadata(project=["${appId}"], meta=[${JSON.stringify(
+								{
+									tag: data.APP_TAGS,
+									description: data.APP_DESCRIPTION,
+								},
+							)}])`,
+						);
+					const output =
+						setProjectMetadataResponse.pixelReturn[0].output;
+					const operationType =
+						setProjectMetadataResponse.pixelReturn[0].operationType;
+					if (operationType.indexOf("ERROR") > -1) {
+						toast.error(output);
+						return;
 					}
 				}
 			} else {

--- a/packages/client/src/components/app/app.types.ts
+++ b/packages/client/src/components/app/app.types.ts
@@ -7,6 +7,7 @@ export type AppType =
 	| "INSIGHT"
 	| "SKILL"
 	| "WORKSPACE"
+	| "WORKFLOW"
 	| "";
 
 /**

--- a/packages/client/src/components/landing/developer-user-screen.tsx
+++ b/packages/client/src/components/landing/developer-user-screen.tsx
@@ -123,6 +123,10 @@ export const DeveloperUserScreen = observer(() => {
 							});
 						} else if (type === "agent") {
 							navigate("/app/new/prompt");
+						} else if (type === "workflow") {
+							setNewAppOptions({
+								type: "workflow",
+							});
 						}
 					}}
 				/>

--- a/packages/client/src/components/landing/landing-header.tsx
+++ b/packages/client/src/components/landing/landing-header.tsx
@@ -36,18 +36,26 @@ const CARDS = [
 		type: "agent",
 		testId: "new-app-agent-btn",
 	},
+	{
+		title: "Build a workflow",
+		description:
+			"Connect engines, models, and data sources into a visual pipeline. Design, save, and execute multi-step workflows with drag-and-drop nodes.",
+		image: Appagent,
+		type: "workflow",
+		testId: "new-app-workflow-btn",
+	},
 ] as const;
 
 interface LandingHeaderProps {
 	/** Trigger creation of a new app */
-	onCreate: (type: "blocks" | "code" | "agent") => void;
+	onCreate: (type: "blocks" | "code" | "agent" | "workflow") => void;
 }
 
 export const LandingHeader: React.FC<LandingHeaderProps> = ({
 	onCreate = () => null,
 }) => {
 	return (
-		<div className="grid w-full grid-cols-1 gap-4 md:grid-cols-3">
+		<div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
 			{CARDS.map((card) => (
 				<Card
 					key={card.title}

--- a/packages/client/src/components/workflow-workspace/index.ts
+++ b/packages/client/src/components/workflow-workspace/index.ts
@@ -1,0 +1,2 @@
+export type { WorkflowNodeData } from "./nodes/node-card";
+export { WorkflowWorkspace } from "./workflow-workspace";

--- a/packages/client/src/components/workflow-workspace/nodes/node-card.tsx
+++ b/packages/client/src/components/workflow-workspace/nodes/node-card.tsx
@@ -1,0 +1,411 @@
+import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
+import { ChevronDown, ChevronUp, Settings, Trash2 } from "lucide-react";
+import type { FC } from "react";
+import {
+	Input,
+	Label,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	Textarea,
+} from "@semoss/ui/next";
+import type { WorkflowNode, WorkflowNodeConfig } from "../workflow.types";
+import { NODE_PALETTE } from "../workflow.types";
+import { useWorkflowWorkspaceContext } from "../workflow-workspace-context";
+
+/** Data shape stored on each ReactFlow node */
+export interface WorkflowNodeData {
+	wfNode: WorkflowNode;
+}
+
+type RFWorkflowNode = Node<WorkflowNodeData>;
+
+function getNodeMeta(type: string) {
+	return NODE_PALETTE.find((m) => m.type === type);
+}
+
+/**
+ * Engine select dropdown — loaded from WorkflowWorkspaceContext.enginesByType.
+ * engineTypeKey is the SEMOSS engine type string (e.g. "MODEL", "DATABASE").
+ */
+const EngineSelect: FC<{
+	engineTypeKey: string;
+	value: string;
+	onChange: (id: string) => void;
+}> = ({ engineTypeKey, value, onChange }) => {
+	const { enginesByType } = useWorkflowWorkspaceContext();
+	const options = enginesByType[engineTypeKey] ?? [];
+
+	return (
+		<div className="nodrag nopan flex flex-col gap-1">
+			<Label className="text-xs">Engine</Label>
+			<Select value={value} onValueChange={onChange}>
+				<SelectTrigger className="h-7 text-xs">
+					<SelectValue placeholder="Select engine…" />
+				</SelectTrigger>
+				<SelectContent>
+					{options.length === 0 && (
+						<SelectItem value="__none__" disabled>
+							No engines available
+						</SelectItem>
+					)}
+					{options.map((opt) => (
+						<SelectItem key={opt.engine_id} value={opt.engine_id}>
+							{opt.engine_display_name ?? opt.engine_name}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+		</div>
+	);
+};
+
+/** Inline form rendered when a node is expanded. Per-type form fields. */
+const InlineNodeForm: FC<{
+	wfNode: WorkflowNode;
+	onUpdate: (cfg: WorkflowNodeConfig) => void;
+}> = ({ wfNode, onUpdate }) => {
+	const cfg = wfNode.config as Record<string, string>;
+	const set = (key: string, val: string) =>
+		onUpdate({ ...cfg, [key]: val } as WorkflowNodeConfig);
+
+	switch (wfNode.type) {
+		case "trigger":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Mode</Label>
+						<Select
+							value={cfg.mode ?? "manual"}
+							onValueChange={(v) => set("mode", v)}
+						>
+							<SelectTrigger className="h-7 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="manual">Manual</SelectItem>
+								<SelectItem value="schedule">
+									Schedule
+								</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					{cfg.mode === "schedule" && (
+						<div className="flex flex-col gap-1">
+							<Label className="text-xs">Cron expression</Label>
+							<Input
+								className="nodrag nopan h-7 text-xs"
+								placeholder="0 * * * *"
+								value={cfg.cronExpression ?? ""}
+								onChange={(e) =>
+									set("cronExpression", e.target.value)
+								}
+							/>
+						</div>
+					)}
+				</div>
+			);
+
+		case "model-engine":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<EngineSelect
+						engineTypeKey="MODEL"
+						value={cfg.engineId ?? ""}
+						onChange={(v) => set("engineId", v)}
+					/>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Prompt</Label>
+						<Textarea
+							className="nodrag nopan text-xs"
+							rows={3}
+							placeholder="Prompt… use ${nodeId} for upstream output"
+							value={cfg.promptTemplate ?? ""}
+							onChange={(e) =>
+								set("promptTemplate", e.target.value)
+							}
+						/>
+					</div>
+				</div>
+			);
+
+		case "database-engine":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<EngineSelect
+						engineTypeKey="DATABASE"
+						value={cfg.engineId ?? ""}
+						onChange={(v) => set("engineId", v)}
+					/>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Operation</Label>
+						<Select
+							value={cfg.operation ?? "query"}
+							onValueChange={(v) => set("operation", v)}
+						>
+							<SelectTrigger className="h-7 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="query">Query</SelectItem>
+								<SelectItem value="update">Update</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">SQL expression</Label>
+						<Textarea
+							className="nodrag nopan text-xs"
+							rows={3}
+							placeholder="SELECT * FROM …"
+							value={cfg.expression ?? ""}
+							onChange={(e) => set("expression", e.target.value)}
+						/>
+					</div>
+				</div>
+			);
+
+		case "vector-engine":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<EngineSelect
+						engineTypeKey="VECTOR"
+						value={cfg.engineId ?? ""}
+						onChange={(v) => set("engineId", v)}
+					/>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Operation</Label>
+						<Select
+							value={cfg.operation ?? "query"}
+							onValueChange={(v) => set("operation", v)}
+						>
+							<SelectTrigger className="h-7 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="query">Query</SelectItem>
+								<SelectItem value="embed">
+									Embed document
+								</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Expression</Label>
+						<Input
+							className="nodrag nopan h-7 text-xs"
+							placeholder="Search query or file path…"
+							value={cfg.expression ?? ""}
+							onChange={(e) => set("expression", e.target.value)}
+						/>
+					</div>
+				</div>
+			);
+
+		case "storage-engine":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<EngineSelect
+						engineTypeKey="STORAGE"
+						value={cfg.engineId ?? ""}
+						onChange={(v) => set("engineId", v)}
+					/>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Operation</Label>
+						<Select
+							value={cfg.operation ?? "list"}
+							onValueChange={(v) => set("operation", v)}
+						>
+							<SelectTrigger className="h-7 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="list">List</SelectItem>
+								<SelectItem value="read">Read</SelectItem>
+								<SelectItem value="write">Write</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Path</Label>
+						<Input
+							className="nodrag nopan h-7 text-xs"
+							placeholder="/folder/file.txt"
+							value={cfg.path ?? ""}
+							onChange={(e) => set("path", e.target.value)}
+						/>
+					</div>
+				</div>
+			);
+
+		case "function-engine":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<EngineSelect
+						engineTypeKey="FUNCTION"
+						value={cfg.engineId ?? ""}
+						onChange={(v) => set("engineId", v)}
+					/>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Parameters</Label>
+						<Textarea
+							className="nodrag nopan text-xs"
+							rows={2}
+							placeholder='{"key": "value"}'
+							value={cfg.paramsExpression ?? ""}
+							onChange={(e) =>
+								set("paramsExpression", e.target.value)
+							}
+						/>
+					</div>
+				</div>
+			);
+
+		case "custom-pixel":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Pixel expression</Label>
+						<Textarea
+							className="nodrag nopan font-mono text-xs"
+							rows={4}
+							placeholder="MyReactor(param=[${upstreamNode}]);"
+							value={cfg.pixel ?? ""}
+							onChange={(e) => set("pixel", e.target.value)}
+						/>
+					</div>
+				</div>
+			);
+
+		case "transform":
+			return (
+				<div className="nodrag nopan flex flex-col gap-2 p-2">
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Operation</Label>
+						<Select
+							value={cfg.operation ?? "map"}
+							onValueChange={(v) => set("operation", v)}
+						>
+							<SelectTrigger className="h-7 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="map">Map</SelectItem>
+								<SelectItem value="filter">Filter</SelectItem>
+								<SelectItem value="reduce">Reduce</SelectItem>
+								<SelectItem value="flatten">Flatten</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Expression</Label>
+						<Textarea
+							className="nodrag nopan font-mono text-xs"
+							rows={3}
+							placeholder="item => item.value"
+							value={cfg.expression ?? ""}
+							onChange={(e) => set("expression", e.target.value)}
+						/>
+					</div>
+				</div>
+			);
+
+		default:
+			return (
+				<div className="p-2 text-muted-foreground text-xs">
+					No configuration for this node type.
+				</div>
+			);
+	}
+};
+
+/**
+ * Custom ReactFlow node — clicking the header toggles inline expansion.
+ * Config updates go through onNodeUpdate; expansion through toggleExpand.
+ */
+export const WorkflowNodeCard: FC<NodeProps<RFWorkflowNode>> = ({ data }) => {
+	const { wfNode } = data;
+	const {
+		expandedNodeId,
+		onNodeUpdate,
+		deleteNode,
+		openSettings,
+		toggleExpand,
+	} = useWorkflowWorkspaceContext();
+
+	const meta = getNodeMeta(wfNode.type);
+	const isExpanded = expandedNodeId === wfNode.id;
+
+	const handleUpdate = (cfg: WorkflowNodeConfig) => {
+		onNodeUpdate({ ...wfNode, config: cfg });
+	};
+
+	return (
+		<div
+			className="min-w-52 rounded-lg border border-border bg-card shadow-md"
+			style={{
+				borderTopWidth: 3,
+				borderTopColor: meta?.color ?? "#475569",
+			}}
+		>
+			<Handle
+				type="target"
+				position={Position.Top}
+				className="!bg-muted-foreground"
+			/>
+
+			{/* Header: label button (expands) + action buttons (siblings, not nested) */}
+			<div className="flex items-center gap-2 px-3 py-2">
+				<button
+					type="button"
+					className="nodrag nopan flex min-w-0 flex-1 cursor-pointer flex-col text-left"
+					onClick={() => toggleExpand(wfNode.id)}
+				>
+					<span className="truncate font-semibold text-sm">
+						{wfNode.label}
+					</span>
+					<span className="text-muted-foreground text-xs">
+						{meta?.label ?? wfNode.type}
+					</span>
+				</button>
+				<div className="flex shrink-0 items-center gap-1">
+					<button
+						type="button"
+						className="nodrag nopan rounded p-0.5 text-muted-foreground hover:text-foreground"
+						onClick={() => openSettings(wfNode.id)}
+						title="Full settings"
+					>
+						<Settings className="size-3.5" />
+					</button>
+					<button
+						type="button"
+						className="nodrag nopan rounded p-0.5 text-muted-foreground hover:text-destructive"
+						onClick={() => deleteNode(wfNode.id)}
+						title="Delete node"
+					>
+						<Trash2 className="size-3.5" />
+					</button>
+					{isExpanded ? (
+						<ChevronUp className="size-3.5 text-muted-foreground" />
+					) : (
+						<ChevronDown className="size-3.5 text-muted-foreground" />
+					)}
+				</div>
+			</div>
+
+			{isExpanded && (
+				<div className="border-border border-t">
+					<InlineNodeForm wfNode={wfNode} onUpdate={handleUpdate} />
+				</div>
+			)}
+
+			<Handle
+				type="source"
+				position={Position.Bottom}
+				className="!bg-muted-foreground"
+			/>
+		</div>
+	);
+};

--- a/packages/client/src/components/workflow-workspace/nodes/node-palette.tsx
+++ b/packages/client/src/components/workflow-workspace/nodes/node-palette.tsx
@@ -1,0 +1,36 @@
+import type { DragEvent, FC } from "react";
+import { NODE_PALETTE } from "../workflow.types";
+
+/**
+ * Left sidebar palette — each item can be dragged onto the ReactFlow canvas.
+ * Sets dataTransfer with the node type so the canvas drop handler can read it.
+ */
+export const NodePalette: FC = () => {
+	const onDragStart = (event: DragEvent<HTMLButtonElement>, type: string) => {
+		event.dataTransfer.setData("application/workflow-node-type", type);
+		event.dataTransfer.effectAllowed = "move";
+	};
+
+	return (
+		<div className="flex h-full w-52 shrink-0 flex-col gap-1 overflow-y-auto border-border border-r bg-background p-2">
+			<p className="px-1 py-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+				Nodes
+			</p>
+			{NODE_PALETTE.map((meta) => (
+				<button
+					key={meta.type}
+					type="button"
+					draggable
+					onDragStart={(e) => onDragStart(e, meta.type)}
+					className="flex cursor-grab flex-col gap-0.5 rounded-md border border-border bg-card px-3 py-2 text-left shadow-sm transition-shadow hover:shadow-md active:cursor-grabbing"
+					style={{ borderLeftWidth: 3, borderLeftColor: meta.color }}
+				>
+					<span className="font-medium text-sm">{meta.label}</span>
+					<span className="line-clamp-2 text-muted-foreground text-xs">
+						{meta.description}
+					</span>
+				</button>
+			))}
+		</div>
+	);
+};

--- a/packages/client/src/components/workflow-workspace/workflow-workspace-context.tsx
+++ b/packages/client/src/components/workflow-workspace/workflow-workspace-context.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext } from "react";
+import type { EngineOption, WorkflowNode } from "./workflow.types";
+
+interface WorkflowWorkspaceContextValue {
+	/** Engines indexed by type string (e.g. "MODEL", "DATABASE") */
+	enginesByType: Record<string, EngineOption[]>;
+	/** ID of the node currently expanded inline on the canvas (or null) */
+	expandedNodeId: string | null;
+	/** Look up a workflow node by its id */
+	getWfNode: (id: string) => WorkflowNode | undefined;
+	/** Persist an updated node's config/label without toggling expansion */
+	onNodeUpdate: (updated: WorkflowNode) => void;
+	/** Toggle inline expansion for a node */
+	toggleExpand: (id: string) => void;
+	/** Remove a node from the canvas */
+	deleteNode: (id: string) => void;
+	/** Open the full settings panel for a node */
+	openSettings: (id: string) => void;
+}
+
+export const WorkflowWorkspaceContext =
+	createContext<WorkflowWorkspaceContextValue | null>(null);
+
+export function useWorkflowWorkspaceContext(): WorkflowWorkspaceContextValue {
+	const ctx = useContext(WorkflowWorkspaceContext);
+	if (!ctx) {
+		throw new Error(
+			"useWorkflowWorkspaceContext must be used inside WorkflowWorkspaceContext.Provider",
+		);
+	}
+	return ctx;
+}

--- a/packages/client/src/components/workflow-workspace/workflow-workspace.tsx
+++ b/packages/client/src/components/workflow-workspace/workflow-workspace.tsx
@@ -1,0 +1,586 @@
+import {
+	addEdge,
+	Background,
+	type Connection,
+	Controls,
+	type Edge,
+	MiniMap,
+	type Node,
+	ReactFlow,
+	ReactFlowProvider,
+	useEdgesState,
+	useNodesState,
+	useReactFlow,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import {
+	CheckCircle,
+	Loader2,
+	Play,
+	Save,
+	Settings,
+	XCircle,
+} from "lucide-react";
+import { type FC, useCallback, useEffect, useId, useState } from "react";
+import { useInsight } from "@semoss/sdk/react";
+import {
+	Button,
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+	Textarea,
+	toast,
+} from "@semoss/ui/next";
+import { useRootStore, useWorkspace } from "@/hooks";
+import { WorkflowNodeCard, type WorkflowNodeData } from "./nodes/node-card";
+import { NodePalette } from "./nodes/node-palette";
+import type {
+	EngineOption,
+	WorkflowDocument,
+	WorkflowEdge,
+	WorkflowNode,
+	WorkflowNodeConfig,
+	WorkflowRunDetail,
+} from "./workflow.types";
+import { WorkflowWorkspaceContext } from "./workflow-workspace-context";
+
+const NODE_TYPES = { workflowNode: WorkflowNodeCard };
+
+type RFWorkflowNode = Node<WorkflowNodeData>;
+
+function wfNodeToRF(wfNode: WorkflowNode): RFWorkflowNode {
+	return {
+		id: wfNode.id,
+		type: "workflowNode",
+		position: wfNode.position ?? { x: 200, y: 200 },
+		data: { wfNode },
+	};
+}
+
+function rfNodeToWf(rfNode: RFWorkflowNode): WorkflowNode {
+	return {
+		...rfNode.data.wfNode,
+		position: rfNode.position,
+	};
+}
+
+function wfEdgeToRF(wfEdge: WorkflowEdge): Edge {
+	return {
+		id: wfEdge.id,
+		source: wfEdge.source,
+		target: wfEdge.target,
+	};
+}
+
+/** Inner canvas — must be inside ReactFlowProvider */
+const WorkflowCanvas: FC = () => {
+	const insight = useInsight();
+	const { monolithStore } = useRootStore();
+	const { workspace } = useWorkspace();
+	const appId = workspace.appId;
+	const rfInstance = useReactFlow();
+
+	const [rfNodes, setRfNodes, onNodesChange] = useNodesState<RFWorkflowNode>(
+		[],
+	);
+	const [rfEdges, setRfEdges, onEdgesChange] = useEdgesState<Edge>([]);
+
+	const [enginesByType, setEnginesByType] = useState<
+		Record<string, EngineOption[]>
+	>({});
+	const [expandedNodeId, setExpandedNodeId] = useState<string | null>(null);
+	const [settingsPanelNodeId, setSettingsPanelNodeId] = useState<
+		string | null
+	>(null);
+	const [runDetail, setRunDetail] = useState<WorkflowRunDetail | null>(null);
+	const [isSaving, setIsSaving] = useState(false);
+	const [isRunning, setIsRunning] = useState(false);
+
+	// Derived: keep wfNodes in sync with rfNodes (source of truth is rfNodes after drops/moves)
+	const [wfNodes, setWfNodes] = useState<WorkflowNode[]>([]);
+	useEffect(() => {
+		setWfNodes(rfNodes.map((rf) => rfNodeToWf(rf)));
+	}, [rfNodes]);
+
+	// Load workflow on mount
+	useEffect(() => {
+		if (!insight.isReady || !appId) return;
+		monolithStore
+			.runQuery<[string]>(
+				`GetWorkflow(project=["${appId}"]);`,
+				insight.insightId,
+			)
+			.then(({ errors, pixelReturn }) => {
+				if (errors.length > 0) return;
+				try {
+					const doc: WorkflowDocument = JSON.parse(
+						pixelReturn[0].output,
+					);
+					setRfNodes((doc.nodes ?? []).map((n) => wfNodeToRF(n)));
+					setRfEdges((doc.edges ?? []).map((e) => wfEdgeToRF(e)));
+				} catch (_) {
+					// empty / malformed JSON — start fresh
+				}
+			});
+	}, [
+		insight.isReady,
+		appId,
+		insight.insightId,
+		monolithStore,
+		setRfNodes,
+		setRfEdges,
+	]);
+
+	// Load engines on mount
+	useEffect(() => {
+		if (!insight.isReady) return;
+		const engineTypes = [
+			"MODEL",
+			"DATABASE",
+			"VECTOR",
+			"STORAGE",
+			"FUNCTION",
+		];
+		Promise.all(
+			engineTypes.map((et) =>
+				monolithStore
+					.runQuery<[EngineOption[]]>(
+						`MyEngines(engineTypes=["${et}"]);`,
+						insight.insightId,
+					)
+					.then(({ errors, pixelReturn }) => {
+						if (errors.length > 0)
+							return [et, [] as EngineOption[]] as const;
+						const list = pixelReturn[0]?.output ?? [];
+						return [et, list] as const;
+					})
+					.catch(() => [et, [] as EngineOption[]] as const),
+			),
+		).then((results) => {
+			const map: Record<string, EngineOption[]> = {};
+			for (const [et, list] of results) map[et] = list;
+			setEnginesByType(map);
+		});
+	}, [insight.isReady, insight.insightId, monolithStore]);
+
+	const onConnect = useCallback(
+		(connection: Connection) =>
+			setRfEdges((eds) =>
+				addEdge(
+					{
+						...connection,
+						id: `e-${connection.source}-${connection.target}`,
+					},
+					eds,
+				),
+			),
+		[setRfEdges],
+	);
+
+	const onDrop = useCallback(
+		(event: React.DragEvent<HTMLDivElement>) => {
+			event.preventDefault();
+			const type = event.dataTransfer.getData(
+				"application/workflow-node-type",
+			);
+			if (!type) return;
+
+			// screenToFlowPosition takes raw client coords (not canvas-relative)
+			const position = rfInstance.screenToFlowPosition({
+				x: event.clientX,
+				y: event.clientY,
+			});
+
+			const id = crypto.randomUUID();
+			const newWfNode: WorkflowNode = {
+				id,
+				type: type as WorkflowNode["type"],
+				label: type
+					.split("-")
+					.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+					.join(" "),
+				config: {} as WorkflowNodeConfig,
+				position,
+			};
+
+			setRfNodes((prev) => [...prev, wfNodeToRF(newWfNode)]);
+		},
+		[rfInstance, setRfNodes],
+	);
+
+	const onDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+		event.preventDefault();
+		event.dataTransfer.dropEffect = "move";
+	}, []);
+
+	// Context callbacks — keep these stable
+	const getWfNode = useCallback(
+		(id: string) => wfNodes.find((n) => n.id === id),
+		[wfNodes],
+	);
+
+	const onNodeUpdate = useCallback(
+		(updated: WorkflowNode) => {
+			setRfNodes((prev) =>
+				prev.map((rf) =>
+					rf.id === updated.id
+						? { ...rf, data: { wfNode: updated } }
+						: rf,
+				),
+			);
+		},
+		[setRfNodes],
+	);
+
+	const toggleExpand = useCallback((id: string) => {
+		setExpandedNodeId((cur) => (cur === id ? null : id));
+	}, []);
+
+	const deleteNode = useCallback(
+		(id: string) => {
+			setRfNodes((prev) => prev.filter((rf) => rf.id !== id));
+			setRfEdges((prev) =>
+				prev.filter((e) => e.source !== id && e.target !== id),
+			);
+			setExpandedNodeId((cur) => (cur === id ? null : cur));
+		},
+		[setRfNodes, setRfEdges],
+	);
+
+	const openSettings = useCallback((id: string) => {
+		setSettingsPanelNodeId(id);
+	}, []);
+
+	const saveWorkflow = async () => {
+		setIsSaving(true);
+		try {
+			const doc: WorkflowDocument = {
+				version: "1.0",
+				nodes: wfNodes,
+				edges: rfEdges.map((e) => ({
+					id: e.id,
+					source: e.source,
+					target: e.target,
+				})),
+			};
+			const encoded = encodeURIComponent(JSON.stringify(doc));
+			const { errors } = await monolithStore.runQuery(
+				`SaveWorkflow(project=["${appId}"], json=["<encode>${encoded}</encode>"]);`,
+				insight.insightId,
+			);
+			if (errors.length > 0) throw new Error(errors.join(", "));
+			toast.success("Workflow saved");
+		} catch (e) {
+			toast.error(`Save failed: ${(e as Error).message}`);
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const runWorkflow = async () => {
+		await saveWorkflow();
+		setIsRunning(true);
+		setRunDetail(null);
+		try {
+			const { errors, pixelReturn } = await monolithStore.runQuery<
+				[WorkflowRunDetail]
+			>(`WorkflowExecutor(project=["${appId}"]);`, insight.insightId);
+			if (errors.length > 0) throw new Error(errors.join(", "));
+			const result = pixelReturn[0]
+				.output as unknown as WorkflowRunDetail;
+			setRunDetail(result);
+			const hasErrors = result?.nodeResults?.some(
+				(r) => r.status === "error",
+			);
+			if (hasErrors) {
+				toast.error("Workflow completed with errors — check run panel");
+			} else {
+				toast.success("Workflow run complete");
+			}
+		} catch (e) {
+			toast.error(`Run failed: ${(e as Error).message}`);
+		} finally {
+			setIsRunning(false);
+		}
+	};
+
+	const settingNode = settingsPanelNodeId
+		? wfNodes.find((n) => n.id === settingsPanelNodeId)
+		: null;
+
+	return (
+		<WorkflowWorkspaceContext.Provider
+			value={{
+				enginesByType,
+				expandedNodeId,
+				getWfNode,
+				onNodeUpdate,
+				deleteNode,
+				openSettings,
+				toggleExpand,
+			}}
+		>
+			<div className="flex h-full w-full flex-col">
+				{/* Toolbar */}
+				<div className="flex shrink-0 items-center gap-2 border-border border-b bg-background px-4 py-2">
+					<span className="font-semibold text-sm">
+						Workflow Builder
+					</span>
+					<div className="ml-auto flex items-center gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={isSaving || isRunning}
+							onClick={saveWorkflow}
+						>
+							{isSaving ? (
+								<Loader2 className="mr-1.5 size-3.5 animate-spin" />
+							) : (
+								<Save className="mr-1.5 size-3.5" />
+							)}
+							Save
+						</Button>
+						<Button
+							size="sm"
+							disabled={isRunning || isSaving}
+							onClick={runWorkflow}
+						>
+							{isRunning ? (
+								<Loader2 className="mr-1.5 size-3.5 animate-spin" />
+							) : (
+								<Play className="mr-1.5 size-3.5" />
+							)}
+							Run
+						</Button>
+					</div>
+				</div>
+
+				{/* Main area: palette + canvas + optional run panel */}
+				<div className="flex min-h-0 flex-1">
+					<NodePalette />
+
+					<section
+						aria-label="Workflow canvas"
+						className="flex-1"
+						onDrop={onDrop}
+						onDragOver={onDragOver}
+					>
+						<ReactFlow
+							nodes={rfNodes}
+							edges={rfEdges}
+							nodeTypes={NODE_TYPES}
+							onNodesChange={onNodesChange}
+							onEdgesChange={onEdgesChange}
+							onConnect={onConnect}
+							fitView
+							deleteKeyCode="Delete"
+						>
+							<Background />
+							<Controls />
+							<MiniMap />
+						</ReactFlow>
+					</section>
+
+					{runDetail && (
+						<RunResultsPanel
+							detail={runDetail}
+							onClose={() => setRunDetail(null)}
+						/>
+					)}
+				</div>
+			</div>
+
+			{/* Settings side sheet */}
+			<Sheet
+				open={!!settingNode}
+				onOpenChange={(open) => {
+					if (!open) setSettingsPanelNodeId(null);
+				}}
+			>
+				<SheetContent side="right" className="w-96 overflow-y-auto">
+					<SheetHeader>
+						<SheetTitle className="flex items-center gap-2">
+							<Settings className="size-4" />
+							{settingNode?.label ?? "Node Settings"}
+						</SheetTitle>
+					</SheetHeader>
+					{settingNode && (
+						<SettingsPanel
+							key={settingNode.id}
+							wfNode={settingNode}
+							onUpdate={(updated) => {
+								onNodeUpdate(updated);
+								setSettingsPanelNodeId(null);
+							}}
+						/>
+					)}
+				</SheetContent>
+			</Sheet>
+		</WorkflowWorkspaceContext.Provider>
+	);
+};
+
+/** Full settings panel — standalone component, only mounted when settingNode exists */
+const SettingsPanel: FC<{
+	wfNode: WorkflowNode;
+	onUpdate: (updated: WorkflowNode) => void;
+}> = ({ wfNode, onUpdate }) => {
+	const cfg = wfNode.config as Record<string, string>;
+	const [label, setLabel] = useState(wfNode.label);
+	const [localCfg, setLocalCfg] = useState<Record<string, string>>(cfg);
+
+	const nodeLabelId = useId();
+	const pixelId = useId();
+	const promptId = useId();
+	const expressionId = useId();
+
+	const set = (key: string, val: string) =>
+		setLocalCfg((prev) => ({ ...prev, [key]: val }));
+
+	return (
+		<div className="flex flex-col gap-4 p-4">
+			<div className="flex flex-col gap-1">
+				<label htmlFor={nodeLabelId} className="font-medium text-xs">
+					Node label
+				</label>
+				<input
+					id={nodeLabelId}
+					className="rounded border border-border px-2 py-1 text-sm"
+					value={label}
+					onChange={(e) => setLabel(e.target.value)}
+				/>
+			</div>
+			<div className="flex flex-col gap-1">
+				<span className="text-muted-foreground text-xs">
+					Type: {wfNode.type}
+				</span>
+			</div>
+			{"pixel" in localCfg && (
+				<div className="flex flex-col gap-1">
+					<label htmlFor={pixelId} className="font-medium text-xs">
+						Custom Pixel
+					</label>
+					<Textarea
+						id={pixelId}
+						className="font-mono text-xs"
+						rows={6}
+						value={localCfg.pixel ?? ""}
+						onChange={(e) => set("pixel", e.target.value)}
+					/>
+				</div>
+			)}
+			{"promptTemplate" in localCfg && (
+				<div className="flex flex-col gap-1">
+					<label htmlFor={promptId} className="font-medium text-xs">
+						Prompt template
+					</label>
+					<Textarea
+						id={promptId}
+						className="font-mono text-xs"
+						rows={6}
+						value={localCfg.promptTemplate ?? ""}
+						onChange={(e) => set("promptTemplate", e.target.value)}
+					/>
+				</div>
+			)}
+			{"expression" in localCfg && (
+				<div className="flex flex-col gap-1">
+					<label
+						htmlFor={expressionId}
+						className="font-medium text-xs"
+					>
+						Expression
+					</label>
+					<Textarea
+						id={expressionId}
+						className="font-mono text-xs"
+						rows={4}
+						value={localCfg.expression ?? ""}
+						onChange={(e) => set("expression", e.target.value)}
+					/>
+				</div>
+			)}
+			<Button
+				onClick={() =>
+					onUpdate({
+						...wfNode,
+						label,
+						config: localCfg as WorkflowNodeConfig,
+					})
+				}
+			>
+				Apply
+			</Button>
+		</div>
+	);
+};
+
+/** Panel showing per-node run results */
+const RunResultsPanel: FC<{
+	detail: WorkflowRunDetail;
+	onClose: () => void;
+}> = ({ detail, onClose }) => (
+	<div className="flex w-80 shrink-0 flex-col border-border border-l bg-background">
+		<div className="flex items-center justify-between border-border border-b px-3 py-2">
+			<span className="font-semibold text-sm">Run Results</span>
+			<button
+				type="button"
+				onClick={onClose}
+				className="text-muted-foreground text-xs hover:text-foreground"
+			>
+				✕
+			</button>
+		</div>
+		<div className="flex-1 overflow-y-auto p-2">
+			<div className="mb-2 flex items-center gap-1.5">
+				{detail.status === "success" ? (
+					<CheckCircle className="size-4 text-green-600" />
+				) : (
+					<XCircle className="size-4 text-destructive" />
+				)}
+				<span className="text-muted-foreground text-xs">
+					Run {detail.runId} · {detail.startedAt}
+				</span>
+			</div>
+			<div className="flex flex-col gap-2">
+				{(detail.nodeResults ?? []).map((nr) => (
+					<div
+						key={nr.nodeId}
+						className="rounded border border-border p-2 text-xs"
+					>
+						<div className="flex items-center justify-between">
+							<span className="font-medium">{nr.nodeId}</span>
+							<span
+								className={
+									nr.status === "success"
+										? "text-green-600"
+										: nr.status === "error"
+											? "text-destructive"
+											: "text-muted-foreground"
+								}
+							>
+								{nr.status} · {nr.elapsedMs}ms
+							</span>
+						</div>
+						{nr.error && (
+							<p className="mt-1 text-destructive">{nr.error}</p>
+						)}
+						{nr.output && (
+							<pre className="mt-1 max-h-24 overflow-y-auto whitespace-pre-wrap break-words rounded bg-muted p-1 text-[10px]">
+								{nr.output}
+							</pre>
+						)}
+					</div>
+				))}
+			</div>
+		</div>
+	</div>
+);
+
+/** Public export — wraps canvas in ReactFlowProvider */
+export const WorkflowWorkspace: FC = () => (
+	<ReactFlowProvider>
+		<WorkflowCanvas />
+	</ReactFlowProvider>
+);

--- a/packages/client/src/components/workflow-workspace/workflow.types.ts
+++ b/packages/client/src/components/workflow-workspace/workflow.types.ts
@@ -1,0 +1,213 @@
+/** All node types supported by the workflow builder */
+export type WorkflowNodeType =
+	| "trigger"
+	| "database-engine"
+	| "storage-engine"
+	| "vector-engine"
+	| "model-engine"
+	| "function-engine"
+	| "custom-pixel"
+	| "transform"
+	| "conditional"
+	| "fan-out";
+
+export interface TriggerConfig {
+	mode: "manual" | "schedule";
+	cronExpression?: string;
+}
+
+export interface DatabaseEngineConfig {
+	engineId: string;
+	operation: "query" | "update";
+	expression: string;
+}
+
+export interface StorageEngineConfig {
+	engineId: string;
+	operation: "list" | "read" | "write";
+	path?: string;
+}
+
+export interface VectorEngineConfig {
+	engineId: string;
+	operation: "query" | "embed";
+	expression?: string;
+}
+
+export interface ModelEngineConfig {
+	engineId: string;
+	promptTemplate: string;
+}
+
+export interface FunctionEngineConfig {
+	engineId: string;
+	paramsExpression?: string;
+}
+
+export interface CustomPixelConfig {
+	pixel: string;
+}
+
+export interface TransformConfig {
+	operation: "map" | "filter" | "reduce" | "flatten";
+	expression: string;
+}
+
+export interface ConditionalConfig {
+	condition: string;
+}
+
+export interface FanOutConfig {
+	inputVar: string;
+	itemAlias: string;
+	parallelism?: number;
+}
+
+export type WorkflowNodeConfig =
+	| TriggerConfig
+	| DatabaseEngineConfig
+	| StorageEngineConfig
+	| VectorEngineConfig
+	| ModelEngineConfig
+	| FunctionEngineConfig
+	| CustomPixelConfig
+	| TransformConfig
+	| ConditionalConfig
+	| FanOutConfig;
+
+export interface WorkflowNode {
+	id: string;
+	type: WorkflowNodeType;
+	label: string;
+	config: WorkflowNodeConfig;
+	position?: { x: number; y: number };
+}
+
+export interface WorkflowEdge {
+	id: string;
+	source: string;
+	target: string;
+}
+
+export interface WorkflowDocument {
+	version: string;
+	nodes: WorkflowNode[];
+	edges: WorkflowEdge[];
+}
+
+export interface EngineOption {
+	engine_id: string;
+	engine_name: string;
+	engine_display_name?: string;
+	engine_type: string;
+}
+
+export interface WorkflowRunNodeResult {
+	nodeId: string;
+	nodeType: string;
+	status: "success" | "error" | "skipped";
+	output?: string;
+	error?: string;
+	elapsedMs: number;
+}
+
+export interface WorkflowRunSummary {
+	runId: string;
+	projectId: string;
+	startedAt: string;
+	status: "success" | "error";
+	nodeCount: number;
+}
+
+export interface WorkflowRunDetail extends WorkflowRunSummary {
+	nodeResults: WorkflowRunNodeResult[];
+}
+
+/** Palette entry — one card per node type in the left sidebar */
+export interface NodePaletteMeta {
+	type: WorkflowNodeType;
+	label: string;
+	description: string;
+	color: string;
+	defaultConfig: WorkflowNodeConfig;
+}
+
+export const NODE_PALETTE: NodePaletteMeta[] = [
+	{
+		type: "trigger",
+		label: "Trigger",
+		description: "Start the workflow manually or on a schedule",
+		color: "#7c3aed",
+		defaultConfig: { mode: "manual" } as TriggerConfig,
+	},
+	{
+		type: "model-engine",
+		label: "Model Engine",
+		description: "Call an LLM with a prompt template",
+		color: "#2563eb",
+		defaultConfig: {
+			engineId: "",
+			promptTemplate: "",
+		} as ModelEngineConfig,
+	},
+	{
+		type: "database-engine",
+		label: "Database Engine",
+		description: "Query or update a database engine",
+		color: "#059669",
+		defaultConfig: {
+			engineId: "",
+			operation: "query",
+			expression: "",
+		} as DatabaseEngineConfig,
+	},
+	{
+		type: "vector-engine",
+		label: "Vector Engine",
+		description: "Query a vector database or embed documents",
+		color: "#d97706",
+		defaultConfig: {
+			engineId: "",
+			operation: "query",
+			expression: "",
+		} as VectorEngineConfig,
+	},
+	{
+		type: "storage-engine",
+		label: "Storage Engine",
+		description: "Read or write files in a storage engine",
+		color: "#db2777",
+		defaultConfig: {
+			engineId: "",
+			operation: "list",
+			path: "",
+		} as StorageEngineConfig,
+	},
+	{
+		type: "function-engine",
+		label: "Function Engine",
+		description: "Call a function engine with parameters",
+		color: "#0891b2",
+		defaultConfig: {
+			engineId: "",
+			paramsExpression: "",
+		} as FunctionEngineConfig,
+	},
+	{
+		type: "custom-pixel",
+		label: "Custom Pixel",
+		description: "Execute any Pixel expression",
+		color: "#475569",
+		defaultConfig: { pixel: "" } as CustomPixelConfig,
+	},
+	{
+		type: "transform",
+		label: "Transform",
+		description: "Map, filter, or reduce data between nodes",
+		color: "#9333ea",
+		defaultConfig: {
+			operation: "map",
+			expression: "",
+		} as TransformConfig,
+	},
+];

--- a/packages/client/src/components/workspace/workspace.tsx
+++ b/packages/client/src/components/workspace/workspace.tsx
@@ -24,6 +24,11 @@ const AgentWorkspace = lazy(() =>
 		default: m.AgentWorkspace,
 	})),
 );
+const WorkflowWorkspace = lazy(() =>
+	import("@/components/workflow-workspace").then((m) => ({
+		default: m.WorkflowWorkspace,
+	})),
+);
 
 import { useRootStore } from "@/hooks";
 import type { WorkspaceStore } from "@/stores";
@@ -123,6 +128,7 @@ export const Workspace: React.FC<WorkspaceProps> = ({ app }) => {
 				{workspace.type === "BLOCKS" && <BlocksWorkspace />}
 				{workspace.type === "SKILL" && <SkillWorkspace />}
 				{workspace.type === "WORKSPACE" && <AgentWorkspace />}
+				{workspace.type === "WORKFLOW" && <WorkflowWorkspace />}
 			</Suspense>
 		</WorkspaceContext.Provider>
 	);

--- a/packages/client/src/pages/AuthenticatedLayout.tsx
+++ b/packages/client/src/pages/AuthenticatedLayout.tsx
@@ -1,4 +1,5 @@
 import { observer } from "mobx-react-lite";
+import { useEffect } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { useRootStore } from "@/hooks/";
 
@@ -6,17 +7,33 @@ import { useRootStore } from "@/hooks/";
  * Wrap the database routes and add additional funcitonality
  */
 export const AuthenticatedLayout = observer(() => {
-	const { configStore } = useRootStore();
+	const { configStore, monolithStore } = useRootStore();
 	const location = useLocation();
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: MobX observer handles reactive updates; store object identity is stable
+	useEffect(() => {
+		if (configStore.store.status === "SUCCESS") {
+			monolithStore
+				.runQuery("GetUserPlatformFeatures();")
+				.then((res) => {
+					const { operationType, output } = res.pixelReturn[0];
+					if (operationType.indexOf("ERROR") === -1 && output) {
+						configStore.store.platformFeatures = output as Record<
+							string,
+							boolean
+						>;
+					}
+				})
+				.catch(() => {
+					// fail open
+				});
+		}
+	}, [configStore.store.status, monolithStore]);
 
 	// wait till the config is authenticated to load the view
 	if (configStore.store.status === "MISSING AUTHENTICATION") {
 		return <Navigate to="/login" state={{ from: location }} replace />;
 	}
 
-	return (
-		<>
-			<Outlet />
-		</>
-	);
+	return <Outlet />;
 });

--- a/packages/client/src/pages/app/app-detail-tabs/profiles.tsx
+++ b/packages/client/src/pages/app/app-detail-tabs/profiles.tsx
@@ -1,0 +1,625 @@
+import { Pencil, Plus, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import {
+	Badge,
+	Button,
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Input,
+	Separator,
+	Switch,
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+	toast,
+} from "@semoss/ui/next";
+import { useRootStore } from "@/hooks";
+
+interface AppProfilesProps {
+	appId: string;
+	permission: string;
+}
+
+type ApiProfile = {
+	profileId: string;
+	profileName: string;
+	description?: string;
+	isDefault?: boolean;
+	userCount?: number;
+};
+
+type ApiProfileFeature = {
+	featureId: string;
+	featureKey: string;
+	description?: string;
+	enabled?: boolean;
+};
+
+type ApiProfileUser = {
+	userId: string;
+	displayName?: string;
+	email?: string;
+};
+
+function sanitizeForPixel(s: string): string {
+	return s.replace(/[^a-zA-Z0-9 _\-.,!?]/g, "");
+}
+
+export const AppProfiles = ({ appId, permission }: AppProfilesProps) => {
+	const { monolithStore } = useRootStore();
+	const [profiles, setProfiles] = useState<ApiProfile[]>([]);
+	const [selectedProfile, setSelectedProfile] = useState<ApiProfile | null>(
+		null,
+	);
+	const [profileFeatures, setProfileFeatures] = useState<ApiProfileFeature[]>(
+		[],
+	);
+	const [profileUsers, setProfileUsers] = useState<ApiProfileUser[]>([]);
+	const [profileDialogOpen, setProfileDialogOpen] = useState(false);
+	const [featureDialogOpen, setFeatureDialogOpen] = useState(false);
+	const [deleteProfileDialogOpen, setDeleteProfileDialogOpen] =
+		useState(false);
+	const [editingProfile, setEditingProfile] = useState<ApiProfile | null>(
+		null,
+	);
+	const [profileName, setProfileName] = useState("");
+	const [profileDesc, setProfileDesc] = useState("");
+	const [profileIsDefault, setProfileIsDefault] = useState(false);
+	const [featureKey, setFeatureKey] = useState("");
+	const [featureDesc, setFeatureDesc] = useState("");
+	const [featureKeyError, setFeatureKeyError] = useState("");
+
+	const canManage = permission === "author" || permission === "editor";
+
+	const loadProfiles = useCallback(async () => {
+		try {
+			const res = await monolithStore.runQuery(
+				`GetAppProfiles(app="${appId}");`,
+			);
+			const { operationType, output } = res.pixelReturn[0];
+			if (operationType.indexOf("ERROR") === -1 && output) {
+				setProfiles(
+					Array.isArray(output) ? output : Object.values(output),
+				);
+			}
+		} catch {
+			toast.error("Failed to load profiles");
+		}
+	}, [appId, monolithStore]);
+
+	const loadProfileFeatures = useCallback(
+		async (profileId: string) => {
+			try {
+				const res = await monolithStore.runQuery(
+					`GetProfileFeatures(app="${appId}", profileId="${profileId}");`,
+				);
+				const { operationType, output } = res.pixelReturn[0];
+				if (operationType.indexOf("ERROR") === -1 && output) {
+					setProfileFeatures(
+						Array.isArray(output) ? output : Object.values(output),
+					);
+				}
+			} catch {
+				toast.error("Failed to load profile features");
+			}
+		},
+		[appId, monolithStore],
+	);
+
+	const loadProfileUsers = useCallback(
+		async (profileId: string) => {
+			try {
+				const res = await monolithStore.runQuery(
+					`GetProfileUsers(app="${appId}", profileId="${profileId}");`,
+				);
+				const { operationType, output } = res.pixelReturn[0];
+				if (operationType.indexOf("ERROR") === -1 && output) {
+					setProfileUsers(
+						Array.isArray(output) ? output : Object.values(output),
+					);
+				}
+			} catch {
+				toast.error("Failed to load profile users");
+			}
+		},
+		[appId, monolithStore],
+	);
+
+	useEffect(() => {
+		loadProfiles();
+	}, [loadProfiles]);
+
+	useEffect(() => {
+		if (selectedProfile) {
+			loadProfileFeatures(selectedProfile.profileId);
+			loadProfileUsers(selectedProfile.profileId);
+		}
+	}, [selectedProfile, loadProfileFeatures, loadProfileUsers]);
+
+	const handleSaveProfile = async () => {
+		const name = sanitizeForPixel(profileName.trim());
+		if (!name) return;
+		try {
+			if (editingProfile) {
+				await monolithStore.runQuery(
+					`UpdateAppProfile(app="${appId}", profileId="${editingProfile.profileId}", name="${name}", description="${sanitizeForPixel(profileDesc)}", isDefault="${profileIsDefault}");`,
+				);
+				toast.success("Profile updated");
+			} else {
+				await monolithStore.runQuery(
+					`CreateAppProfile(app="${appId}", name="${name}", description="${sanitizeForPixel(profileDesc)}", isDefault="${profileIsDefault}");`,
+				);
+				toast.success("Profile created");
+			}
+		} catch {
+			toast.error("Failed to save profile");
+		}
+		setProfileDialogOpen(false);
+		setEditingProfile(null);
+		setProfileName("");
+		setProfileDesc("");
+		setProfileIsDefault(false);
+		await loadProfiles();
+	};
+
+	const handleDeleteProfile = async () => {
+		if (!selectedProfile) return;
+		try {
+			await monolithStore.runQuery(
+				`DeleteAppProfile(app="${appId}", profileId="${selectedProfile.profileId}");`,
+			);
+			toast.success("Profile deleted");
+		} catch {
+			toast.error("Failed to delete profile");
+		}
+		setDeleteProfileDialogOpen(false);
+		setSelectedProfile(null);
+		await loadProfiles();
+	};
+
+	const handleSaveFeature = async () => {
+		const key = featureKey.trim();
+		if (!/^[a-zA-Z0-9-]+$/.test(key)) {
+			setFeatureKeyError("Only letters, numbers, and hyphens allowed.");
+			return;
+		}
+		try {
+			await monolithStore.runQuery(
+				`CreateAppFeature(app="${appId}", key="${key}", description="${sanitizeForPixel(featureDesc)}");`,
+			);
+			toast.success("Feature created");
+		} catch {
+			toast.error("Failed to create feature");
+		}
+		setFeatureDialogOpen(false);
+		setFeatureKey("");
+		setFeatureDesc("");
+		setFeatureKeyError("");
+		if (selectedProfile)
+			await loadProfileFeatures(selectedProfile.profileId);
+	};
+
+	const handleToggleFeature = async (featureId: string, enabled: boolean) => {
+		if (!selectedProfile) return;
+		try {
+			await monolithStore.runQuery(
+				`SetProfileFeature(app="${appId}", profileId="${selectedProfile.profileId}", featureId="${featureId}", enabled="${enabled}");`,
+			);
+			await loadProfileFeatures(selectedProfile.profileId);
+		} catch {
+			toast.error("Failed to update feature");
+		}
+	};
+
+	const handleRemoveUser = async (userId: string) => {
+		try {
+			await monolithStore.runQuery(
+				`RemoveUserProfile(app="${appId}", userId="${userId}");`,
+			);
+			toast.success("User removed from profile");
+		} catch {
+			toast.error("Failed to remove user");
+		}
+		if (selectedProfile) await loadProfileUsers(selectedProfile.profileId);
+	};
+
+	return (
+		<div className="flex h-full gap-4 p-4">
+			{/* Left panel */}
+			<div className="flex w-72 shrink-0 flex-col gap-2">
+				<div className="flex items-center justify-between">
+					<span className="font-semibold text-base">Profiles</span>
+					{canManage && (
+						<Button
+							size="sm"
+							onClick={() => {
+								setEditingProfile(null);
+								setProfileName("");
+								setProfileDesc("");
+								setProfileIsDefault(false);
+								setProfileDialogOpen(true);
+							}}
+						>
+							<Plus className="mr-1 size-4" /> New Profile
+						</Button>
+					)}
+				</div>
+
+				<div className="flex flex-col gap-2">
+					{profiles.map((profile) => (
+						// biome-ignore lint/a11y/useSemanticElements: card has nested interactive buttons; converting outer div to button would make nested buttons invalid HTML
+						<div
+							key={profile.profileId}
+							role="button"
+							tabIndex={0}
+							className={`cursor-pointer rounded border p-3 transition-colors ${
+								selectedProfile?.profileId === profile.profileId
+									? "border-primary bg-accent"
+									: "border-border bg-background hover:bg-muted"
+							}`}
+							onClick={() => setSelectedProfile(profile)}
+							onKeyDown={(e) =>
+								e.key === "Enter" && setSelectedProfile(profile)
+							}
+						>
+							<div className="flex items-center justify-between">
+								<div className="flex flex-col gap-0.5">
+									<div className="flex items-center gap-2">
+										<span className="font-medium text-sm">
+											{profile.profileName}
+										</span>
+										{profile.isDefault && (
+											<Badge
+												variant="secondary"
+												className="text-xs"
+											>
+												Default
+											</Badge>
+										)}
+									</div>
+									<span className="text-muted-foreground text-xs">
+										{profile.userCount ?? 0} user
+										{profile.userCount !== 1 ? "s" : ""}
+									</span>
+								</div>
+								{canManage && (
+									<div className="flex items-center gap-1">
+										<Button
+											variant="ghost"
+											size="icon"
+											className="size-7"
+											onClick={(e) => {
+												e.stopPropagation();
+												setEditingProfile(profile);
+												setProfileName(
+													profile.profileName,
+												);
+												setProfileDesc(
+													profile.description || "",
+												);
+												setProfileIsDefault(
+													profile.isDefault,
+												);
+												setProfileDialogOpen(true);
+											}}
+										>
+											<Pencil className="size-3.5" />
+										</Button>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<span>
+													<Button
+														variant="ghost"
+														size="icon"
+														className="size-7"
+														disabled={
+															(profile.userCount ??
+																0) > 0
+														}
+														onClick={(e) => {
+															e.stopPropagation();
+															setSelectedProfile(
+																profile,
+															);
+															setDeleteProfileDialogOpen(
+																true,
+															);
+														}}
+													>
+														<Trash2 className="size-3.5" />
+													</Button>
+												</span>
+											</TooltipTrigger>
+											<TooltipContent>
+												{(profile.userCount ?? 0) > 0
+													? `${profile.userCount} user(s) assigned — remove them first`
+													: "Delete profile"}
+											</TooltipContent>
+										</Tooltip>
+									</div>
+								)}
+							</div>
+						</div>
+					))}
+					{profiles.length === 0 && (
+						<p className="text-muted-foreground text-sm">
+							No profiles defined yet.
+						</p>
+					)}
+				</div>
+			</div>
+
+			<Separator orientation="vertical" className="h-full" />
+
+			{/* Right panel */}
+			{selectedProfile ? (
+				<div className="flex flex-1 flex-col gap-3">
+					<span className="font-semibold text-base">
+						{selectedProfile.profileName}
+					</span>
+					<Tabs defaultValue="features">
+						<TabsList>
+							<TabsTrigger value="features">Features</TabsTrigger>
+							<TabsTrigger value="members">Members</TabsTrigger>
+						</TabsList>
+
+						<TabsContent
+							value="features"
+							className="mt-3 flex flex-col gap-2"
+						>
+							{canManage && (
+								<Button
+									size="sm"
+									className="self-start"
+									onClick={() => setFeatureDialogOpen(true)}
+								>
+									<Plus className="mr-1 size-4" /> Add Feature
+								</Button>
+							)}
+							{profileFeatures.length === 0 && (
+								<p className="text-muted-foreground text-sm">
+									No features defined for this app.
+								</p>
+							)}
+							{profileFeatures.map((pf) => (
+								<div
+									key={pf.featureId}
+									className="flex items-center justify-between rounded border border-border p-3"
+								>
+									<div className="flex flex-col">
+										<span className="font-medium text-sm">
+											{pf.featureKey}
+										</span>
+										{pf.description && (
+											<span className="text-muted-foreground text-xs">
+												{pf.description}
+											</span>
+										)}
+									</div>
+									<Switch
+										checked={!!pf.enabled}
+										disabled={!canManage}
+										onCheckedChange={(checked) =>
+											handleToggleFeature(
+												pf.featureId,
+												checked,
+											)
+										}
+									/>
+								</div>
+							))}
+						</TabsContent>
+
+						<TabsContent
+							value="members"
+							className="mt-3 flex flex-col gap-2"
+						>
+							{profileUsers.length === 0 && (
+								<p className="text-muted-foreground text-sm">
+									No users assigned to this profile.
+								</p>
+							)}
+							{profileUsers.map((u) => (
+								<div
+									key={u.userId}
+									className="flex items-center justify-between rounded border border-border p-3"
+								>
+									<div className="flex flex-col">
+										<span className="font-medium text-sm">
+											{u.displayName}
+										</span>
+										<span className="text-muted-foreground text-xs">
+											{u.email}
+										</span>
+									</div>
+									{canManage && (
+										<Button
+											variant="ghost"
+											size="icon"
+											className="size-7"
+											onClick={() =>
+												handleRemoveUser(u.userId)
+											}
+										>
+											<Trash2 className="size-3.5" />
+										</Button>
+									)}
+								</div>
+							))}
+						</TabsContent>
+					</Tabs>
+				</div>
+			) : (
+				<div className="flex flex-1 items-center justify-center">
+					<p className="text-muted-foreground text-sm">
+						Select a profile to view details.
+					</p>
+				</div>
+			)}
+
+			{/* Profile create/edit dialog */}
+			<Dialog
+				open={profileDialogOpen}
+				onOpenChange={(v) => !v && setProfileDialogOpen(false)}
+			>
+				<DialogContent className="max-w-sm">
+					<DialogHeader>
+						<DialogTitle>
+							{editingProfile ? "Edit Profile" : "New Profile"}
+						</DialogTitle>
+					</DialogHeader>
+					<div className="flex flex-col gap-4 py-2">
+						<div className="flex flex-col gap-1">
+							<span className="font-medium text-sm">
+								Name <span className="text-destructive">*</span>
+							</span>
+							<Input
+								value={profileName}
+								onChange={(e) => setProfileName(e.target.value)}
+								maxLength={100}
+								placeholder="Profile name"
+							/>
+						</div>
+						<div className="flex flex-col gap-1">
+							<span className="font-medium text-sm">
+								Description
+							</span>
+							<Input
+								value={profileDesc}
+								onChange={(e) => setProfileDesc(e.target.value)}
+								placeholder="Optional description"
+							/>
+						</div>
+						<div className="flex items-center gap-2">
+							<Switch
+								checked={profileIsDefault}
+								onCheckedChange={setProfileIsDefault}
+							/>
+							<span className="text-sm">
+								Set as default profile
+							</span>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setProfileDialogOpen(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							onClick={handleSaveProfile}
+							disabled={!profileName.trim()}
+						>
+							Save
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Feature create dialog */}
+			<Dialog
+				open={featureDialogOpen}
+				onOpenChange={(v) => !v && setFeatureDialogOpen(false)}
+			>
+				<DialogContent className="max-w-sm">
+					<DialogHeader>
+						<DialogTitle>Add Feature</DialogTitle>
+					</DialogHeader>
+					<div className="flex flex-col gap-4 py-2">
+						<div className="flex flex-col gap-1">
+							<span className="font-medium text-sm">
+								Feature Key{" "}
+								<span className="text-destructive">*</span>
+							</span>
+							<Input
+								value={featureKey}
+								onChange={(e) => {
+									setFeatureKey(e.target.value);
+									setFeatureKeyError("");
+								}}
+								maxLength={100}
+								placeholder="e.g. export-csv"
+								className={
+									featureKeyError ? "border-destructive" : ""
+								}
+							/>
+							{featureKeyError && (
+								<span className="text-destructive text-xs">
+									{featureKeyError}
+								</span>
+							)}
+							<span className="text-muted-foreground text-xs">
+								Letters, numbers, and hyphens only
+							</span>
+						</div>
+						<div className="flex flex-col gap-1">
+							<span className="font-medium text-sm">
+								Description
+							</span>
+							<Input
+								value={featureDesc}
+								onChange={(e) => setFeatureDesc(e.target.value)}
+								placeholder="Optional description"
+							/>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => {
+								setFeatureDialogOpen(false);
+								setFeatureKeyError("");
+							}}
+						>
+							Cancel
+						</Button>
+						<Button
+							onClick={handleSaveFeature}
+							disabled={!featureKey.trim()}
+						>
+							Add
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Delete confirmation dialog */}
+			<Dialog
+				open={deleteProfileDialogOpen}
+				onOpenChange={(v) => !v && setDeleteProfileDialogOpen(false)}
+			>
+				<DialogContent className="max-w-sm">
+					<DialogHeader>
+						<DialogTitle>Delete Profile</DialogTitle>
+					</DialogHeader>
+					<p className="text-muted-foreground text-sm">
+						Delete "{selectedProfile?.profileName}"? This cannot be
+						undone.
+					</p>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setDeleteProfileDialogOpen(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							onClick={handleDeleteProfile}
+						>
+							Delete
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+};

--- a/packages/client/src/pages/app/app-detail.constants.ts
+++ b/packages/client/src/pages/app/app-detail.constants.ts
@@ -7,6 +7,7 @@ import { AppFilesPage } from "./app-files-page";
 import { AppGithubPage } from "./app-github-page";
 import { AppMcpUsagePage } from "./app-mcp-usage-page";
 import { AppOverviewPage } from "./app-overview-page";
+import { AppProfilesPage } from "./app-profiles-page";
 import { AppSettingsPage } from "./app-settings-page";
 import { AppSmssPage } from "./app-smss-page";
 
@@ -76,6 +77,12 @@ export const APP_DETAIL_TABS: AppDetailTab[] = [
 		name: "Access Control",
 		path: "access-control",
 		component: AppAccessControlPage,
+		restrict: ["author", "editor"],
+	},
+	{
+		name: "Profiles",
+		path: "profiles",
+		component: AppProfilesPage,
 		restrict: ["author", "editor"],
 	},
 	{

--- a/packages/client/src/pages/app/app-profiles-page.tsx
+++ b/packages/client/src/pages/app/app-profiles-page.tsx
@@ -1,0 +1,7 @@
+import { useAppDetail } from "@/contexts";
+import { AppProfiles } from "./app-detail-tabs/profiles";
+
+export const AppProfilesPage = () => {
+	const { appId, permission } = useAppDetail();
+	return <AppProfiles appId={appId} permission={permission} />;
+};

--- a/packages/client/src/pages/settings/platform-profiles-page.tsx
+++ b/packages/client/src/pages/settings/platform-profiles-page.tsx
@@ -1,0 +1,401 @@
+import { Pencil, Plus, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Input,
+	Separator,
+	Switch,
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+	toast,
+} from "@semoss/ui/next";
+import { useRootStore } from "@/hooks";
+
+const PLATFORM_FEATURE_LABELS: Record<string, string> = {
+	"nav.app-catalog": "App Catalog",
+	"nav.build": "Build",
+	"nav.skills": "Skills",
+	"nav.settings": "Settings",
+	"nav.engine": "Engines",
+};
+
+function sanitizeForPixel(s: string): string {
+	return s.replace(/[^a-zA-Z0-9 _\-.,!?]/g, "");
+}
+
+type ApiPlatformProfile = {
+	profileId: string;
+	profileName: string;
+	description?: string;
+	userCount?: number;
+};
+
+export const PlatformProfilesPage = () => {
+	const { monolithStore } = useRootStore();
+	const [profiles, setProfiles] = useState<ApiPlatformProfile[]>([]);
+	const [selectedProfile, setSelectedProfile] =
+		useState<ApiPlatformProfile | null>(null);
+	const [profileFeatures, setProfileFeatures] = useState<
+		Record<string, boolean>
+	>({});
+	const [profileDialogOpen, setProfileDialogOpen] = useState(false);
+	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+	const [editingProfile, setEditingProfile] =
+		useState<ApiPlatformProfile | null>(null);
+	const [profileName, setProfileName] = useState("");
+	const [profileDesc, setProfileDesc] = useState("");
+
+	const loadProfiles = useCallback(async () => {
+		try {
+			const res = await monolithStore.runQuery("GetPlatformProfiles();");
+			const { operationType, output } = res.pixelReturn[0];
+			if (operationType.indexOf("ERROR") === -1 && output) {
+				setProfiles(
+					Array.isArray(output) ? output : Object.values(output),
+				);
+			}
+		} catch {
+			toast.error("Failed to load platform profiles");
+		}
+	}, [monolithStore]);
+
+	const loadProfileFeatures = useCallback(
+		async (profileId: string) => {
+			try {
+				const res = await monolithStore.runQuery(
+					`GetPlatformFeatures(profileId="${profileId}");`,
+				);
+				const { operationType, output } = res.pixelReturn[0];
+				if (operationType.indexOf("ERROR") === -1 && output) {
+					setProfileFeatures(output as Record<string, boolean>);
+				}
+			} catch {
+				toast.error("Failed to load profile features");
+			}
+		},
+		[monolithStore],
+	);
+
+	useEffect(() => {
+		loadProfiles();
+	}, [loadProfiles]);
+
+	useEffect(() => {
+		if (selectedProfile) {
+			loadProfileFeatures(selectedProfile.profileId);
+		}
+	}, [selectedProfile, loadProfileFeatures]);
+
+	const handleSaveProfile = async () => {
+		const name = sanitizeForPixel(profileName.trim());
+		if (!name) return;
+		try {
+			if (editingProfile) {
+				await monolithStore.runQuery(
+					`UpdatePlatformProfile(profileId="${editingProfile.profileId}", name="${name}", description="${sanitizeForPixel(profileDesc)}");`,
+				);
+				toast.success("Profile updated");
+			} else {
+				await monolithStore.runQuery(
+					`CreatePlatformProfile(name="${name}", description="${sanitizeForPixel(profileDesc)}");`,
+				);
+				toast.success("Profile created");
+			}
+		} catch {
+			toast.error("Failed to save profile");
+		}
+		setProfileDialogOpen(false);
+		setEditingProfile(null);
+		setProfileName("");
+		setProfileDesc("");
+		await loadProfiles();
+	};
+
+	const handleDeleteProfile = async () => {
+		if (!selectedProfile) return;
+		try {
+			await monolithStore.runQuery(
+				`DeletePlatformProfile(profileId="${selectedProfile.profileId}");`,
+			);
+			toast.success("Profile deleted");
+		} catch {
+			toast.error("Failed to delete profile");
+		}
+		setDeleteDialogOpen(false);
+		setSelectedProfile(null);
+		await loadProfiles();
+	};
+
+	const handleToggleFeature = async (
+		featureKey: string,
+		enabled: boolean,
+	) => {
+		if (!selectedProfile) return;
+		try {
+			await monolithStore.runQuery(
+				`SetPlatformFeature(profileId="${selectedProfile.profileId}", featureKey="${featureKey}", enabled="${enabled}");`,
+			);
+			await loadProfileFeatures(selectedProfile.profileId);
+		} catch {
+			toast.error("Failed to update feature");
+		}
+	};
+
+	return (
+		<div className="flex h-full gap-4 p-4">
+			{/* Left panel */}
+			<div className="flex w-72 shrink-0 flex-col gap-2">
+				<div className="flex items-center justify-between">
+					<span className="font-semibold text-base">
+						Platform Profiles
+					</span>
+					<Button
+						size="sm"
+						onClick={() => {
+							setEditingProfile(null);
+							setProfileName("");
+							setProfileDesc("");
+							setProfileDialogOpen(true);
+						}}
+					>
+						<Plus className="mr-1 size-4" /> New
+					</Button>
+				</div>
+
+				<div className="flex flex-col gap-2">
+					{profiles.map((profile) => (
+						// biome-ignore lint/a11y/useSemanticElements: card has nested interactive buttons; converting outer div to button would make nested buttons invalid HTML
+						<div
+							key={profile.profileId}
+							role="button"
+							tabIndex={0}
+							className={`cursor-pointer rounded border p-3 transition-colors ${
+								selectedProfile?.profileId === profile.profileId
+									? "border-primary bg-accent"
+									: "border-border bg-background hover:bg-muted"
+							}`}
+							onClick={() => setSelectedProfile(profile)}
+							onKeyDown={(e) =>
+								e.key === "Enter" && setSelectedProfile(profile)
+							}
+						>
+							<div className="flex items-center justify-between">
+								<div className="flex flex-col gap-0.5">
+									<span className="font-medium text-sm">
+										{profile.profileName}
+									</span>
+									<span className="text-muted-foreground text-xs">
+										{profile.userCount ?? 0} user
+										{profile.userCount !== 1 ? "s" : ""}
+									</span>
+								</div>
+								<div className="flex items-center gap-1">
+									<Button
+										variant="ghost"
+										size="icon"
+										className="size-7"
+										onClick={(e) => {
+											e.stopPropagation();
+											setEditingProfile(profile);
+											setProfileName(profile.profileName);
+											setProfileDesc(
+												profile.description || "",
+											);
+											setProfileDialogOpen(true);
+										}}
+									>
+										<Pencil className="size-3.5" />
+									</Button>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span>
+												<Button
+													variant="ghost"
+													size="icon"
+													className="size-7"
+													disabled={
+														(profile.userCount ??
+															0) > 0
+													}
+													onClick={(e) => {
+														e.stopPropagation();
+														setSelectedProfile(
+															profile,
+														);
+														setDeleteDialogOpen(
+															true,
+														);
+													}}
+												>
+													<Trash2 className="size-3.5" />
+												</Button>
+											</span>
+										</TooltipTrigger>
+										<TooltipContent>
+											{(profile.userCount ?? 0) > 0
+												? `${profile.userCount} user(s) assigned — remove them first`
+												: "Delete profile"}
+										</TooltipContent>
+									</Tooltip>
+								</div>
+							</div>
+						</div>
+					))}
+					{profiles.length === 0 && (
+						<p className="text-muted-foreground text-sm">
+							No platform profiles defined.
+						</p>
+					)}
+				</div>
+			</div>
+
+			<Separator orientation="vertical" className="h-full" />
+
+			{/* Right panel */}
+			{selectedProfile ? (
+				<div className="flex flex-1 flex-col gap-3">
+					<span className="font-semibold text-base">
+						{selectedProfile.profileName}
+					</span>
+					<Tabs defaultValue="features">
+						<TabsList>
+							<TabsTrigger value="features">
+								Platform Features
+							</TabsTrigger>
+							<TabsTrigger value="members">Members</TabsTrigger>
+						</TabsList>
+
+						<TabsContent
+							value="features"
+							className="mt-3 flex flex-col gap-2"
+						>
+							{Object.entries(PLATFORM_FEATURE_LABELS).map(
+								([key, label]) => (
+									<div
+										key={key}
+										className="flex items-center justify-between rounded border border-border p-3"
+									>
+										<span className="text-sm">{label}</span>
+										<Switch
+											checked={!!profileFeatures[key]}
+											onCheckedChange={(checked) =>
+												handleToggleFeature(
+													key,
+													checked,
+												)
+											}
+										/>
+									</div>
+								),
+							)}
+						</TabsContent>
+
+						<TabsContent value="members" className="mt-3">
+							<p className="text-muted-foreground text-sm">
+								No users assigned to this profile.
+							</p>
+						</TabsContent>
+					</Tabs>
+				</div>
+			) : (
+				<div className="flex flex-1 items-center justify-center">
+					<p className="text-muted-foreground text-sm">
+						Select a profile to view details.
+					</p>
+				</div>
+			)}
+
+			{/* Profile create/edit dialog */}
+			<Dialog
+				open={profileDialogOpen}
+				onOpenChange={(v) => !v && setProfileDialogOpen(false)}
+			>
+				<DialogContent className="max-w-sm">
+					<DialogHeader>
+						<DialogTitle>
+							{editingProfile
+								? "Edit Profile"
+								: "New Platform Profile"}
+						</DialogTitle>
+					</DialogHeader>
+					<div className="flex flex-col gap-4 py-2">
+						<div className="flex flex-col gap-1">
+							<span className="font-medium text-sm">
+								Name <span className="text-destructive">*</span>
+							</span>
+							<Input
+								value={profileName}
+								onChange={(e) => setProfileName(e.target.value)}
+								placeholder="Profile name"
+							/>
+						</div>
+						<div className="flex flex-col gap-1">
+							<span className="font-medium text-sm">
+								Description
+							</span>
+							<Input
+								value={profileDesc}
+								onChange={(e) => setProfileDesc(e.target.value)}
+								placeholder="Optional description"
+							/>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setProfileDialogOpen(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							onClick={handleSaveProfile}
+							disabled={!profileName.trim()}
+						>
+							Save
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Delete confirmation dialog */}
+			<Dialog
+				open={deleteDialogOpen}
+				onOpenChange={(v) => !v && setDeleteDialogOpen(false)}
+			>
+				<DialogContent className="max-w-sm">
+					<DialogHeader>
+						<DialogTitle>Delete Profile</DialogTitle>
+					</DialogHeader>
+					<p className="text-muted-foreground text-sm">
+						Delete "{selectedProfile?.profileName}"? This cannot be
+						undone.
+					</p>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setDeleteDialogOpen(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							onClick={handleDeleteProfile}
+						>
+							Delete
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+};

--- a/packages/client/src/pages/settings/settings-router.tsx
+++ b/packages/client/src/pages/settings/settings-router.tsx
@@ -13,6 +13,7 @@ import { InsightSettingsPage } from "./insight-settings-page";
 import { LLMFeedbackPage } from "./llm-feedback-page";
 import { MemberSettingsPage } from "./MemberSettingsPage";
 import { MyProfilePage } from "./my-profile-page";
+import { PlatformProfilesPage } from "./platform-profiles-page";
 import { ProjectSettingsDetailsPage } from "./project-settings-details-page";
 import { ProjectSettingsPage } from "./project-settings-page";
 import { RDFMapPage } from "./rdf-map-page";
@@ -44,6 +45,7 @@ const SETTINGS_COMPONETS = {
 	"team-permissions/:type/:id": TeamSettingsDetailPage,
 	"view-rdf-map": RDFMapPage,
 	"llm-feedback": LLMFeedbackPage,
+	"platform-profiles": PlatformProfilesPage,
 
 	// engine
 	database: () => <EngineSettingsIndexPage type="DATABASE" />,

--- a/packages/client/src/pages/settings/settings.constants.ts
+++ b/packages/client/src/pages/settings/settings.constants.ts
@@ -10,6 +10,7 @@ import {
 	mdiDatabaseSearch,
 	mdiGithub,
 	mdiPalette,
+	mdiShieldAccount,
 	mdiTabletCellphone,
 } from "@mdi/js";
 
@@ -254,6 +255,14 @@ export const SETTINGS_ROUTES: {
 		path: "view-rdf-map",
 		description: "See configuration details in the RDF Map of the instance",
 		icon: mdiClipboardTextOutline,
+		history: ["settings/"],
+		admin: true,
+	},
+	{
+		title: "Platform Profiles",
+		path: "platform-profiles",
+		description: "Control which platform pages are visible to each user.",
+		icon: mdiShieldAccount,
 		history: ["settings/"],
 		admin: true,
 	},

--- a/packages/client/src/stores/config/config.store.ts
+++ b/packages/client/src/stores/config/config.store.ts
@@ -816,6 +816,8 @@ export class ConfigStore {
 			workspace.type = "SKILL";
 		} else if (metadata.project_type === "WORKSPACE") {
 			workspace.type = "WORKSPACE";
+		} else if (metadata.project_type === "WORKFLOW") {
+			workspace.type = "WORKFLOW";
 		}
 
 		// create the newly loaded workspace

--- a/packages/client/src/stores/workspace/workspace.store.ts
+++ b/packages/client/src/stores/workspace/workspace.store.ts
@@ -39,7 +39,7 @@ export interface WorkspaceStoreInterface {
 	/**
 	 * Type of the app
 	 */
-	type: "BLOCKS" | "CODE" | "SKILL" | "WORKSPACE";
+	type: "BLOCKS" | "CODE" | "SKILL" | "WORKSPACE" | "WORKFLOW";
 
 	/**
 	 * Model associated with the layout
@@ -120,7 +120,7 @@ export interface WorkspaceConfigInterface {
 	/**
 	 * Type of the app
 	 */
-	type: "BLOCKS" | "CODE" | "SKILL" | "WORKSPACE";
+	type: "BLOCKS" | "CODE" | "SKILL" | "WORKSPACE" | "WORKFLOW";
 
 	/**
 	 * Metadata associated with the loaded app


### PR DESCRIPTION
## Description

Implements the frontend for the Role-Based Feature Visibility system. Adds an App Profiles tab to the app detail page (for app owners/editors to manage which features each user group can see) and a Platform Profiles admin page in Settings (for admins to control which nav pages each user group can access).

## Changes Made

### New Files
- **`packages/client/src/pages/app/app-detail-tabs/profiles.tsx`** — Two-panel App Profiles management UI: profile list (left) + detail panel with Features and Members tabs (right). Supports create/edit/delete profiles, toggle feature flags per profile, remove users. Restricted to `author`/`editor` permission.
- **`packages/client/src/pages/app/app-profiles-page.tsx`** — Thin page wrapper using `useAppDetail` context to pass `appId` and `permission` to `AppProfiles`.
- **`packages/client/src/pages/settings/platform-profiles-page.tsx`** — Two-panel Platform Profiles admin UI: profile list (left) + Platform Features tab with toggles for the 5 predefined nav keys (`nav.app-catalog`, `nav.build`, `nav.skills`, `nav.settings`, `nav.engine`).

### Modified Files
- **`app-detail.constants.ts`** — Adds "Profiles" tab to APP_DETAIL_TABS with `restrict: ["author", "editor"]`
- **`settings-router.tsx`** — Registers `PlatformProfilesPage` in SETTINGS_COMPONENTS
- **`settings.constants.ts`** — Adds Platform Profiles route entry (admin-only) with `mdiShieldAccount` icon
- **`AuthenticatedLayout.tsx`** — Calls `GetUserPlatformFeatures()` on startup when config status is SUCCESS; stores result in `configStore.store.platformFeatures` for downstream nav gating

### Tech Stack
- `@semoss/ui/next`: `Dialog`, `Tabs/TabsList/TabsTrigger/TabsContent`, `Switch`, `Input`, `Button`, `Tooltip/TooltipContent/TooltipTrigger`, `Badge`, `Separator`, `toast`
- `lucide-react`: `Plus`, `Pencil`, `Trash2`
- Tailwind CSS for layout

## How to Test

1. Build the frontend: `make build-frontend`
2. Log in as an app owner and navigate to any app → **Profiles** tab
3. Create a profile, add features, toggle them on/off, assign users
4. Log in as admin → **Settings → Platform Profiles**
5. Create a platform profile, toggle nav features on/off

## Screenshots

| App Profiles Tab | Platform Profiles Admin |
|---|---|
| `tasks/screenshots/rbfv-05-app-profiles-empty.png` | `tasks/screenshots/rbfv-03-platform-profiles.png` |
| `tasks/screenshots/rbfv-06-app-profile-detail.png` | `tasks/screenshots/rbfv-04-platform-profile-detail.png` |

## Notes

- `sanitizeForPixel()` strips non-safe chars before embedding in Pixel strings
- Feature key validation: `^[a-zA-Z0-9\-]+$` — enforced both client-side and in `PlatformProfileUtils.setProfileFeature`
- `AuthenticatedLayout` change moves platform feature hydration earlier (before nav renders) so nav gating is available immediately after login
- The `configStore.store.platformFeatures` field is new — downstream nav code can read it for visibility decisions