### PR TITLE
fix: removed google logos from model dropdowns

### DIFF
--- a/packages/playground/src/components/room/room-input.tsx
+++ b/packages/playground/src/components/room/room-input.tsx
@@ -910,6 +910,7 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 													contextTooltipContent={
 														contextTooltipContent
 													}
+													showEngineIcon={false}
 												/>
 											)}
 										</div>

--- a/packages/playground/src/components/room/room-options-form.tsx
+++ b/packages/playground/src/components/room/room-options-form.tsx
@@ -126,6 +126,7 @@ export const RoomOptionsForm: React.FC<RoomOptionsFormProps> = observer(
 											popoverContentProps={{
 												align: "start",
 											}}
+											showEngineIcon={false}
 										/>
 									</div>
 								</Field>


### PR DESCRIPTION
## Description
Remove Google Icons from model dropdown

## Changes Made
  - room-input.tsx - Added showEngineIcon={false} to a component rendered in the room input area.
  - room-options-form.tsx - Added showEngineIcon={false} to a component in the room options form.
Both changes hide the engine/provider icon (which in this context was displaying Google logos) from the model dropdown selectors.

## How to Test
 - Run semoss-ui locally and click on the model dropdown to see if the icons exist in front of the model names or not

## Notes
 - @kzsb03 this is ultimately a business decision of whether or not you think the logos should be taken away. If you'd like to keep them, then please disregard this PR. Thank you!
 - Changing model descriptions is done directly on the environment
        - e.g. SetEngineMetadata(engine = ['8405ac40-89c6-4613-848c-3d89986fbc01'], meta = [{"description": ["Anthropic's model best for everyday tasks"]}])

<img width="1907" height="982" alt="Screenshot 2026-06-30 124443" src="https://github.com/user-attachments/assets/36f84ea1-81a3-45da-b806-2b976921d29a" />