### PR TITLE
feat(agent-config): add platform skills to skills list

### DIFF
--- a/libs/i18n/src/resources/locales/en/playground/workspace.json
+++ b/libs/i18n/src/resources/locales/en/playground/workspace.json
@@ -163,6 +163,7 @@
 		"charCount": "{{count}} characters"
 	},
 	"skills": {
-		"noSkills": "No skills added"
+		"noSkills": "No skills added",
+		"builtInBadge": "Platform"
 	}
 }

--- a/libs/i18n/src/resources/locales/en/shared/mcp.json
+++ b/libs/i18n/src/resources/locales/en/shared/mcp.json
@@ -6,7 +6,10 @@
 		"noToolboxesFound": "No toolboxes found",
 		"noKnowledgeFound": "No knowledge found",
 		"noAgentsFound": "No agents found",
-		"noSkillsFound": "No skills found"
+		"noSkillsFound": "No skills found",
+		"platformBadge": "Platform",
+		"builtInSection": "Platform skills",
+		"registrySection": "Your skills"
 	},
 	"permission": {
 		"owner": "Owner",

--- a/libs/shared/src/components/mcp/mcp-card.tsx
+++ b/libs/shared/src/components/mcp/mcp-card.tsx
@@ -61,6 +61,11 @@ export interface MCPCardProps {
 	 * for skills, which are projects but should read "Skill".
 	 */
 	typeLabel?: string;
+	/**
+	 * Optional small badge shown next to the type label — e.g. "Platform" to
+	 * mark a read-only platform skill apart from a user's registry skills.
+	 */
+	badge?: string;
 }
 
 export const MCPCard = ({
@@ -74,6 +79,7 @@ export const MCPCard = ({
 	fromWorkspace,
 	getPlatformUrl,
 	typeLabel,
+	badge,
 }: MCPCardProps) => {
 	const { t } = useTranslation(["mcp", "common", "workspace"]);
 	const effectiveOnClick = fromWorkspace ? undefined : onClick;
@@ -265,6 +271,14 @@ export const MCPCard = ({
 						<div className="flex items-center gap-1.5 text-muted-foreground text-xs">
 							<TypeIcon className="size-3.5 shrink-0" />
 							<span>{typeLabel ?? toSentenceCase(m.type)}</span>
+							{badge ? (
+								<Badge
+									variant="secondary"
+									className="h-4 px-1.5 text-[10px]"
+								>
+									{badge}
+								</Badge>
+							) : null}
 						</div>
 					</div>
 

--- a/libs/shared/src/components/skills/skill-selector.tsx
+++ b/libs/shared/src/components/skills/skill-selector.tsx
@@ -1,7 +1,7 @@
 import { SearchIcon, XIcon } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "@semoss/i18n";
-import { useIteratorPixel } from "@semoss/sdk/react";
+import { useIteratorPixel, usePixel } from "@semoss/sdk/react";
 import {
 	Button,
 	cn,
@@ -15,9 +15,21 @@ import {
 	useDebouncedValue,
 	useInfiniteScroll,
 } from "@semoss/ui/next";
-import type { App, SkillConfig } from "../../types";
+import type { App, MCP, SkillConfig } from "../../types";
 import { MCPCard } from "../mcp/mcp-card";
 import { engineProjectToMCP } from "../mcp/mcp-utils";
+
+/**
+ * Raw platform-skill row returned by `GetSkills(filter="platform")`. Platform
+ * skills are read-only built-ins shipped with the platform: they are not
+ * projects, so they have no id and are referenced by their folder `slug`.
+ */
+interface PlatformSkill {
+	slug: string;
+	name: string;
+	description: string;
+	origin: "PLATFORM";
+}
 
 interface SkillSelectorProps {
 	/** Selected skills */
@@ -35,6 +47,10 @@ interface SkillSelectorProps {
 
 /**
  * Renders the SkillSelector component for attaching skills to an agent.
+ *
+ * Two kinds of skills are listed: the user's own registry skills (SKILL
+ * projects, attached by id) and read-only platform built-ins (attached by
+ * slug). Platform skills are shown in their own "Platform" group with a badge.
  */
 export const SkillSelector: React.FC<SkillSelectorProps> = ({
 	values,
@@ -47,7 +63,7 @@ export const SkillSelector: React.FC<SkillSelectorProps> = ({
 
 	const debouncedSearch = useDebouncedValue(search, 500);
 
-	// track the selected ones by id
+	// track the selected ones by id (platform skills key by slug)
 	const selected = values.reduce(
 		(acc, curr) => {
 			acc[curr.id] = curr;
@@ -57,7 +73,7 @@ export const SkillSelector: React.FC<SkillSelectorProps> = ({
 	);
 
 	/**
-	 * Get all of the skills with lazy loading
+	 * Get all of the registry skills with lazy loading
 	 */
 	const getSkills = useIteratorPixel<App[], App>(
 		(limit, offset) =>
@@ -69,7 +85,27 @@ export const SkillSelector: React.FC<SkillSelectorProps> = ({
 	);
 
 	/**
-	 * Setup infinite scroll for the skill list
+	 * Get the platform (built-in) skills. This is a small fixed set, so it is
+	 * fetched in one shot and filtered client-side by the search box.
+	 */
+	const platformSkills = usePixel<PlatformSkill[]>(
+		`GetSkills(filter="platform")`,
+		{
+			data: [],
+		},
+	);
+
+	const filteredPlatformSkills = platformSkills.data.filter((s) => {
+		if (!debouncedSearch) return true;
+		const q = debouncedSearch.toLowerCase();
+		return (
+			s.name.toLowerCase().includes(q) ||
+			(s.description ?? "").toLowerCase().includes(q)
+		);
+	});
+
+	/**
+	 * Setup infinite scroll for the registry skill list
 	 */
 	const { setScroll } = useInfiniteScroll({
 		disabled: getSkills.isLoading || !getSkills.hasMore,
@@ -89,10 +125,24 @@ export const SkillSelector: React.FC<SkillSelectorProps> = ({
 		}
 	};
 
-	const isEmpty =
+	/** Normalize a platform skill into the shared MCP card shape. */
+	const platformSkillToMCP = (skill: PlatformSkill): MCP => ({
+		type: "PROJECT",
+		id: skill.slug,
+		name: skill.name,
+		description: skill.description ?? "",
+		tags: [],
+		permission: "READ_ONLY",
+	});
+
+	const platformLoading = platformSkills.status === "LOADING";
+	const noResults =
 		!getSkills.isLoading &&
+		!platformLoading &&
 		getSkills.data.length === 0 &&
-		values.length === 0;
+		filteredPlatformSkills.length === 0;
+
+	const isEmpty = noResults && values.length === 0;
 
 	return (
 		<div
@@ -119,33 +169,81 @@ export const SkillSelector: React.FC<SkillSelectorProps> = ({
 				className="min-h-0 w-full flex-1"
 				viewportRef={(e) => setScroll(e)}
 			>
+				{/* Platform skills */}
+				{filteredPlatformSkills.length > 0 && (
+					<div>
+						<div className="px-4 pt-4 pb-1 font-medium text-muted-foreground text-xs">
+							{t("selector.builtInSection")}
+						</div>
+						<div className="grid grid-cols-1 gap-4 px-4 pt-2 pb-2 md:grid-cols-2 lg:grid-cols-3">
+							{filteredPlatformSkills.map((skill) => {
+								const mcp = platformSkillToMCP(skill);
+								return (
+									<MCPCard
+										key={mcp.id}
+										m={mcp}
+										typeLabel="Skill"
+										badge={t("selector.platformBadge")}
+										selected={Object.hasOwn(
+											selected,
+											mcp.id,
+										)}
+										onClick={() =>
+											onSelect({
+												id: skill.slug,
+												name: skill.name,
+												type: "PLATFORM_SKILL",
+											})
+										}
+									/>
+								);
+							})}
+						</div>
+					</div>
+				)}
+
+				{/* Registry skills */}
 				{getSkills.isLoading && (
 					<div className="flex h-64 w-full items-center justify-center">
 						<Spinner />
 					</div>
 				)}
-				{!getSkills.isLoading && getSkills.data.length === 0 && (
-					<div className="flex h-24 w-full items-center justify-center">
-						<Muted>{t("selector.noSkillsFound")}</Muted>
+				{!getSkills.isLoading && getSkills.data.length !== 0 && (
+					<div>
+						<div className="px-4 pt-4 pb-1 font-medium text-muted-foreground text-xs">
+							{t("selector.registrySection")}
+						</div>
+						<div className="grid grid-cols-1 gap-4 px-4 pt-2 pb-4 md:grid-cols-2 lg:grid-cols-3">
+							{getSkills.data.map((skill) => {
+								const mcp = engineProjectToMCP(skill);
+								return (
+									<MCPCard
+										key={mcp.id}
+										m={mcp}
+										typeLabel="Skill"
+										selected={Object.hasOwn(
+											selected,
+											mcp.id,
+										)}
+										effectivePermission={mcp.permission}
+										onClick={() =>
+											onSelect({
+												id: mcp.id,
+												name: mcp.name,
+												type: "SKILL",
+											})
+										}
+									/>
+								);
+							})}
+						</div>
 					</div>
 				)}
-				{!getSkills.isLoading && getSkills.data.length !== 0 && (
-					<div className="grid grid-cols-1 gap-4 p-4 md:grid-cols-2 lg:grid-cols-3">
-						{getSkills.data.map((skill) => {
-							const mcp = engineProjectToMCP(skill);
-							return (
-								<MCPCard
-									key={mcp.id}
-									m={mcp}
-									typeLabel="Skill"
-									selected={Object.hasOwn(selected, mcp.id)}
-									effectivePermission={mcp.permission}
-									onClick={() =>
-										onSelect({ id: mcp.id, name: mcp.name })
-									}
-								/>
-							);
-						})}
+
+				{/* Nothing to show */}
+				{noResults && (
+					<div className="flex h-24 w-full items-center justify-center">
+						<Muted>{t("selector.noSkillsFound")}</Muted>
 					</div>
 				)}
 			</ScrollArea>

--- a/libs/shared/src/types.ts
+++ b/libs/shared/src/types.ts
@@ -389,23 +389,36 @@ export type MCPConfig = Pick<MCP, "type" | "id" | "name"> & {
 };
 
 export interface Skill {
-	/** Id of the skill (project id) */
+	/**
+	 * Identifier of the skill. For a registry skill this is the project id
+	 * (a UUID). For a platform skill it is the folder `slug` — platform
+	 * skills are not projects and have no project id, and GetWorkspace
+	 * returns `id === slug` for them.
+	 */
 	id: string;
 	/** Display name of the skill */
 	name: string;
-	/** Type discriminator — always SKILL */
-	type: "SKILL";
+	/**
+	 * Type discriminator. `SKILL` is a user-owned registry skill (attached
+	 * by skill id); `PLATFORM_SKILL` is a read-only built-in shipped with
+	 * the platform (attached by slug).
+	 */
+	type: "SKILL" | "PLATFORM_SKILL";
 	/** URL-friendly identifier */
 	slug: string;
+	/** Optional description (shown on platform skill cards) */
+	description?: string;
 }
 
 /**
  * The shape carried in form state and selectors. Mirrors MCPConfig — the
  * name travels with the value so selectors can render chips without a
- * separate lookup. Reduced to IDs only at the EditWorkspace/AddWorkspace
- * pixel boundary.
+ * separate lookup. The `type` discriminator lets save paths split registry
+ * skills (persisted by id via `skills=`) from platform skills (persisted by
+ * slug via `platformSkills=`); for platform skills `id` is the slug.
+ * Reduced to identifiers only at the EditWorkspace/AddWorkspace pixel boundary.
  */
-export type SkillConfig = Pick<Skill, "id" | "name">;
+export type SkillConfig = Pick<Skill, "id" | "name" | "type">;
 
 export interface ProjectDependency {
 	engine_type:

--- a/packages/client/src/components/agent-workspace/agent-editor.tsx
+++ b/packages/client/src/components/agent-workspace/agent-editor.tsx
@@ -96,9 +96,14 @@ export const AgentEditor = () => {
 		try {
 			setIsLoading(true);
 			const mcp = [...data.knowledge, ...data.toolboxes];
-			const skills = data.skills.map((s) => s.id);
+			const skills = data.skills
+				.filter((s) => s.type !== "PLATFORM_SKILL")
+				.map((s) => s.id);
+			const platformSkills = data.skills
+				.filter((s) => s.type === "PLATFORM_SKILL")
+				.map((s) => s.id);
 			const { errors } = await monolithStore.runQuery(
-				`EditWorkspace(workspaceId=["${workspace.appId}"], name=${JSON.stringify(data.name)}, description=${JSON.stringify(data.description)}, systemPrompt=${JSON.stringify(data.instructions)}, mcp=${JSON.stringify(mcp)}, skills=${JSON.stringify(skills)}, prompts=${JSON.stringify(data.prompts)});`,
+				`EditWorkspace(workspaceId=["${workspace.appId}"], name=${JSON.stringify(data.name)}, description=${JSON.stringify(data.description)}, systemPrompt=${JSON.stringify(data.instructions)}, mcp=${JSON.stringify(mcp)}, skills=${JSON.stringify(skills)}, platformSkills=${JSON.stringify(platformSkills)}, prompts=${JSON.stringify(data.prompts)});`,
 			);
 			if (errors.length > 0) throw new Error(errors.join(", "));
 			toast.success("Agent saved");

--- a/packages/client/src/pages/agent/create-agent-page.tsx
+++ b/packages/client/src/pages/agent/create-agent-page.tsx
@@ -82,13 +82,17 @@ export const CreateAgentPage = () => {
 
 			// Combine knowledge and toolboxes into mcp array
 			const mcp = [...data.knowledge, ...data.toolboxes];
-
-			const skills = data.skills.map((s) => s.id);
+			const skills = data.skills
+				.filter((s) => s.type !== "PLATFORM_SKILL")
+				.map((s) => s.id);
+			const platformSkills = data.skills
+				.filter((s) => s.type === "PLATFORM_SKILL")
+				.map((s) => s.id);
 
 			const { errors, pixelReturn } = await monolithStore.runQuery<
 				[string]
 			>(
-				`AddWorkspace(name=${JSON.stringify(data.name)}, description=${JSON.stringify(data.description)}, systemPrompt=${JSON.stringify(data.instructions)}, mcp=${JSON.stringify(mcp)}, skills=${JSON.stringify(skills)}, prompts=${JSON.stringify(data.prompts)});`,
+				`AddWorkspace(name=${JSON.stringify(data.name)}, description=${JSON.stringify(data.description)}, systemPrompt=${JSON.stringify(data.instructions)}, mcp=${JSON.stringify(mcp)}, skills=${JSON.stringify(skills)}, platformSkills=${JSON.stringify(platformSkills)}, prompts=${JSON.stringify(data.prompts)});`,
 			);
 
 			if (errors.length > 0) throw new Error(errors.join(","));

--- a/packages/playground/src/components/workspace/workspace-skill-list.tsx
+++ b/packages/playground/src/components/workspace/workspace-skill-list.tsx
@@ -1,6 +1,6 @@
 import { BlocksIcon } from "lucide-react";
 import { useTranslation } from "@semoss/i18n";
-import { Muted, ScrollArea } from "@semoss/ui/next";
+import { Badge, Muted, ScrollArea } from "@semoss/ui/next";
 import type { SkillConfig } from "@/types";
 
 interface WorkspaceSkillListProps {
@@ -35,6 +35,14 @@ export const WorkspaceSkillList = ({ skills }: WorkspaceSkillListProps) => {
 						<div className="font-semibold text-foreground text-sm">
 							{s.name}
 						</div>
+						{s.type === "PLATFORM_SKILL" && (
+							<Badge
+								variant="secondary"
+								className="ms-auto h-4 px-1.5 text-[10px]"
+							>
+								{t("skills.builtInBadge", "Platform")}
+							</Badge>
+						)}
 					</div>
 				))}
 			</div>

--- a/packages/playground/src/stores/chat/chat.store.ts
+++ b/packages/playground/src/stores/chat/chat.store.ts
@@ -460,9 +460,14 @@ export class ChatStore {
 			const mcp = data.mcp.map(
 				({ name, id, type }): MCPConfig => ({ name, id, type }),
 			);
-			const skills = data.skills.map((s) => s.id);
+			const skills = data.skills
+				.filter((s) => s.type !== "PLATFORM_SKILL")
+				.map((s) => s.id);
+			const platformSkills = data.skills
+				.filter((s) => s.type === "PLATFORM_SKILL")
+				.map((s) => s.id);
 
-			const pixel = `AddWorkspace(name=${JSON.stringify(data.name)}, description="<encode>${data.description}</encode>", systemPrompt="<encode>${data.system_prompt}</encode>", mcp=${JSON.stringify(mcp)}, skills=${JSON.stringify(skills)}, prompts=${JSON.stringify(data.prompts)})`;
+			const pixel = `AddWorkspace(name=${JSON.stringify(data.name)}, description="<encode>${data.description}</encode>", systemPrompt="<encode>${data.system_prompt}</encode>", mcp=${JSON.stringify(mcp)}, skills=${JSON.stringify(skills)}, platformSkills=${JSON.stringify(platformSkills)}, prompts=${JSON.stringify(data.prompts)})`;
 			const { pixelReturn } = await this._actions.run<[string]>(pixel);
 
 			return pixelReturn[0].output;
@@ -490,12 +495,16 @@ export class ChatStore {
 			const mcp = data.mcp.map(
 				({ name, id, type }): MCPConfig => ({ name, id, type }),
 			);
-			const skills = data.skills.map((s) => s.id);
+			const skills = data.skills
+				.filter((s) => s.type !== "PLATFORM_SKILL")
+				.map((s) => s.id);
+			const platformSkills = data.skills
+				.filter((s) => s.type === "PLATFORM_SKILL")
+				.map((s) => s.id);
 
-			const pixel = `EditWorkspace(workspaceId=${JSON.stringify(workspaceId)}, name=${JSON.stringify(data.name)}, description="<encode>${data.description}</encode>", systemPrompt="<encode>${data.system_prompt}</encode>", mcp=${JSON.stringify(mcp)}, skills=${JSON.stringify(skills)}, prompts=${JSON.stringify(data.prompts)})`;
+			const pixel = `EditWorkspace(workspaceId=${JSON.stringify(workspaceId)}, name=${JSON.stringify(data.name)}, description="<encode>${data.description}</encode>", systemPrompt="<encode>${data.system_prompt}</encode>", mcp=${JSON.stringify(mcp)}, skills=${JSON.stringify(skills)}, platformSkills=${JSON.stringify(platformSkills)}, prompts=${JSON.stringify(data.prompts)})`;
 			const { pixelReturn } = await this._actions.run<[string]>(pixel);
 
-			// throw errors
 			if (!pixelReturn[0].output) {
 				throw new Error();
 			}


### PR DESCRIPTION
# feat(agent-config): add platform skills to the skills list

## Summary

Adds **platform skills** (read-only built-ins shipped with the platform — `database`, `model`, `vector`, `python`, `agent-memory`, etc.) to the Agent Config skills list, alongside the user's own registry skills. Users can now attach and detach these built-ins to an agent's workspace, with the attached state persisting across reloads.

Previously the skills list only showed registry skills, so the platform built-ins were invisible in the UI even though the backend already supported attaching them.

## Background

Skills come in two flavors:

- **Registry skills** — real `SKILL`-type projects owned by a user, identified by a `skill_id` (UUID). Attached by **id**.
- **Platform skills** — disk-backed, read-only built-ins. They are *not* projects (no `skill_id`) and are referenced by a **`slug`** with `origin: "PLATFORM"`. Attached by **slug**.

On read-back from `GetWorkspace`, both come back in `skills[]` distinguished by `type` (`"SKILL"` vs `"PLATFORM_SKILL"`); for a platform skill the `id` **is** its slug.

## What changed

The codebase already persists skills via a full-replace pattern (re-send the complete id array on save). This PR extends that same pattern with a parallel `platformSkills` (slug) array rather than introducing incremental attach/detach calls — lower risk and consistent with the existing flow. Because the full selection lives in form state, the complete `platformSkills` list is sent on every save (satisfying the reactor's full-replace contract).

- **Types** (`libs/shared/src/types.ts`) — widened `Skill.type` to `"SKILL" | "PLATFORM_SKILL"`, added optional `description`, and added `type` to `SkillConfig` so save paths can split the two kinds. Convention: a platform skill's `id` is its slug (matches `GetWorkspace` read-back).
- **Selector** (`libs/shared/src/components/skills/skill-selector.tsx`) — fetches platform skills via `GetSkills(filter="platform")` (one-shot; small fixed set) and renders them in a distinct **"Platform skills"** group with a **"Platform"** badge, above the existing **"Your skills"** registry grid. Search filters both groups; attached-state, toggle, and empty-state logic account for both.
- **Card** (`libs/shared/src/components/mcp/mcp-card.tsx`) — added an optional `badge` prop rendered next to the type label (selection checkbox slot untouched, so platform cards stay selectable).
- **Save wiring** — every skill-save path now splits `skills` (registry ids) from `platformSkills` (slugs) and sends both:
  - `packages/client/src/components/agent-workspace/agent-editor.tsx` (`EditWorkspace`)
  - `packages/client/src/pages/agent/create-agent-page.tsx` (`AddWorkspace`)
  - `packages/playground/src/stores/chat/chat.store.ts` (`addWorkspace` + `editWorkspace`)
- **Read-back** — `GetWorkspace` `type` now flows through `SkillConfig` unchanged, so attached state renders correctly on load. Added the "Platform" badge to the read-only `workspace-skill-list.tsx` for visual consistency.
- **i18n** — new strings in the `mcp` (shared) and `workspace` (playground) English locales.

## Files changed

```
libs/shared/src/types.ts
libs/shared/src/components/skills/skill-selector.tsx
libs/shared/src/components/mcp/mcp-card.tsx
packages/client/src/components/agent-workspace/agent-editor.tsx
packages/client/src/pages/agent/create-agent-page.tsx
packages/playground/src/stores/chat/chat.store.ts
packages/playground/src/components/workspace/workspace-skill-list.tsx
libs/i18n/src/resources/locales/en/shared/mcp.json
libs/i18n/src/resources/locales/en/playground/workspace.json
```