### PR TITLE
fix: adjusted priority user-picked > theme for default model

### DIFF
--- a/packages/playground/src/stores/chat/chat.store.ts
+++ b/packages/playground/src/stores/chat/chat.store.ts
@@ -552,10 +552,10 @@ export class ChatStore {
 			const profileDefaultModelId = this._store.profileDefaultModelId;
 			let isSelected = false;
 
-			// 1. theme/admin-enforced default
-			if (defaultModelId) {
+			// 1. user's profile default — explicitly set by the user, highest personal priority
+			if (profileDefaultModelId) {
 				for (const m of output) {
-					if (m.engine_id === defaultModelId) {
+					if (m.engine_id === profileDefaultModelId) {
 						this.setSelectedModel(m);
 						isSelected = true;
 						break;
@@ -592,10 +592,10 @@ export class ChatStore {
 				} catch {}
 			}
 
-			// 3. user's profile default — used on fresh login when no session model exists
-			if (!isSelected && profileDefaultModelId) {
+			// 3. theme/admin-suggested default — used as a fallback when the user has no preference
+			if (!isSelected && defaultModelId) {
 				for (const m of output) {
-					if (m.engine_id === profileDefaultModelId) {
+					if (m.engine_id === defaultModelId) {
 						this.setSelectedModel(m);
 						isSelected = true;
 						break;


### PR DESCRIPTION
## Description
User default model choice overrides Theme

## Changes Made
When a user sets their default model on the token-usage-page, saves it server-side, then logs out and back in — getUser() fetches their fresh profile meta, and the profile default is now selected before the theme default is ever checked.

## How to Test
1. Change default model on the Models page
2. Log out and log back in
3. Make sure new default model persisted in Settings -> My Profile