### PR TITLE
Allow tags to be tagged

### DIFF
--- a/packages/client/src/components/project/edit-project-detail-dialog.tsx
+++ b/packages/client/src/components/project/edit-project-detail-dialog.tsx
@@ -202,10 +202,21 @@ export const EditProjectDetailDialog = ({
 		try {
 			setIsLoading(true);
 
+			// only send the fields the backend actually allows as metadata,
+			// not the full form state (which mixes in project_id, permissions, etc.)
+			const meta: Record<string, unknown> = {
+				description: form.description,
+				markdown: form.markdown,
+				tag: form.tag,
+			};
+			for (const { metakey } of projectMetaKeys) {
+				meta[metakey] = form[metakey];
+			}
+
 			// update the metadata for the project
 			await configStore.runPixel(
 				`SetProjectMetadata(project=["${project.project_id}"], meta=[${JSON.stringify(
-					form,
+					meta,
 				)}])`,
 			);
 

--- a/packages/client/src/components/project/project-detail-tabs.tsx
+++ b/packages/client/src/components/project/project-detail-tabs.tsx
@@ -83,23 +83,24 @@ export const ProjectDetailTabs = ({
 		dependencies: string[];
 	}>(appId ? `GetProjectDependencies(project=["${appId}"]);` : "");
 
+	// the core metadata keys plus any dynamic ones from the project config
+	const metaKeys = useMemo(() => {
+		const dynamicKeys = configStore.store.config.projectMetaKeys
+			.map((k) => k.metakey)
+			.filter(
+				(key) =>
+					key !== "description" &&
+					key !== "markdown" &&
+					key !== "tag" &&
+					key !== "tags",
+			);
+		return ["description", "markdown", "tag", ...dynamicKeys];
+	}, [configStore.store.config.projectMetaKeys]);
+
 	// get the metadata for the project
 	const getMetadata = usePixel<Project>(
 		appId
-			? `GetProjectMetadata(project=["${appId}"], metaKeys=${JSON.stringify(
-					configStore.store.config.projectMetaKeys
-						.filter((k) => {
-							return (
-								k.metakey !== "description" &&
-								k.metakey !== "markdown" &&
-								k.metakey !== "tag" &&
-								k.metakey !== "tags"
-							);
-						})
-						.map((k) => {
-							return k.metakey;
-						}),
-				)});`
+			? `GetProjectMetadata(project=["${appId}"], metaKeys=${JSON.stringify(metaKeys)});`
 			: "",
 	);
 

--- a/packages/client/src/pages/project/project-detail-layout.tsx
+++ b/packages/client/src/pages/project/project-detail-layout.tsx
@@ -101,23 +101,24 @@ export const ProjectDetailLayout = ({
 		dependencies: string[];
 	}>(appId ? `GetProjectDependencies(project=["${appId}"]);` : "");
 
+	// the core metadata keys plus any dynamic ones from the project config
+	const metaKeys = useMemo(() => {
+		const dynamicKeys = configStore.store.config.projectMetaKeys
+			.map((k) => k.metakey)
+			.filter(
+				(key) =>
+					key !== "description" &&
+					key !== "markdown" &&
+					key !== "tag" &&
+					key !== "tags",
+			);
+		return ["description", "markdown", "tag", ...dynamicKeys];
+	}, [configStore.store.config.projectMetaKeys]);
+
 	// get the metadata for the project
 	const getMetadata = usePixel<Project>(
 		appId
-			? `GetProjectMetadata(project=["${appId}"], metaKeys=${JSON.stringify(
-					configStore.store.config.projectMetaKeys
-						.filter((k) => {
-							return (
-								k.metakey !== "description" &&
-								k.metakey !== "markdown" &&
-								k.metakey !== "tag" &&
-								k.metakey !== "tags"
-							);
-						})
-						.map((k) => {
-							return k.metakey;
-						}),
-				)});`
+			? `GetProjectMetadata(project=["${appId}"], metaKeys=${JSON.stringify(metaKeys)});`
 			: "",
 	);
 


### PR DESCRIPTION
## Description
`SetProjectMetadata` sent the entire form state, so the backend's new allow-list rejected it with "Unallowed metakeys." `GetProjectMetadata` excluded `description`, `markdown`, and `tag` from its request, so tags never came back.

## Changes Made
- `edit-project-detail-dialog.tsx`: build an explicit `meta` payload instead of sending raw form state.
- `project-detail-tabs.tsx` / `project-detail-layout.tsx`: include core fields in the `metaKeys` request instead of excluding them.

## How to Test
1. Edit and save project details - no "Unallowed metakeys" error.
2. Open a project with tags set - tags now display.

## Notes
Both bugs came from the "3374 update the skill catalog" refactor (#3441, d668c29f7). The prior code scoped the `Set` payload and requested all metakeys on `Get`; neither issue existed before that rewrite.