### PR TITLE
Agent Activity Page

### DIFF
--- a/packages/client/src/components/agent-workspace/agent-workspace.tsx
+++ b/packages/client/src/components/agent-workspace/agent-workspace.tsx
@@ -150,6 +150,11 @@ export const AgentWorkspace: React.FC = observer(() => {
 							restrict: ["OWNER"],
 						},
 						{
+							name: "Agent Activity",
+							component: "agent-activity",
+							restrict: ["OWNER", "EDIT", "READ_ONLY"],
+						},
+						{
 							name: "Access Control",
 							component: "access-control",
 							restrict: ["OWNER", "EDIT"],

--- a/packages/client/src/components/project/project-detail-tabs.tsx
+++ b/packages/client/src/components/project/project-detail-tabs.tsx
@@ -10,6 +10,7 @@ import { AppGithubPage } from "@/pages/app/app-github-page";
 import { AppMcpUsagePage } from "@/pages/app/app-mcp-usage-page";
 import { AppSettingsPage } from "@/pages/app/app-settings-page";
 import { AppSmssPage } from "@/pages/app/app-smss-page";
+import { AgentActivityPage } from "@/pages/project/agent/agent-activity-page";
 import { ProjectDependenciesPage } from "@/pages/project/project-dependencies-page";
 
 interface ProjectDetailTabsProps {
@@ -21,6 +22,7 @@ interface ProjectDetailTabsProps {
 			| "project-dependencies"
 			| "mcp-usage"
 			| "activity"
+			| "agent-activity"
 			| "commits"
 			| "github"
 			| "settings"
@@ -95,6 +97,9 @@ export const ProjectDetailTabs = ({ tabs }: ProjectDetailTabsProps) => {
 				)}
 				{activeTab?.component === "mcp-usage" && <AppMcpUsagePage />}
 				{activeTab?.component === "activity" && <AppActivityPage />}
+				{activeTab?.component === "agent-activity" && (
+					<AgentActivityPage />
+				)}
 				{activeTab?.component === "commits" && <AppCommitsPage />}
 				{activeTab?.component === "github" && <AppGithubPage />}
 				{activeTab?.component === "settings" && <AppSettingsPage />}

--- a/packages/client/src/pages/project/agent/agent-activity-page.tsx
+++ b/packages/client/src/pages/project/agent/agent-activity-page.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, ChevronRight, Clock, MessageSquare } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Badge, Button, Skeleton, toast } from "@semoss/ui/next";
 import { useProject, useRootStore } from "@/hooks";
 import { formatDateToRelative } from "@/utility/date";
@@ -7,6 +7,7 @@ import type {
 	AgentActivityLogResponse,
 	AgentActivityRun,
 	AgentRunDetail,
+	EngineInfo,
 	RoomRunDetail,
 	RoomSummary,
 	SubagentRun,
@@ -14,18 +15,49 @@ import type {
 } from "./agent-activity-types";
 import { toMs } from "./agent-activity-types";
 import { AgentRunGraph } from "./agent-run-graph";
+import type { ClaudeCodeTranscriptEvent } from "./claude-code-transcript";
+import { mergeClaudeCodeTranscript } from "./claude-code-transcript";
 
 const MAX_SUBAGENT_DEPTH = 5;
+
+/** Subset of the GetEngineMetadata output this page reads. */
+interface EngineMetadataOutput {
+	engine_display_name?: string;
+	engine_name?: string;
+}
+
+/** Every distinct model engine id used by the runs, incl. nested subagents. */
+const collectModelIds = (runs: RoomRunDetail[]): Set<string> => {
+	const ids = new Set<string>();
+	const visitSubagent = (node: SubagentRunNode) => {
+		if (node.modelId) {
+			ids.add(node.modelId);
+		}
+		node.children.forEach(visitSubagent);
+	};
+	for (const run of runs) {
+		if (run.modelId) {
+			ids.add(run.modelId);
+		}
+		run.subagents.forEach(visitSubagent);
+	}
+	return ids;
+};
 
 const summarizeRoom = (
 	roomId: string,
 	runs: AgentActivityRun[],
 ): RoomSummary => {
+	let roomName: string | null = null;
 	let mostRecentCompletedAt: string | null = null;
 	let mostRecentCompletedMs = -Infinity;
 	let sortMs = -Infinity;
 
 	for (const run of runs) {
+		if (!roomName && run.roomName) {
+			roomName = run.roomName;
+		}
+
 		const completedMs = toMs(run.completedAt);
 		if (completedMs > mostRecentCompletedMs) {
 			mostRecentCompletedMs = completedMs;
@@ -40,7 +72,13 @@ const summarizeRoom = (
 		);
 	}
 
-	return { roomId, runCount: runs.length, mostRecentCompletedAt, sortMs };
+	return {
+		roomId,
+		roomName,
+		runCount: runs.length,
+		mostRecentCompletedAt,
+		sortMs,
+	};
 };
 
 /**
@@ -56,11 +94,19 @@ export const AgentActivityPage = () => {
 	const [activity, setActivity] = useState<AgentActivityLogResponse>({});
 	const [loading, setLoading] = useState(true);
 
-	const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
+	const [selectedRoom, setSelectedRoom] = useState<RoomSummary | null>(null);
 	const [selectedRoomRuns, setSelectedRoomRuns] = useState<RoomRunDetail[]>(
 		[],
 	);
 	const [loadingRunDetails, setLoadingRunDetails] = useState(false);
+
+	const [engineInfo, setEngineInfo] = useState<Record<string, EngineInfo>>(
+		{},
+	);
+	// Engine metadata is stable - cache lookups across room clicks.
+	const engineInfoCache = useRef(
+		new Map<string, Promise<EngineInfo | null>>(),
+	);
 
 	useEffect(() => {
 		const agentId = project.project_id;
@@ -123,6 +169,105 @@ export const AgentActivityPage = () => {
 	};
 
 	/**
+	 * Resolve a model engine id to its display name via GetEngineMetadata so
+	 * the graph can show "CallCenterModel" instead of the engine UUID stored
+	 * on AGENT_RUN.
+	 */
+	const fetchEngineInfo = (engineId: string): Promise<EngineInfo | null> => {
+		let pending = engineInfoCache.current.get(engineId);
+		if (!pending) {
+			pending = monolithStore
+				.runQuery<[EngineMetadataOutput]>(
+					`GetEngineMetadata(engine=["${engineId}"], metaKeys=${JSON.stringify(
+						[["engine_display_name", "engine_name"]],
+					)});`,
+				)
+				.then((response) => {
+					const { operationType, output } = response.pixelReturn[0];
+					if (operationType.indexOf("ERROR") > -1) {
+						throw new Error(String(output));
+					}
+					const name =
+						output?.engine_display_name || output?.engine_name;
+					return name ? { name } : null;
+				})
+				.catch((error) => {
+					console.error("Error fetching engine metadata:", error);
+					return null;
+				});
+			engineInfoCache.current.set(engineId, pending);
+		}
+		return pending;
+	};
+
+	const resolveEngineInfo = async (modelIds: Set<string>) => {
+		const entries = await Promise.all(
+			Array.from(modelIds).map(
+				async (id) => [id, await fetchEngineInfo(id)] as const,
+			),
+		);
+		const resolved: Record<string, EngineInfo> = {};
+		for (const [id, info] of entries) {
+			if (info) {
+				resolved[id] = info;
+			}
+		}
+		if (Object.keys(resolved).length > 0) {
+			setEngineInfo((prev) => ({ ...prev, ...resolved }));
+		}
+	};
+
+	/**
+	 * claude_code-harness runs don't persist tool activity as room messages -
+	 * it lives in the room's Claude Code JSONL transcript. Fetch it once per
+	 * room (the cache holds the in-flight promise) and splice the parsed tool
+	 * calls/results into the run so the graph treats both harnesses the same.
+	 */
+	const enrichWithClaudeCodeTranscript = async (
+		run: AgentRunDetail,
+		transcriptCache: Map<string, Promise<ClaudeCodeTranscriptEvent[]>>,
+		multiRunRoomId: string | null,
+	): Promise<AgentRunDetail> => {
+		if (run.harnessType !== "claude_code" || !run.roomId) {
+			return run;
+		}
+		try {
+			let pending = transcriptCache.get(run.roomId);
+			if (!pending) {
+				pending = monolithStore
+					.runQuery<[ClaudeCodeTranscriptEvent[]]>(
+						`GetClaudeCodeTranscriptHistory ( roomId = "${run.roomId}" ) ;`,
+					)
+					.then((response) => {
+						const { operationType, output } =
+							response.pixelReturn[0];
+						if (operationType.indexOf("ERROR") > -1) {
+							throw new Error(String(output));
+						}
+						return output ?? [];
+					});
+				transcriptCache.set(run.roomId, pending);
+			}
+			const events = await pending;
+			if (events.length === 0) {
+				return run;
+			}
+			// The JSONL covers the whole room; narrow to this run's time
+			// window only when other runs share the room.
+			return mergeClaudeCodeTranscript(
+				run,
+				events,
+				run.roomId === multiRunRoomId,
+			);
+		} catch (error) {
+			// Transcript may be missing on disk - the run still renders from
+			// its room messages.
+			console.error("Error fetching Claude Code transcript:", error);
+			return run;
+		}
+	};
+
+	/**
 	 * Recursively load the subagent run tree under a run via GetSubagentRuns,
 	 * pulling each subagent's full transcript via GetAgentRun so the graph can
 	 * show its room, tool calls, and nested subagents just like the parent.
@@ -132,6 +277,8 @@ export const AgentActivityPage = () => {
 	const fetchSubagentRunTree = async (
 		runId: string,
 		visited: Set<string>,
+		transcriptCache: Map<string, Promise<ClaudeCodeTranscriptEvent[]>>,
+		multiRunRoomId: string | null,
 		depth = 0,
 	): Promise<SubagentRunNode[]> => {
 		if (depth >= MAX_SUBAGENT_DEPTH) {
@@ -156,9 +303,19 @@ export const AgentActivityPage = () => {
 					// A dead transcript shouldn't sink the whole room view -
 					// fall back to the summary row with no messages.
 					fetchRunDetail(run.runId).catch(() => null),
-					fetchSubagentRunTree(run.runId, visited, depth + 1),
+					fetchSubagentRunTree(
+						run.runId,
+						visited,
+						transcriptCache,
+						multiRunRoomId,
+						depth + 1,
+					),
 				]);
-				const base = detail ?? { ...run, messages: [] };
+				const base = await enrichWithClaudeCodeTranscript(
+					detail ?? { ...run, messages: [] },
+					transcriptCache,
+					multiRunRoomId,
+				);
 				return { ...base, children };
 			}),
 		);
@@ -173,22 +330,43 @@ export const AgentActivityPage = () => {
 			(run) => !run.parentRunId || !roomRunIds.has(run.parentRunId),
 		);
 
-		setSelectedRoomId(room.roomId);
+		setSelectedRoom(room);
 		setSelectedRoomRuns([]);
 		setLoadingRunDetails(true);
 
 		try {
 			const visited = new Set(runs.map((run) => run.runId));
+			const transcriptCache = new Map<
+				string,
+				Promise<ClaudeCodeTranscriptEvent[]>
+			>();
+			// Sub-agent rooms host a single run, but this room's JSONL spans
+			// every run listed here - those need time-window filtering.
+			const multiRunRoomId = allRuns.length > 1 ? room.roomId : null;
 			const runDetails = await Promise.all(
 				runs.map(async (run) => {
 					const [detail, subagents] = await Promise.all([
-						fetchRunDetail(run.runId),
-						fetchSubagentRunTree(run.runId, visited),
+						fetchRunDetail(run.runId).then((fetched) =>
+							enrichWithClaudeCodeTranscript(
+								fetched,
+								transcriptCache,
+								multiRunRoomId,
+							),
+						),
+						fetchSubagentRunTree(
+							run.runId,
+							visited,
+							transcriptCache,
+							multiRunRoomId,
+						),
 					]);
 					return { ...detail, subagents };
 				}),
 			);
 			setSelectedRoomRuns(runDetails);
+			// Resolve model display names in the background - the graph
+			// falls back to raw engine ids until these land.
+			void resolveEngineInfo(collectModelIds(runDetails));
 		} catch (error) {
 			console.error("Error fetching agent run:", error);
 			toast.error(`Error fetching agent run: ${error}`);
@@ -198,7 +376,7 @@ export const AgentActivityPage = () => {
 	};
 
 	const handleBackToList = () => {
-		setSelectedRoomId(null);
+		setSelectedRoom(null);
 		setSelectedRoomRuns([]);
 	};
 
@@ -224,7 +402,7 @@ export const AgentActivityPage = () => {
 		);
 	}
 
-	if (selectedRoomId) {
+	if (selectedRoom) {
 		return (
 			<div className="flex flex-col gap-4">
 				<div className="flex items-center gap-2">
@@ -237,8 +415,15 @@ export const AgentActivityPage = () => {
 						<ArrowLeft className="size-4" />
 					</Button>
 					<div>
-						<h6 className="font-mono font-semibold text-sm">
-							{selectedRoomId}
+						<h6
+							className={
+								selectedRoom.roomName
+									? "font-semibold text-sm"
+									: "font-mono font-semibold text-sm"
+							}
+							title={selectedRoom.roomId}
+						>
+							{selectedRoom.roomName ?? selectedRoom.roomId}
 						</h6>
 						<p className="text-muted-foreground text-xs">
 							Execution graph of agent runs, sub-agents, and tool
@@ -251,9 +436,11 @@ export const AgentActivityPage = () => {
 					<Skeleton className="h-[600px] w-full rounded-xl" />
 				) : selectedRoomRuns.length > 0 ? (
 					<AgentRunGraph
-						key={selectedRoomId}
-						roomId={selectedRoomId}
+						key={selectedRoom.roomId}
+						roomId={selectedRoom.roomId}
+						roomName={selectedRoom.roomName ?? undefined}
 						runs={selectedRoomRuns}
+						engineInfo={engineInfo}
 					/>
 				) : (
 					<p className="text-muted-foreground text-sm">
@@ -285,10 +472,14 @@ export const AgentActivityPage = () => {
 							<MessageSquare className="size-4" />
 						</span>
 						<span
-							className="min-w-0 flex-1 truncate font-mono text-muted-foreground text-xs"
+							className={
+								room.roomName
+									? "min-w-0 flex-1 truncate font-medium text-sm"
+									: "min-w-0 flex-1 truncate font-mono text-muted-foreground text-xs"
+							}
 							title={room.roomId}
 						>
-							{room.roomId}
+							{room.roomName ?? room.roomId}
 						</span>
 						<Badge variant="secondary" className="shrink-0">
 							{room.runCount}{" "}

--- a/packages/client/src/pages/project/agent/agent-activity-page.tsx
+++ b/packages/client/src/pages/project/agent/agent-activity-page.tsx
@@ -123,7 +123,9 @@ export const AgentActivityPage = () => {
 	};
 
 	/**
-	 * Recursively load the subagent run tree under a run via GetSubagentRuns.
+	 * Recursively load the subagent run tree under a run via GetSubagentRuns,
+	 * pulling each subagent's full transcript via GetAgentRun so the graph can
+	 * show its room, tool calls, and nested subagents just like the parent.
 	 * `visited` guards against cycles/duplicates across the whole room fetch;
 	 * depth is capped as a safety net.
 	 */
@@ -149,14 +151,16 @@ export const AgentActivityPage = () => {
 			visited.add(run.runId);
 		}
 		return Promise.all(
-			subagentRuns.map(async (run) => ({
-				...run,
-				children: await fetchSubagentRunTree(
-					run.runId,
-					visited,
-					depth + 1,
-				),
-			})),
+			subagentRuns.map(async (run) => {
+				const [detail, children] = await Promise.all([
+					// A dead transcript shouldn't sink the whole room view -
+					// fall back to the summary row with no messages.
+					fetchRunDetail(run.runId).catch(() => null),
+					fetchSubagentRunTree(run.runId, visited, depth + 1),
+				]);
+				const base = detail ?? { ...run, messages: [] };
+				return { ...base, children };
+			}),
 		);
 	};
 

--- a/packages/client/src/pages/project/agent/agent-activity-page.tsx
+++ b/packages/client/src/pages/project/agent/agent-activity-page.tsx
@@ -1,0 +1,307 @@
+import { ArrowLeft, ChevronRight, Clock, MessageSquare } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Badge, Button, Skeleton, toast } from "@semoss/ui/next";
+import { useProject, useRootStore } from "@/hooks";
+import { formatDateToRelative } from "@/utility/date";
+import type {
+	AgentActivityLogResponse,
+	AgentActivityRun,
+	AgentRunDetail,
+	RoomRunDetail,
+	RoomSummary,
+	SubagentRun,
+	SubagentRunNode,
+} from "./agent-activity-types";
+import { toMs } from "./agent-activity-types";
+import { AgentRunGraph } from "./agent-run-graph";
+
+const MAX_SUBAGENT_DEPTH = 5;
+
+const summarizeRoom = (
+	roomId: string,
+	runs: AgentActivityRun[],
+): RoomSummary => {
+	let mostRecentCompletedAt: string | null = null;
+	let mostRecentCompletedMs = -Infinity;
+	let sortMs = -Infinity;
+
+	for (const run of runs) {
+		const completedMs = toMs(run.completedAt);
+		if (completedMs > mostRecentCompletedMs) {
+			mostRecentCompletedMs = completedMs;
+			mostRecentCompletedAt = run.completedAt ?? null;
+		}
+
+		sortMs = Math.max(
+			sortMs,
+			completedMs,
+			toMs(run.startedAt),
+			toMs(run.dateCreated),
+		);
+	}
+
+	return { roomId, runCount: runs.length, mostRecentCompletedAt, sortMs };
+};
+
+/**
+ * The "Agent Activity" tab of the agent workspace settings panel - lists the
+ * rooms (conversations) this agent has run in, most recently active first.
+ * Clicking a room loads its runs (transcripts via GetAgentRun, sub-agent
+ * hierarchy via GetSubagentRuns) and renders them as a node graph.
+ */
+export const AgentActivityPage = () => {
+	const { project } = useProject();
+	const { monolithStore } = useRootStore();
+
+	const [activity, setActivity] = useState<AgentActivityLogResponse>({});
+	const [loading, setLoading] = useState(true);
+
+	const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
+	const [selectedRoomRuns, setSelectedRoomRuns] = useState<RoomRunDetail[]>(
+		[],
+	);
+	const [loadingRunDetails, setLoadingRunDetails] = useState(false);
+
+	useEffect(() => {
+		const agentId = project.project_id;
+		if (!agentId) {
+			return;
+		}
+
+		let cancelled = false;
+
+		const fetchActivity = async () => {
+			setLoading(true);
+			try {
+				const response = await monolithStore.runQuery<
+					[AgentActivityLogResponse]
+				>(
+					`GetAgentActivityLog(agentId=["${agentId}"], limit=[20], sortByRoom=[true]);`,
+				);
+				const { operationType, output } = response.pixelReturn[0];
+				if (operationType.indexOf("ERROR") > -1) {
+					throw new Error(String(output));
+				}
+				if (!cancelled) {
+					setActivity(output ?? {});
+				}
+			} catch (error) {
+				if (!cancelled) {
+					setActivity({});
+					toast.error(`Error fetching agent activity: ${error}`);
+				}
+				console.error("Error fetching agent activity:", error);
+			} finally {
+				if (!cancelled) {
+					setLoading(false);
+				}
+			}
+		};
+
+		fetchActivity();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [project.project_id, monolithStore]);
+
+	const rooms = useMemo(() => {
+		return Object.entries(activity)
+			.map(([roomId, runs]) => summarizeRoom(roomId, runs))
+			.sort((a, b) => b.sortMs - a.sortMs);
+	}, [activity]);
+
+	const fetchRunDetail = async (runId: string): Promise<AgentRunDetail> => {
+		const response = await monolithStore.runQuery<[AgentRunDetail]>(
+			`GetAgentRun ( runId = "${runId}" , includeMessages = "true" ) ;`,
+		);
+		const { operationType, output } = response.pixelReturn[0];
+		if (operationType.indexOf("ERROR") > -1) {
+			throw new Error(String(output));
+		}
+		return output;
+	};
+
+	/**
+	 * Recursively load the subagent run tree under a run via GetSubagentRuns.
+	 * `visited` guards against cycles/duplicates across the whole room fetch;
+	 * depth is capped as a safety net.
+	 */
+	const fetchSubagentRunTree = async (
+		runId: string,
+		visited: Set<string>,
+		depth = 0,
+	): Promise<SubagentRunNode[]> => {
+		if (depth >= MAX_SUBAGENT_DEPTH) {
+			return [];
+		}
+		const response = await monolithStore.runQuery<[SubagentRun[]]>(
+			`GetSubagentRuns ( runId = "${runId}" ) ;`,
+		);
+		const { operationType, output } = response.pixelReturn[0];
+		if (operationType.indexOf("ERROR") > -1) {
+			throw new Error(String(output));
+		}
+		const subagentRuns = (output ?? []).filter(
+			(run) => !visited.has(run.runId),
+		);
+		for (const run of subagentRuns) {
+			visited.add(run.runId);
+		}
+		return Promise.all(
+			subagentRuns.map(async (run) => ({
+				...run,
+				children: await fetchSubagentRunTree(
+					run.runId,
+					visited,
+					depth + 1,
+				),
+			})),
+		);
+	};
+
+	const handleRoomClick = async (room: RoomSummary) => {
+		const allRuns = activity[room.roomId] ?? [];
+		// Runs with a parent in this room render nested under it via
+		// GetSubagentRuns, so only root the ones whose parent is elsewhere.
+		const roomRunIds = new Set(allRuns.map((run) => run.runId));
+		const runs = allRuns.filter(
+			(run) => !run.parentRunId || !roomRunIds.has(run.parentRunId),
+		);
+
+		setSelectedRoomId(room.roomId);
+		setSelectedRoomRuns([]);
+		setLoadingRunDetails(true);
+
+		try {
+			const visited = new Set(runs.map((run) => run.runId));
+			const runDetails = await Promise.all(
+				runs.map(async (run) => {
+					const [detail, subagents] = await Promise.all([
+						fetchRunDetail(run.runId),
+						fetchSubagentRunTree(run.runId, visited),
+					]);
+					return { ...detail, subagents };
+				}),
+			);
+			setSelectedRoomRuns(runDetails);
+		} catch (error) {
+			console.error("Error fetching agent run:", error);
+			toast.error(`Error fetching agent run: ${error}`);
+		} finally {
+			setLoadingRunDetails(false);
+		}
+	};
+
+	const handleBackToList = () => {
+		setSelectedRoomId(null);
+		setSelectedRoomRuns([]);
+	};
+
+	if (loading) {
+		return (
+			<div className="flex flex-col gap-2">
+				{["a", "b", "c", "d", "e", "f"].map((key) => (
+					<Skeleton
+						key={`activity-skeleton-${key}`}
+						className="h-14 w-full rounded-xl"
+					/>
+				))}
+			</div>
+		);
+	}
+
+	if (rooms.length === 0) {
+		return (
+			<div className="flex h-full min-h-[200px] flex-col items-center justify-center gap-2 text-center text-muted-foreground">
+				<MessageSquare className="size-8 opacity-50" />
+				<p className="text-sm">No activity yet for this agent.</p>
+			</div>
+		);
+	}
+
+	if (selectedRoomId) {
+		return (
+			<div className="flex flex-col gap-4">
+				<div className="flex items-center gap-2">
+					<Button
+						variant="outline"
+						size="icon-sm"
+						title="Back to list"
+						onClick={handleBackToList}
+					>
+						<ArrowLeft className="size-4" />
+					</Button>
+					<div>
+						<h6 className="font-mono font-semibold text-sm">
+							{selectedRoomId}
+						</h6>
+						<p className="text-muted-foreground text-xs">
+							Execution graph of agent runs, sub-agents, and tool
+							calls in this room.
+						</p>
+					</div>
+				</div>
+
+				{loadingRunDetails ? (
+					<Skeleton className="h-[600px] w-full rounded-xl" />
+				) : selectedRoomRuns.length > 0 ? (
+					<AgentRunGraph
+						key={selectedRoomId}
+						roomId={selectedRoomId}
+						runs={selectedRoomRuns}
+					/>
+				) : (
+					<p className="text-muted-foreground text-sm">
+						No run data available.
+					</p>
+				)}
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-4">
+			<div>
+				<h6 className="font-semibold text-xl">Agent Activity</h6>
+				<p className="text-muted-foreground text-sm">
+					Rooms this agent has run in, most recently active first.
+				</p>
+			</div>
+
+			<div className="flex flex-col gap-2">
+				{rooms.map((room) => (
+					<button
+						key={room.roomId}
+						type="button"
+						onClick={() => handleRoomClick(room)}
+						className="group flex items-center gap-3 rounded-xl border bg-card px-4 py-3 text-left shadow-sm transition-all hover:border-primary/40 hover:shadow-md"
+					>
+						<span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+							<MessageSquare className="size-4" />
+						</span>
+						<span
+							className="min-w-0 flex-1 truncate font-mono text-muted-foreground text-xs"
+							title={room.roomId}
+						>
+							{room.roomId}
+						</span>
+						<Badge variant="secondary" className="shrink-0">
+							{room.runCount}{" "}
+							{room.runCount === 1 ? "run" : "runs"}
+						</Badge>
+						<div className="flex shrink-0 items-center gap-1.5 text-muted-foreground text-xs">
+							<Clock className="size-3.5 shrink-0" />
+							{room.mostRecentCompletedAt
+								? formatDateToRelative(
+										room.mostRecentCompletedAt,
+									)
+								: "N/A"}
+						</div>
+						<ChevronRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+					</button>
+				))}
+			</div>
+		</div>
+	);
+};

--- a/packages/client/src/pages/project/agent/agent-activity-types.ts
+++ b/packages/client/src/pages/project/agent/agent-activity-types.ts
@@ -1,0 +1,171 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import type { ReactNode } from "react";
+
+dayjs.extend(utc);
+
+export interface TreeNodeSpec {
+	id: string;
+	label: ReactNode;
+	leadingIcon?: ReactNode;
+	children?: TreeNodeSpec[];
+}
+
+export interface AgentActivityRun {
+	roomId: string;
+	runId: string;
+	parentRunId?: string;
+	jobId: string;
+	workspaceId: string;
+	userId: string;
+	modelId: string;
+	harnessType: string;
+	status: string;
+	input: string;
+	finalText?: string;
+	dateCreated: string;
+	startedAt: string;
+	completedAt?: string;
+	inputMessageId?: string;
+	finalOutputMessageId?: string;
+	artifacts: unknown[];
+}
+
+export type AgentActivityLogResponse = Record<string, AgentActivityRun[]>;
+
+export interface RoomSummary {
+	roomId: string;
+	runCount: number;
+	mostRecentCompletedAt: string | null;
+	sortMs: number;
+}
+
+export interface TranscriptToolCall {
+	name: string;
+	arguments: Record<string, unknown>;
+	id: string;
+	type: string;
+}
+
+export interface TranscriptToolResult {
+	output: string;
+	serverTool: boolean;
+	toolStatus: "success" | "error";
+	toolCallId: string;
+	toolParameterValues: Record<string, unknown>;
+	toolName: string;
+}
+
+export interface TranscriptPart {
+	type: "SYSTEM" | "TEXT" | "THINKING" | "TOOL_CALL" | "TOOL_RESULT";
+	prompt?: string;
+	uiText?: string;
+	text?: string;
+	thinking?: string;
+	toolCall?: TranscriptToolCall;
+	toolResult?: TranscriptToolResult;
+}
+
+export interface TranscriptMessage {
+	messageId: string;
+	visible: boolean;
+	io: "INPUT" | "OUTPUT";
+	type: "INPUT_TEXT" | "RESPONSE_TOOL" | "INPUT_TOOL_EXEC" | "RESPONSE_TEXT";
+	dateCreated: string;
+	ornaments: {
+		modelName: string;
+		agentRunRole:
+			| "input"
+			| "assistant_tool"
+			| "tool_result"
+			| "final_output";
+		agentRunId: string;
+	};
+	parts: TranscriptPart[];
+}
+
+export interface SubagentRun {
+	runId: string;
+	parentRunId?: string;
+	roomId: string;
+	workspaceId: string;
+	modelId: string;
+	harnessType: string;
+	jobId: string;
+	status: string;
+	input: string;
+	finalText?: string;
+	errorMessage?: string;
+	dateCreated: string;
+	startedAt?: string;
+	completedAt?: string;
+	userId: string;
+}
+
+export interface SubagentRunNode extends SubagentRun {
+	children: SubagentRunNode[];
+}
+
+export interface AgentRunDetail {
+	jobId: string;
+	runId: string;
+	parentRunId?: string;
+	roomId: string;
+	userId: string;
+	workspaceId: string;
+	harnessType: string;
+	modelId: string;
+	status: string;
+	input: string;
+	finalText?: string;
+	finalOutputMessageId?: string;
+	inputMessageId?: string;
+	startedAt: string;
+	completedAt?: string;
+	dateCreated: string;
+	messages: TranscriptMessage[];
+	artifacts: unknown[];
+}
+
+export interface RoomRunDetail extends AgentRunDetail {
+	subagents: SubagentRunNode[];
+}
+
+export const toMs = (dateStr: string | undefined): number =>
+	dateStr && dayjs.utc(dateStr).isValid()
+		? dayjs.utc(dateStr).valueOf()
+		: -Infinity;
+
+export const formatRunDuration = (
+	startedAt?: string,
+	completedAt?: string,
+): string | null => {
+	const startMs = toMs(startedAt);
+	const endMs = toMs(completedAt);
+	if (
+		!Number.isFinite(startMs) ||
+		!Number.isFinite(endMs) ||
+		endMs < startMs
+	) {
+		return null;
+	}
+	const ms = endMs - startMs;
+	return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(2)}s`;
+};
+
+export const isFailureStatus = (status: string): boolean =>
+	/fail|error|cancel/i.test(status);
+
+export const isActiveStatus = (status: string): boolean =>
+	/running|submitted|input/i.test(status);
+
+export const tryParseJson = (value: string): unknown => {
+	try {
+		return JSON.parse(value);
+	} catch {
+		return undefined;
+	}
+};
+
+export const toPrettyJson = (value: unknown): string =>
+	JSON.stringify(value, null, 2);

--- a/packages/client/src/pages/project/agent/agent-activity-types.ts
+++ b/packages/client/src/pages/project/agent/agent-activity-types.ts
@@ -13,6 +13,7 @@ export interface TreeNodeSpec {
 
 export interface AgentActivityRun {
 	roomId: string;
+	roomName?: string;
 	runId: string;
 	parentRunId?: string;
 	jobId: string;
@@ -35,6 +36,7 @@ export type AgentActivityLogResponse = Record<string, AgentActivityRun[]>;
 
 export interface RoomSummary {
 	roomId: string;
+	roomName: string | null;
 	runCount: number;
 	mostRecentCompletedAt: string | null;
 	sortMs: number;
@@ -100,6 +102,7 @@ export interface SubagentRun {
 	startedAt?: string;
 	completedAt?: string;
 	userId: string;
+	artifacts: unknown[];
 }
 
 export interface AgentRunDetail {
@@ -107,6 +110,7 @@ export interface AgentRunDetail {
 	runId: string;
 	parentRunId?: string;
 	roomId: string;
+	roomName?: string;
 	userId: string;
 	workspaceId: string;
 	harnessType: string;
@@ -134,6 +138,14 @@ export interface SubagentRunNode extends AgentRunDetail {
 
 export interface RoomRunDetail extends AgentRunDetail {
 	subagents: SubagentRunNode[];
+}
+
+/**
+ * Display info for a model engine, resolved via GetEngineMetadata. `name` is
+ * the engine's display name (e.g. "CallCenterModel").
+ */
+export interface EngineInfo {
+	name: string;
 }
 
 export const toMs = (dateStr: string | undefined): number =>

--- a/packages/client/src/pages/project/agent/agent-activity-types.ts
+++ b/packages/client/src/pages/project/agent/agent-activity-types.ts
@@ -102,10 +102,6 @@ export interface SubagentRun {
 	userId: string;
 }
 
-export interface SubagentRunNode extends SubagentRun {
-	children: SubagentRunNode[];
-}
-
 export interface AgentRunDetail {
 	jobId: string;
 	runId: string;
@@ -118,13 +114,22 @@ export interface AgentRunDetail {
 	status: string;
 	input: string;
 	finalText?: string;
+	errorMessage?: string;
 	finalOutputMessageId?: string;
 	inputMessageId?: string;
-	startedAt: string;
+	startedAt?: string;
 	completedAt?: string;
 	dateCreated: string;
 	messages: TranscriptMessage[];
 	artifacts: unknown[];
+}
+
+/**
+ * A subagent run with its full run detail (transcript included when the
+ * GetAgentRun fetch succeeded) plus its own recursively-loaded subagents.
+ */
+export interface SubagentRunNode extends AgentRunDetail {
+	children: SubagentRunNode[];
 }
 
 export interface RoomRunDetail extends AgentRunDetail {

--- a/packages/client/src/pages/project/agent/agent-run-graph.tsx
+++ b/packages/client/src/pages/project/agent/agent-run-graph.tsx
@@ -4,7 +4,6 @@ import {
 	type Edge,
 	Handle,
 	MarkerType,
-	MiniMap,
 	type Node,
 	type NodeProps,
 	Position,
@@ -72,6 +71,7 @@ type GraphSelection =
 	| { kind: "room"; roomId: string; runs: RoomRunDetail[] }
 	| { kind: "run"; run: RoomRunDetail }
 	| { kind: "subagent"; run: SubagentRunNode }
+	| { kind: "subroom"; roomId: string; run: SubagentRunNode }
 	| { kind: "tool"; toolName: string; invocations: ToolInvocation[] };
 
 interface LayoutTreeNode {
@@ -79,6 +79,8 @@ interface LayoutTreeNode {
 	data: ActivityNodeData;
 	selection: GraphSelection;
 	children: LayoutTreeNode[];
+	/** Status coloring the edge from this node's parent; undefined = tool gray. */
+	edgeStatus?: string;
 	x?: number;
 	y?: number;
 }
@@ -189,18 +191,69 @@ const collectToolInvocations = (
 	return invocationsByTool;
 };
 
-const buildSubagentTreeNode = (run: SubagentRunNode): LayoutTreeNode => ({
-	id: run.runId,
-	data: {
-		kind: "subagent",
-		label: run.input || run.runId,
-		sublabel: run.modelId,
-		status: run.status,
-		duration: formatRunDuration(run.startedAt, run.completedAt),
-	},
-	selection: { kind: "subagent", run },
-	children: run.children.map(buildSubagentTreeNode),
-});
+const buildToolTreeNodes = (run: AgentRunDetail): LayoutTreeNode[] =>
+	Array.from(collectToolInvocations(run).entries()).map(
+		([toolName, invocations]) => ({
+			id: `${run.runId}-tool-${toolName}`,
+			data: {
+				kind: "tool" as const,
+				label: toolName,
+				count: invocations.length,
+				status: invocations.some(
+					(inv) => inv.result?.toolStatus === "error",
+				)
+					? "FAILED"
+					: undefined,
+			},
+			selection: { kind: "tool" as const, toolName, invocations },
+			children: [],
+		}),
+	);
+
+/**
+ * A subagent run mirrors the parent structure: the run card points at its own
+ * room, which fans out into the tools it called and any nested subagents.
+ */
+const buildSubagentTreeNode = (run: SubagentRunNode): LayoutTreeNode => {
+	const contents: LayoutTreeNode[] = [
+		...buildToolTreeNodes(run),
+		...run.children.map(buildSubagentTreeNode),
+	];
+
+	const roomChildren: LayoutTreeNode[] = run.roomId
+		? [
+				{
+					id: `${run.runId}-room`,
+					data: {
+						kind: "room" as const,
+						label: run.roomId,
+						count: contents.length,
+					},
+					selection: {
+						kind: "subroom" as const,
+						roomId: run.roomId,
+						run,
+					},
+					children: contents,
+					edgeStatus: run.status,
+				},
+			]
+		: contents;
+
+	return {
+		id: run.runId,
+		data: {
+			kind: "subagent",
+			label: run.input || run.runId,
+			sublabel: run.modelId,
+			status: run.status,
+			duration: formatRunDuration(run.startedAt, run.completedAt),
+		},
+		selection: { kind: "subagent", run },
+		children: roomChildren,
+		edgeStatus: run.status,
+	};
+};
 
 const buildGraph = (
 	roomId: string,
@@ -218,42 +271,22 @@ const buildGraph = (
 			count: runs.length,
 		},
 		selection: { kind: "room", roomId, runs },
-		children: runs.map((run) => {
-			const invocationsByTool = collectToolInvocations(run);
-			const toolChildren: LayoutTreeNode[] = Array.from(
-				invocationsByTool.entries(),
-			).map(([toolName, invocations]) => ({
-				id: `${run.runId}-tool-${toolName}`,
-				data: {
-					kind: "tool" as const,
-					label: toolName,
-					count: invocations.length,
-					status: invocations.some(
-						(inv) => inv.result?.toolStatus === "error",
-					)
-						? "FAILED"
-						: undefined,
-				},
-				selection: { kind: "tool" as const, toolName, invocations },
-				children: [],
-			}));
-
-			return {
-				id: run.runId,
-				data: {
-					kind: "run" as const,
-					label: run.input || run.runId,
-					sublabel: run.modelId,
-					status: run.status,
-					duration: formatRunDuration(run.startedAt, run.completedAt),
-				},
-				selection: { kind: "run" as const, run },
-				children: [
-					...toolChildren,
-					...run.subagents.map(buildSubagentTreeNode),
-				],
-			};
-		}),
+		children: runs.map((run) => ({
+			id: run.runId,
+			data: {
+				kind: "run" as const,
+				label: run.input || run.runId,
+				sublabel: run.modelId,
+				status: run.status,
+				duration: formatRunDuration(run.startedAt, run.completedAt),
+			},
+			selection: { kind: "run" as const, run },
+			children: [
+				...buildToolTreeNodes(run),
+				...run.subagents.map(buildSubagentTreeNode),
+			],
+			edgeStatus: run.status,
+		})),
 	};
 
 	layoutTree(root);
@@ -276,9 +309,7 @@ const buildGraph = (
 				id: `${node.id}->${child.id}`,
 				source: node.id,
 				target: child.id,
-				...edgeStyleForStatus(
-					child.data.kind === "tool" ? undefined : child.data.status,
-				),
+				...edgeStyleForStatus(child.edgeStatus),
 			});
 			visit(child);
 		}
@@ -394,11 +425,23 @@ const nodeTypes = {
 const CodeBlock = ({
 	code,
 	language,
+	fill = false,
 }: {
 	code: string;
 	language: "json" | "text";
+	/**
+	 * When true the block sizes to its content but may shrink (and scroll)
+	 * to fit its flex container instead of capping at max-h-64 - lets a lone
+	 * block use the panel's full height before scrolling.
+	 */
+	fill?: boolean;
 }) => (
-	<CodeContainer className="max-h-64 overflow-auto bg-muted text-xs">
+	<CodeContainer
+		className={cn(
+			"overflow-auto bg-muted text-xs",
+			fill ? "min-h-0" : "max-h-64",
+		)}
+	>
 		<Code code={code} language={language} />
 	</CodeContainer>
 );
@@ -619,7 +662,13 @@ const MetaRow = ({ label, value }: { label: string; value?: string | null }) =>
 		</div>
 	) : null;
 
-const RunDetailPanel = ({ run }: { run: RoomRunDetail }) => {
+const RunDetailPanel = ({
+	run,
+	title,
+}: {
+	run: AgentRunDetail;
+	title: string;
+}) => {
 	const stepNodes = useMemo(() => buildTranscriptStepNodes(run), [run]);
 	const [expanded, setExpanded] = useState<string[]>([]);
 
@@ -630,11 +679,12 @@ const RunDetailPanel = ({ run }: { run: RoomRunDetail }) => {
 	return (
 		<div className="flex flex-col gap-3">
 			<div className="flex items-center justify-between gap-2">
-				<h6 className="font-semibold text-sm">Agent run</h6>
+				<h6 className="font-semibold text-sm">{title}</h6>
 				<StatusBadge status={run.status} />
 			</div>
 			<div className="flex flex-col gap-1 rounded-lg border bg-muted/40 p-3">
 				<MetaRow label="Run ID" value={run.runId} />
+				<MetaRow label="Room" value={run.roomId} />
 				<MetaRow label="Model" value={run.modelId} />
 				<MetaRow label="Harness" value={run.harnessType} />
 				<MetaRow
@@ -643,63 +693,78 @@ const RunDetailPanel = ({ run }: { run: RoomRunDetail }) => {
 				/>
 				<MetaRow label="Started" value={run.startedAt} />
 			</div>
+			{run.errorMessage && (
+				<div>
+					<p className="mb-1 flex items-center gap-1 font-medium text-destructive text-xs">
+						<XCircle className="size-3.5" />
+						Error
+					</p>
+					<p className="whitespace-pre-wrap text-destructive text-xs">
+						{run.errorMessage}
+					</p>
+				</div>
+			)}
 			{stepNodes.length > 0 ? (
 				<TreeView expanded={expanded} onExpandChange={setExpanded}>
 					{renderTreeNodes(stepNodes)}
 				</TreeView>
 			) : (
-				<p className="text-muted-foreground text-sm">
-					No transcript available for this run.
-				</p>
+				<>
+					{run.input && (
+						<div>
+							<p className="mb-1 font-medium text-muted-foreground text-xs">
+								Input
+							</p>
+							<Markdown className="text-sm">{run.input}</Markdown>
+						</div>
+					)}
+					{run.finalText && (
+						<div>
+							<p className="mb-1 flex items-center gap-1 font-medium text-muted-foreground text-xs">
+								<CheckCircle2 className="size-3.5 text-green-600" />
+								Final answer
+							</p>
+							<Markdown className="text-sm">
+								{run.finalText}
+							</Markdown>
+						</div>
+					)}
+					{!run.input && !run.finalText && (
+						<p className="text-muted-foreground text-sm">
+							No transcript available for this run.
+						</p>
+					)}
+				</>
 			)}
 		</div>
 	);
 };
 
-const SubagentDetailPanel = ({ run }: { run: SubagentRunNode }) => (
+const SubroomDetailPanel = ({
+	roomId,
+	run,
+}: {
+	roomId: string;
+	run: SubagentRunNode;
+}) => (
 	<div className="flex flex-col gap-3">
-		<div className="flex items-center justify-between gap-2">
-			<h6 className="font-semibold text-sm">Sub-agent run</h6>
-			<StatusBadge status={run.status} />
-		</div>
+		<h6 className="font-semibold text-sm">Sub-agent room</h6>
 		<div className="flex flex-col gap-1 rounded-lg border bg-muted/40 p-3">
-			<MetaRow label="Run ID" value={run.runId} />
-			<MetaRow label="Model" value={run.modelId} />
-			<MetaRow label="Harness" value={run.harnessType} />
+			<MetaRow label="Room ID" value={roomId} />
+			<MetaRow label="Sub-agent run" value={run.runId} />
 			<MetaRow
-				label="Duration"
-				value={formatRunDuration(run.startedAt, run.completedAt)}
+				label="Tools used"
+				value={String(collectToolInvocations(run).size)}
 			/>
-			<MetaRow label="Started" value={run.startedAt} />
+			<MetaRow
+				label="Nested sub-agents"
+				value={String(run.children.length)}
+			/>
 		</div>
-		{run.input && (
-			<div>
-				<p className="mb-1 font-medium text-muted-foreground text-xs">
-					Input
-				</p>
-				<Markdown className="text-sm">{run.input}</Markdown>
-			</div>
-		)}
-		{run.finalText && (
-			<div>
-				<p className="mb-1 flex items-center gap-1 font-medium text-muted-foreground text-xs">
-					<CheckCircle2 className="size-3.5 text-green-600" />
-					Final answer
-				</p>
-				<Markdown className="text-sm">{run.finalText}</Markdown>
-			</div>
-		)}
-		{run.errorMessage && (
-			<div>
-				<p className="mb-1 flex items-center gap-1 font-medium text-destructive text-xs">
-					<XCircle className="size-3.5" />
-					Error
-				</p>
-				<p className="whitespace-pre-wrap text-destructive text-xs">
-					{run.errorMessage}
-				</p>
-			</div>
-		)}
+		<p className="text-muted-foreground text-xs">
+			Room the sub-agent ran in. Click its tool or sub-agent nodes to
+			inspect them.
+		</p>
 	</div>
 );
 
@@ -709,56 +774,67 @@ const ToolDetailPanel = ({
 }: {
 	toolName: string;
 	invocations: ToolInvocation[];
-}) => (
-	<div className="flex flex-col gap-3">
-		<div className="flex items-center justify-between gap-2">
-			<h6 className="font-mono font-semibold text-sm">{toolName}</h6>
-			<Badge variant="secondary">
-				{invocations.length}{" "}
-				{invocations.length === 1 ? "call" : "calls"}
-			</Badge>
-		</div>
-		{invocations.map(({ call, result }, idx) => {
-			const parsedOutput = result
-				? tryParseJson(result.output)
-				: undefined;
-			return (
-				<div
-					key={call.id}
-					className="flex flex-col gap-2 rounded-lg border p-3"
-				>
-					<div className="flex items-center justify-between gap-2">
-						<span className="font-medium text-muted-foreground text-xs">
-							Call {idx + 1}
-						</span>
-						{result &&
-							(result.toolStatus === "error" ? (
-								<XCircle className="size-3.5 text-destructive" />
-							) : (
-								<CheckCircle2 className="size-3.5 text-green-600" />
-							))}
-					</div>
-					<CodeBlock
-						code={toPrettyJson(call.arguments)}
-						language="json"
-					/>
-					{result && (
+}) => {
+	// A lone invocation gets the panel's full height before scrolling instead
+	// of capping its code blocks while whitespace sits below them.
+	const single = invocations.length === 1;
+
+	return (
+		<div className={cn("flex flex-col gap-3", single && "h-full")}>
+			<div className="flex shrink-0 items-center justify-between gap-2">
+				<h6 className="font-mono font-semibold text-sm">{toolName}</h6>
+				<Badge variant="secondary">
+					{invocations.length}{" "}
+					{invocations.length === 1 ? "call" : "calls"}
+				</Badge>
+			</div>
+			{invocations.map(({ call, result }, idx) => {
+				const parsedOutput = result
+					? tryParseJson(result.output)
+					: undefined;
+				return (
+					<div
+						key={call.id}
+						className={cn(
+							"flex flex-col gap-2 rounded-lg border p-3",
+							single && "min-h-0",
+						)}
+					>
+						<div className="flex shrink-0 items-center justify-between gap-2">
+							<span className="font-medium text-muted-foreground text-xs">
+								Call {idx + 1}
+							</span>
+							{result &&
+								(result.toolStatus === "error" ? (
+									<XCircle className="size-3.5 text-destructive" />
+								) : (
+									<CheckCircle2 className="size-3.5 text-green-600" />
+								))}
+						</div>
 						<CodeBlock
-							code={
-								parsedOutput !== undefined
-									? toPrettyJson(parsedOutput)
-									: result.output
-							}
-							language={
-								parsedOutput !== undefined ? "json" : "text"
-							}
+							code={toPrettyJson(call.arguments)}
+							language="json"
+							fill={single}
 						/>
-					)}
-				</div>
-			);
-		})}
-	</div>
-);
+						{result && (
+							<CodeBlock
+								code={
+									parsedOutput !== undefined
+										? toPrettyJson(parsedOutput)
+										: result.output
+								}
+								language={
+									parsedOutput !== undefined ? "json" : "text"
+								}
+								fill={single}
+							/>
+						)}
+					</div>
+				);
+			})}
+		</div>
+	);
+};
 
 const RoomDetailPanel = ({
 	roomId,
@@ -842,11 +918,6 @@ export const AgentRunGraph = ({ roomId, runs }: AgentRunGraphProps) => {
 					onPaneClick={() => setSelectedNodeId("room-root")}
 				>
 					<Background gap={16} />
-					<MiniMap
-						pannable
-						zoomable
-						className="rounded-md border border-border bg-card"
-					/>
 					<Controls
 						showInteractive={false}
 						className="rounded-md border border-border bg-card text-foreground shadow-sm"
@@ -866,10 +937,16 @@ export const AgentRunGraph = ({ roomId, runs }: AgentRunGraphProps) => {
 			</div>
 			<div className="w-[380px] shrink-0 overflow-y-auto border-l bg-background p-4">
 				{selection?.kind === "run" && (
-					<RunDetailPanel run={selection.run} />
+					<RunDetailPanel run={selection.run} title="Agent run" />
 				)}
 				{selection?.kind === "subagent" && (
-					<SubagentDetailPanel run={selection.run} />
+					<RunDetailPanel run={selection.run} title="Sub-agent run" />
+				)}
+				{selection?.kind === "subroom" && (
+					<SubroomDetailPanel
+						roomId={selection.roomId}
+						run={selection.run}
+					/>
 				)}
 				{selection?.kind === "tool" && (
 					<ToolDetailPanel

--- a/packages/client/src/pages/project/agent/agent-run-graph.tsx
+++ b/packages/client/src/pages/project/agent/agent-run-graph.tsx
@@ -1,0 +1,886 @@
+import {
+	Background,
+	Controls,
+	type Edge,
+	Handle,
+	MarkerType,
+	MiniMap,
+	type Node,
+	type NodeProps,
+	Position,
+	ReactFlow,
+} from "@xyflow/react";
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
+import "@xyflow/react/dist/style.css";
+import {
+	Bot,
+	Brain,
+	CheckCircle2,
+	MessageSquare,
+	User,
+	Wrench,
+	XCircle,
+} from "lucide-react";
+import {
+	Badge,
+	Code,
+	CodeContainer,
+	cn,
+	Markdown,
+	TreeView,
+	TreeViewItem,
+	useTheme,
+} from "@semoss/ui/next";
+import type {
+	AgentRunDetail,
+	RoomRunDetail,
+	SubagentRunNode,
+	TranscriptToolCall,
+	TranscriptToolResult,
+	TreeNodeSpec,
+} from "./agent-activity-types";
+import {
+	formatRunDuration,
+	isActiveStatus,
+	isFailureStatus,
+	toPrettyJson,
+	tryParseJson,
+} from "./agent-activity-types";
+
+// GRAPH DATA TYPES
+
+type NodeKind = "room" | "run" | "subagent" | "tool";
+
+type ActivityNodeData = {
+	kind: NodeKind;
+	label: string;
+	sublabel?: string;
+	status?: string;
+	duration?: string | null;
+	count?: number;
+};
+
+type ActivityFlowNode = Node<ActivityNodeData, "activity">;
+
+interface ToolInvocation {
+	call: TranscriptToolCall;
+	result?: TranscriptToolResult;
+}
+
+type GraphSelection =
+	| { kind: "room"; roomId: string; runs: RoomRunDetail[] }
+	| { kind: "run"; run: RoomRunDetail }
+	| { kind: "subagent"; run: SubagentRunNode }
+	| { kind: "tool"; toolName: string; invocations: ToolInvocation[] };
+
+interface LayoutTreeNode {
+	id: string;
+	data: ActivityNodeData;
+	selection: GraphSelection;
+	children: LayoutTreeNode[];
+	x?: number;
+	y?: number;
+}
+
+// LAYOUT
+
+const NODE_WIDTH = 224;
+const COLUMN_GAP = 110;
+const ROW_HEIGHT = 92;
+
+const EDGE_COLORS = {
+	success: "#16a34a",
+	failure: "#dc2626",
+	active: "#3b82f6",
+	tool: "#9ca3af",
+};
+
+/**
+ * Tidy left-to-right tree layout: leaves take sequential rows, parents are
+ * centered on their children.
+ */
+const layoutTree = (root: LayoutTreeNode): void => {
+	let nextRow = 0;
+	const assign = (node: LayoutTreeNode, depth: number) => {
+		node.x = depth * (NODE_WIDTH + COLUMN_GAP);
+		if (node.children.length === 0) {
+			node.y = nextRow * ROW_HEIGHT;
+			nextRow += 1;
+			return;
+		}
+		for (const child of node.children) {
+			assign(child, depth + 1);
+		}
+		const first = node.children[0];
+		const last = node.children[node.children.length - 1];
+		node.y = ((first.y ?? 0) + (last.y ?? 0)) / 2;
+	};
+	assign(root, 0);
+};
+
+const edgeStyleForStatus = (status: string | undefined): Partial<Edge> => {
+	if (!status) {
+		return {
+			style: { stroke: EDGE_COLORS.tool, strokeDasharray: "2 4" },
+			markerEnd: {
+				type: MarkerType.ArrowClosed,
+				color: EDGE_COLORS.tool,
+			},
+		};
+	}
+	if (isFailureStatus(status)) {
+		return {
+			style: { stroke: EDGE_COLORS.failure, strokeDasharray: "6 4" },
+			markerEnd: {
+				type: MarkerType.ArrowClosed,
+				color: EDGE_COLORS.failure,
+			},
+		};
+	}
+	if (isActiveStatus(status)) {
+		return {
+			animated: true,
+			style: { stroke: EDGE_COLORS.active, strokeDasharray: "6 4" },
+			markerEnd: {
+				type: MarkerType.ArrowClosed,
+				color: EDGE_COLORS.active,
+			},
+		};
+	}
+	return {
+		style: { stroke: EDGE_COLORS.success },
+		markerEnd: { type: MarkerType.ArrowClosed, color: EDGE_COLORS.success },
+	};
+};
+
+// GRAPH BUILDING
+
+const collectToolInvocations = (
+	run: AgentRunDetail,
+): Map<string, ToolInvocation[]> => {
+	const resultByToolCallId = new Map<string, TranscriptToolResult>();
+	for (const message of run.messages ?? []) {
+		for (const part of message.parts) {
+			if (part.type === "TOOL_RESULT" && part.toolResult) {
+				resultByToolCallId.set(
+					part.toolResult.toolCallId,
+					part.toolResult,
+				);
+			}
+		}
+	}
+
+	const invocationsByTool = new Map<string, ToolInvocation[]>();
+	for (const message of run.messages ?? []) {
+		if (!message.visible) {
+			continue;
+		}
+		for (const part of message.parts) {
+			if (part.type !== "TOOL_CALL" || !part.toolCall) {
+				continue;
+			}
+			const call = part.toolCall;
+			const existing = invocationsByTool.get(call.name) ?? [];
+			existing.push({ call, result: resultByToolCallId.get(call.id) });
+			invocationsByTool.set(call.name, existing);
+		}
+	}
+	return invocationsByTool;
+};
+
+const buildSubagentTreeNode = (run: SubagentRunNode): LayoutTreeNode => ({
+	id: run.runId,
+	data: {
+		kind: "subagent",
+		label: run.input || run.runId,
+		sublabel: run.modelId,
+		status: run.status,
+		duration: formatRunDuration(run.startedAt, run.completedAt),
+	},
+	selection: { kind: "subagent", run },
+	children: run.children.map(buildSubagentTreeNode),
+});
+
+const buildGraph = (
+	roomId: string,
+	runs: RoomRunDetail[],
+): {
+	nodes: ActivityFlowNode[];
+	edges: Edge[];
+	selectionById: Map<string, GraphSelection>;
+} => {
+	const root: LayoutTreeNode = {
+		id: "room-root",
+		data: {
+			kind: "room",
+			label: roomId,
+			count: runs.length,
+		},
+		selection: { kind: "room", roomId, runs },
+		children: runs.map((run) => {
+			const invocationsByTool = collectToolInvocations(run);
+			const toolChildren: LayoutTreeNode[] = Array.from(
+				invocationsByTool.entries(),
+			).map(([toolName, invocations]) => ({
+				id: `${run.runId}-tool-${toolName}`,
+				data: {
+					kind: "tool" as const,
+					label: toolName,
+					count: invocations.length,
+					status: invocations.some(
+						(inv) => inv.result?.toolStatus === "error",
+					)
+						? "FAILED"
+						: undefined,
+				},
+				selection: { kind: "tool" as const, toolName, invocations },
+				children: [],
+			}));
+
+			return {
+				id: run.runId,
+				data: {
+					kind: "run" as const,
+					label: run.input || run.runId,
+					sublabel: run.modelId,
+					status: run.status,
+					duration: formatRunDuration(run.startedAt, run.completedAt),
+				},
+				selection: { kind: "run" as const, run },
+				children: [
+					...toolChildren,
+					...run.subagents.map(buildSubagentTreeNode),
+				],
+			};
+		}),
+	};
+
+	layoutTree(root);
+
+	const nodes: ActivityFlowNode[] = [];
+	const edges: Edge[] = [];
+	const selectionById = new Map<string, GraphSelection>();
+
+	const visit = (node: LayoutTreeNode) => {
+		nodes.push({
+			id: node.id,
+			type: "activity",
+			position: { x: node.x ?? 0, y: node.y ?? 0 },
+			data: node.data,
+		});
+		selectionById.set(node.id, node.selection);
+
+		for (const child of node.children) {
+			edges.push({
+				id: `${node.id}->${child.id}`,
+				source: node.id,
+				target: child.id,
+				...edgeStyleForStatus(
+					child.data.kind === "tool" ? undefined : child.data.status,
+				),
+			});
+			visit(child);
+		}
+	};
+	visit(root);
+
+	return { nodes, edges, selectionById };
+};
+
+// CUSTOM NODE
+
+const NODE_KIND_STYLES: Record<NodeKind, string> = {
+	room: "border-primary/40 bg-primary/10",
+	run: "border-primary/50 bg-card shadow-sm",
+	subagent: "border-border bg-card",
+	tool: "border-dashed border-border bg-muted/60",
+};
+
+const NODE_KIND_ICONS: Record<NodeKind, ReactNode> = {
+	room: <MessageSquare className="size-4 shrink-0 text-primary" />,
+	run: <Bot className="size-4 shrink-0 text-primary" />,
+	subagent: <Bot className="size-4 shrink-0 text-muted-foreground" />,
+	tool: <Wrench className="size-4 shrink-0 text-muted-foreground" />,
+};
+
+const NODE_KIND_TITLES: Record<NodeKind, string> = {
+	room: "Room",
+	run: "Agent run",
+	subagent: "Sub-agent",
+	tool: "Tool",
+};
+
+const statusDotClass = (status: string): string => {
+	if (isFailureStatus(status)) {
+		return "bg-destructive";
+	}
+	if (isActiveStatus(status)) {
+		return "bg-blue-500";
+	}
+	return "bg-green-600";
+};
+
+const ActivityGraphNode = ({ data, selected }: NodeProps<ActivityFlowNode>) => {
+	return (
+		<div
+			className={cn(
+				"w-56 rounded-lg border px-3 py-2 transition-shadow",
+				NODE_KIND_STYLES[data.kind],
+				selected && "ring-2 ring-primary",
+			)}
+		>
+			<Handle
+				type="target"
+				position={Position.Left}
+				isConnectable={false}
+				className="!size-1.5 !border-none !bg-border"
+			/>
+			<div className="flex items-center gap-1.5 text-[10px] text-muted-foreground uppercase tracking-wide">
+				{NODE_KIND_ICONS[data.kind]}
+				<span>{NODE_KIND_TITLES[data.kind]}</span>
+				{typeof data.count === "number" && (
+					<span className="ml-auto rounded-full bg-muted px-1.5 font-medium">
+						{data.count}
+					</span>
+				)}
+			</div>
+			<p
+				className={cn(
+					"mt-1 truncate text-xs",
+					data.kind === "tool" ? "font-mono" : "font-medium",
+				)}
+				title={data.label}
+			>
+				{data.label}
+			</p>
+			{(data.status || data.duration || data.sublabel) && (
+				<div className="mt-1 flex items-center gap-2 text-[10px] text-muted-foreground">
+					{data.status && (
+						<span className="flex items-center gap-1">
+							<span
+								className={cn(
+									"size-1.5 rounded-full",
+									statusDotClass(data.status),
+								)}
+							/>
+							{data.status}
+						</span>
+					)}
+					{data.duration && <span>{data.duration}</span>}
+					{data.sublabel && (
+						<span className="ml-auto max-w-[45%] truncate">
+							{data.sublabel}
+						</span>
+					)}
+				</div>
+			)}
+			<Handle
+				type="source"
+				position={Position.Right}
+				isConnectable={false}
+				className="!size-1.5 !border-none !bg-border"
+			/>
+		</div>
+	);
+};
+
+const nodeTypes = {
+	activity: ActivityGraphNode,
+};
+
+// DETAIL PANEL
+
+const CodeBlock = ({
+	code,
+	language,
+}: {
+	code: string;
+	language: "json" | "text";
+}) => (
+	<CodeContainer className="max-h-64 overflow-auto bg-muted text-xs">
+		<Code code={code} language={language} />
+	</CodeContainer>
+);
+
+/**
+ * Builds the transcript subtree for a run: You -> Assistant (thinking/text/
+ * tool calls with paired results) -> ... -> Final answer, per the
+ * semoss-transcript-schema turn order. Tool results are matched to calls by
+ * toolCallId (never by array position), and `visible: false` relay turns are
+ * skipped.
+ */
+const buildTranscriptStepNodes = (run: AgentRunDetail): TreeNodeSpec[] => {
+	const resultByToolCallId = new Map<string, TranscriptToolResult>();
+	for (const message of run.messages ?? []) {
+		for (const part of message.parts) {
+			if (part.type === "TOOL_RESULT" && part.toolResult) {
+				resultByToolCallId.set(
+					part.toolResult.toolCallId,
+					part.toolResult,
+				);
+			}
+		}
+	}
+
+	const stepNodes: TreeNodeSpec[] = [];
+
+	for (const message of run.messages ?? []) {
+		if (!message.visible) {
+			continue;
+		}
+		const role = message.ornaments?.agentRunRole;
+
+		if (role === "input") {
+			const textPart = message.parts.find((part) => part.type === "TEXT");
+			stepNodes.push({
+				id: message.messageId,
+				leadingIcon: <User className="size-3.5" />,
+				label: <span className="font-medium text-sm">You</span>,
+				children: [
+					{
+						id: `${message.messageId}-text`,
+						label: (
+							<Markdown className="text-sm">
+								{textPart?.uiText ?? textPart?.text ?? ""}
+							</Markdown>
+						),
+					},
+				],
+			});
+			continue;
+		}
+
+		if (role === "assistant_tool") {
+			const children: TreeNodeSpec[] = [];
+
+			const thinkingPart = message.parts.find(
+				(part) => part.type === "THINKING",
+			);
+			if (thinkingPart?.thinking) {
+				children.push({
+					id: `${message.messageId}-thinking`,
+					leadingIcon: <Brain className="size-3.5" />,
+					label: (
+						<span className="text-muted-foreground text-xs italic">
+							Thinking
+						</span>
+					),
+					children: [
+						{
+							id: `${message.messageId}-thinking-body`,
+							label: (
+								<p className="whitespace-pre-wrap text-muted-foreground text-xs">
+									{thinkingPart.thinking}
+								</p>
+							),
+						},
+					],
+				});
+			}
+
+			const textPart = message.parts.find((part) => part.type === "TEXT");
+			if (textPart?.text) {
+				children.push({
+					id: `${message.messageId}-text`,
+					label: (
+						<Markdown className="text-sm">{textPart.text}</Markdown>
+					),
+				});
+			}
+
+			for (const part of message.parts) {
+				if (part.type !== "TOOL_CALL" || !part.toolCall) {
+					continue;
+				}
+				const call = part.toolCall;
+				const result = resultByToolCallId.get(call.id);
+				const callChildren: TreeNodeSpec[] = [
+					{
+						id: `${call.id}-args`,
+						label: (
+							<CodeBlock
+								code={toPrettyJson(call.arguments)}
+								language="json"
+							/>
+						),
+					},
+				];
+
+				if (result) {
+					const parsedOutput = tryParseJson(result.output);
+					callChildren.push({
+						id: `${call.id}-result`,
+						leadingIcon:
+							result.toolStatus === "error" ? (
+								<XCircle className="size-3.5 text-destructive" />
+							) : (
+								<CheckCircle2 className="size-3.5 text-green-600" />
+							),
+						label: (
+							<span className="text-muted-foreground text-xs">
+								Result
+							</span>
+						),
+						children: [
+							{
+								id: `${call.id}-result-body`,
+								label: (
+									<CodeBlock
+										code={
+											parsedOutput !== undefined
+												? toPrettyJson(parsedOutput)
+												: result.output
+										}
+										language={
+											parsedOutput !== undefined
+												? "json"
+												: "text"
+										}
+									/>
+								),
+							},
+						],
+					});
+				}
+
+				children.push({
+					id: call.id,
+					leadingIcon: <Wrench className="size-3.5" />,
+					label: (
+						<span className="font-mono text-xs">{call.name}</span>
+					),
+					children: callChildren,
+				});
+			}
+
+			stepNodes.push({
+				id: message.messageId,
+				leadingIcon: <Bot className="size-3.5" />,
+				label: <span className="font-medium text-sm">Assistant</span>,
+				children,
+			});
+			continue;
+		}
+
+		if (role === "final_output") {
+			const textPart = message.parts.find((part) => part.type === "TEXT");
+			stepNodes.push({
+				id: message.messageId,
+				leadingIcon: (
+					<CheckCircle2 className="size-3.5 text-green-600" />
+				),
+				label: (
+					<span className="font-medium text-sm">Final answer</span>
+				),
+				children: [
+					{
+						id: `${message.messageId}-text`,
+						label: (
+							<Markdown className="text-sm">
+								{textPart?.text ?? ""}
+							</Markdown>
+						),
+					},
+				],
+			});
+		}
+	}
+
+	return stepNodes;
+};
+
+const renderTreeNodes = (nodes: TreeNodeSpec[]): ReactNode =>
+	nodes.map((node) => (
+		<TreeViewItem
+			key={node.id}
+			id={node.id}
+			label={node.label}
+			item={node}
+			leadingIcon={node.leadingIcon}
+		>
+			{node.children ? renderTreeNodes(node.children) : null}
+		</TreeViewItem>
+	));
+
+const StatusBadge = ({ status }: { status: string }) => (
+	<Badge variant={isFailureStatus(status) ? "destructive" : "secondary"}>
+		{status}
+	</Badge>
+);
+
+const MetaRow = ({ label, value }: { label: string; value?: string | null }) =>
+	value ? (
+		<div className="flex justify-between gap-4 text-xs">
+			<span className="shrink-0 text-muted-foreground">{label}</span>
+			<span className="truncate font-mono" title={value}>
+				{value}
+			</span>
+		</div>
+	) : null;
+
+const RunDetailPanel = ({ run }: { run: RoomRunDetail }) => {
+	const stepNodes = useMemo(() => buildTranscriptStepNodes(run), [run]);
+	const [expanded, setExpanded] = useState<string[]>([]);
+
+	useEffect(() => {
+		setExpanded(stepNodes.map((node) => node.id));
+	}, [stepNodes]);
+
+	return (
+		<div className="flex flex-col gap-3">
+			<div className="flex items-center justify-between gap-2">
+				<h6 className="font-semibold text-sm">Agent run</h6>
+				<StatusBadge status={run.status} />
+			</div>
+			<div className="flex flex-col gap-1 rounded-lg border bg-muted/40 p-3">
+				<MetaRow label="Run ID" value={run.runId} />
+				<MetaRow label="Model" value={run.modelId} />
+				<MetaRow label="Harness" value={run.harnessType} />
+				<MetaRow
+					label="Duration"
+					value={formatRunDuration(run.startedAt, run.completedAt)}
+				/>
+				<MetaRow label="Started" value={run.startedAt} />
+			</div>
+			{stepNodes.length > 0 ? (
+				<TreeView expanded={expanded} onExpandChange={setExpanded}>
+					{renderTreeNodes(stepNodes)}
+				</TreeView>
+			) : (
+				<p className="text-muted-foreground text-sm">
+					No transcript available for this run.
+				</p>
+			)}
+		</div>
+	);
+};
+
+const SubagentDetailPanel = ({ run }: { run: SubagentRunNode }) => (
+	<div className="flex flex-col gap-3">
+		<div className="flex items-center justify-between gap-2">
+			<h6 className="font-semibold text-sm">Sub-agent run</h6>
+			<StatusBadge status={run.status} />
+		</div>
+		<div className="flex flex-col gap-1 rounded-lg border bg-muted/40 p-3">
+			<MetaRow label="Run ID" value={run.runId} />
+			<MetaRow label="Model" value={run.modelId} />
+			<MetaRow label="Harness" value={run.harnessType} />
+			<MetaRow
+				label="Duration"
+				value={formatRunDuration(run.startedAt, run.completedAt)}
+			/>
+			<MetaRow label="Started" value={run.startedAt} />
+		</div>
+		{run.input && (
+			<div>
+				<p className="mb-1 font-medium text-muted-foreground text-xs">
+					Input
+				</p>
+				<Markdown className="text-sm">{run.input}</Markdown>
+			</div>
+		)}
+		{run.finalText && (
+			<div>
+				<p className="mb-1 flex items-center gap-1 font-medium text-muted-foreground text-xs">
+					<CheckCircle2 className="size-3.5 text-green-600" />
+					Final answer
+				</p>
+				<Markdown className="text-sm">{run.finalText}</Markdown>
+			</div>
+		)}
+		{run.errorMessage && (
+			<div>
+				<p className="mb-1 flex items-center gap-1 font-medium text-destructive text-xs">
+					<XCircle className="size-3.5" />
+					Error
+				</p>
+				<p className="whitespace-pre-wrap text-destructive text-xs">
+					{run.errorMessage}
+				</p>
+			</div>
+		)}
+	</div>
+);
+
+const ToolDetailPanel = ({
+	toolName,
+	invocations,
+}: {
+	toolName: string;
+	invocations: ToolInvocation[];
+}) => (
+	<div className="flex flex-col gap-3">
+		<div className="flex items-center justify-between gap-2">
+			<h6 className="font-mono font-semibold text-sm">{toolName}</h6>
+			<Badge variant="secondary">
+				{invocations.length}{" "}
+				{invocations.length === 1 ? "call" : "calls"}
+			</Badge>
+		</div>
+		{invocations.map(({ call, result }, idx) => {
+			const parsedOutput = result
+				? tryParseJson(result.output)
+				: undefined;
+			return (
+				<div
+					key={call.id}
+					className="flex flex-col gap-2 rounded-lg border p-3"
+				>
+					<div className="flex items-center justify-between gap-2">
+						<span className="font-medium text-muted-foreground text-xs">
+							Call {idx + 1}
+						</span>
+						{result &&
+							(result.toolStatus === "error" ? (
+								<XCircle className="size-3.5 text-destructive" />
+							) : (
+								<CheckCircle2 className="size-3.5 text-green-600" />
+							))}
+					</div>
+					<CodeBlock
+						code={toPrettyJson(call.arguments)}
+						language="json"
+					/>
+					{result && (
+						<CodeBlock
+							code={
+								parsedOutput !== undefined
+									? toPrettyJson(parsedOutput)
+									: result.output
+							}
+							language={
+								parsedOutput !== undefined ? "json" : "text"
+							}
+						/>
+					)}
+				</div>
+			);
+		})}
+	</div>
+);
+
+const RoomDetailPanel = ({
+	roomId,
+	runs,
+}: {
+	roomId: string;
+	runs: RoomRunDetail[];
+}) => (
+	<div className="flex flex-col gap-3">
+		<h6 className="font-semibold text-sm">Room</h6>
+		<div className="flex flex-col gap-1 rounded-lg border bg-muted/40 p-3">
+			<MetaRow label="Room ID" value={roomId} />
+			<MetaRow label="Runs" value={String(runs.length)} />
+			<MetaRow
+				label="Sub-agents"
+				value={String(
+					runs.reduce(
+						(total, run) => total + run.subagents.length,
+						0,
+					),
+				)}
+			/>
+		</div>
+		<p className="text-muted-foreground text-xs">
+			Click an agent run, sub-agent, or tool node to inspect it.
+		</p>
+	</div>
+);
+
+const LEGEND_ITEMS: { label: string; className: string }[] = [
+	{ label: "Success", className: "border-t-2 border-[#16a34a]" },
+	{ label: "Failed", className: "border-t-2 border-[#dc2626] border-dashed" },
+	{
+		label: "Running",
+		className: "border-t-2 border-[#3b82f6] border-dashed",
+	},
+	{
+		label: "Tool call",
+		className: "border-t-2 border-[#9ca3af] border-dotted",
+	},
+];
+
+// COMPONENT
+
+interface AgentRunGraphProps {
+	roomId: string;
+	runs: RoomRunDetail[];
+}
+
+/**
+ * Node-graph view of a room's agent activity: room -> agent runs -> tool
+ * calls and (recursive) sub-agent runs, with a detail panel for the selected
+ * node. Render with key={roomId} so selection resets when the room changes.
+ */
+export const AgentRunGraph = ({ roomId, runs }: AgentRunGraphProps) => {
+	const { resolvedTheme } = useTheme();
+	const isDarkTheme = resolvedTheme === "dark";
+
+	const { nodes, edges, selectionById } = useMemo(
+		() => buildGraph(roomId, runs),
+		[roomId, runs],
+	);
+
+	const [selectedNodeId, setSelectedNodeId] = useState<string>("room-root");
+	const selection = selectionById.get(selectedNodeId) ?? null;
+
+	return (
+		<div className="flex h-[600px] overflow-hidden rounded-xl border">
+			<div className="relative min-w-0 flex-1">
+				<ReactFlow
+					nodes={nodes}
+					edges={edges}
+					nodeTypes={nodeTypes}
+					colorMode={isDarkTheme ? "dark" : "light"}
+					fitView={true}
+					fitViewOptions={{ maxZoom: 1, padding: 0.15 }}
+					nodesConnectable={false}
+					edgesFocusable={false}
+					proOptions={{ hideAttribution: true }}
+					onNodeClick={(_event, node) => setSelectedNodeId(node.id)}
+					onPaneClick={() => setSelectedNodeId("room-root")}
+				>
+					<Background gap={16} />
+					<MiniMap
+						pannable
+						zoomable
+						className="rounded-md border border-border bg-card"
+					/>
+					<Controls
+						showInteractive={false}
+						className="rounded-md border border-border bg-card text-foreground shadow-sm"
+					/>
+				</ReactFlow>
+				<div className="absolute top-2 left-2 z-10 flex flex-col gap-1.5 rounded-md border bg-card/95 p-2 shadow-sm backdrop-blur">
+					{LEGEND_ITEMS.map((item) => (
+						<div
+							key={item.label}
+							className="flex items-center gap-2 text-[10px] text-muted-foreground"
+						>
+							<span className={cn("w-6", item.className)} />
+							{item.label}
+						</div>
+					))}
+				</div>
+			</div>
+			<div className="w-[380px] shrink-0 overflow-y-auto border-l bg-background p-4">
+				{selection?.kind === "run" && (
+					<RunDetailPanel run={selection.run} />
+				)}
+				{selection?.kind === "subagent" && (
+					<SubagentDetailPanel run={selection.run} />
+				)}
+				{selection?.kind === "tool" && (
+					<ToolDetailPanel
+						toolName={selection.toolName}
+						invocations={selection.invocations}
+					/>
+				)}
+				{(!selection || selection.kind === "room") && (
+					<RoomDetailPanel roomId={roomId} runs={runs} />
+				)}
+			</div>
+		</div>
+	);
+};

--- a/packages/client/src/pages/project/agent/agent-run-graph.tsx
+++ b/packages/client/src/pages/project/agent/agent-run-graph.tsx
@@ -33,6 +33,7 @@ import {
 } from "@semoss/ui/next";
 import type {
 	AgentRunDetail,
+	EngineInfo,
 	RoomRunDetail,
 	SubagentRunNode,
 	TranscriptToolCall,
@@ -214,10 +215,15 @@ const buildToolTreeNodes = (run: AgentRunDetail): LayoutTreeNode[] =>
  * A subagent run mirrors the parent structure: the run card points at its own
  * room, which fans out into the tools it called and any nested subagents.
  */
-const buildSubagentTreeNode = (run: SubagentRunNode): LayoutTreeNode => {
+const buildSubagentTreeNode = (
+	run: SubagentRunNode,
+	engineInfo: Record<string, EngineInfo>,
+): LayoutTreeNode => {
 	const contents: LayoutTreeNode[] = [
 		...buildToolTreeNodes(run),
-		...run.children.map(buildSubagentTreeNode),
+		...run.children.map((child) =>
+			buildSubagentTreeNode(child, engineInfo),
+		),
 	];
 
 	const roomChildren: LayoutTreeNode[] = run.roomId
@@ -226,7 +232,7 @@ const buildSubagentTreeNode = (run: SubagentRunNode): LayoutTreeNode => {
 					id: `${run.runId}-room`,
 					data: {
 						kind: "room" as const,
-						label: run.roomId,
+						label: run.roomName || run.roomId,
 						count: contents.length,
 					},
 					selection: {
@@ -245,7 +251,7 @@ const buildSubagentTreeNode = (run: SubagentRunNode): LayoutTreeNode => {
 		data: {
 			kind: "subagent",
 			label: run.input || run.runId,
-			sublabel: run.modelId,
+			sublabel: engineInfo[run.modelId]?.name ?? run.modelId,
 			status: run.status,
 			duration: formatRunDuration(run.startedAt, run.completedAt),
 		},
@@ -257,7 +263,9 @@ const buildSubagentTreeNode = (run: SubagentRunNode): LayoutTreeNode => {
 
 const buildGraph = (
 	roomId: string,
+	roomName: string | undefined,
 	runs: RoomRunDetail[],
+	engineInfo: Record<string, EngineInfo>,
 ): {
 	nodes: ActivityFlowNode[];
 	edges: Edge[];
@@ -267,7 +275,7 @@ const buildGraph = (
 		id: "room-root",
 		data: {
 			kind: "room",
-			label: roomId,
+			label: roomName || roomId,
 			count: runs.length,
 		},
 		selection: { kind: "room", roomId, runs },
@@ -276,14 +284,16 @@ const buildGraph = (
 			data: {
 				kind: "run" as const,
 				label: run.input || run.runId,
-				sublabel: run.modelId,
+				sublabel: engineInfo[run.modelId]?.name ?? run.modelId,
 				status: run.status,
 				duration: formatRunDuration(run.startedAt, run.completedAt),
 			},
 			selection: { kind: "run" as const, run },
 			children: [
 				...buildToolTreeNodes(run),
-				...run.subagents.map(buildSubagentTreeNode),
+				...run.subagents.map((subagent) =>
+					buildSubagentTreeNode(subagent, engineInfo),
+				),
 			],
 			edgeStatus: run.status,
 		})),
@@ -665,9 +675,11 @@ const MetaRow = ({ label, value }: { label: string; value?: string | null }) =>
 const RunDetailPanel = ({
 	run,
 	title,
+	engineInfo,
 }: {
 	run: AgentRunDetail;
 	title: string;
+	engineInfo: Record<string, EngineInfo>;
 }) => {
 	const stepNodes = useMemo(() => buildTranscriptStepNodes(run), [run]);
 	const [expanded, setExpanded] = useState<string[]>([]);
@@ -675,6 +687,8 @@ const RunDetailPanel = ({
 	useEffect(() => {
 		setExpanded(stepNodes.map((node) => node.id));
 	}, [stepNodes]);
+
+	const info = engineInfo[run.modelId];
 
 	return (
 		<div className="flex flex-col gap-3">
@@ -684,8 +698,8 @@ const RunDetailPanel = ({
 			</div>
 			<div className="flex flex-col gap-1 rounded-lg border bg-muted/40 p-3">
 				<MetaRow label="Run ID" value={run.runId} />
-				<MetaRow label="Room" value={run.roomId} />
-				<MetaRow label="Model" value={run.modelId} />
+				<MetaRow label="Room" value={run.roomName || run.roomId} />
+				<MetaRow label="Model" value={info?.name ?? run.modelId} />
 				<MetaRow label="Harness" value={run.harnessType} />
 				<MetaRow
 					label="Duration"
@@ -750,6 +764,7 @@ const SubroomDetailPanel = ({
 	<div className="flex flex-col gap-3">
 		<h6 className="font-semibold text-sm">Sub-agent room</h6>
 		<div className="flex flex-col gap-1 rounded-lg border bg-muted/40 p-3">
+			<MetaRow label="Name" value={run.roomName} />
 			<MetaRow label="Room ID" value={roomId} />
 			<MetaRow label="Sub-agent run" value={run.runId} />
 			<MetaRow
@@ -838,14 +853,17 @@ const ToolDetailPanel = ({
 
 const RoomDetailPanel = ({
 	roomId,
+	roomName,
 	runs,
 }: {
 	roomId: string;
+	roomName?: string;
 	runs: RoomRunDetail[];
 }) => (
 	<div className="flex flex-col gap-3">
 		<h6 className="font-semibold text-sm">Room</h6>
 		<div className="flex flex-col gap-1 rounded-lg border bg-muted/40 p-3">
+			<MetaRow label="Name" value={roomName} />
 			<MetaRow label="Room ID" value={roomId} />
 			<MetaRow label="Runs" value={String(runs.length)} />
 			<MetaRow
@@ -881,7 +899,10 @@ const LEGEND_ITEMS: { label: string; className: string }[] = [
 
 interface AgentRunGraphProps {
 	roomId: string;
+	roomName?: string;
 	runs: RoomRunDetail[];
+	/** Model engine id -> display info resolved via GetEngineMetadata. */
+	engineInfo?: Record<string, EngineInfo>;
 }
 
 /**
@@ -889,13 +910,18 @@ interface AgentRunGraphProps {
  * calls and (recursive) sub-agent runs, with a detail panel for the selected
  * node. Render with key={roomId} so selection resets when the room changes.
  */
-export const AgentRunGraph = ({ roomId, runs }: AgentRunGraphProps) => {
+export const AgentRunGraph = ({
+	roomId,
+	roomName,
+	runs,
+	engineInfo = {},
+}: AgentRunGraphProps) => {
 	const { resolvedTheme } = useTheme();
 	const isDarkTheme = resolvedTheme === "dark";
 
 	const { nodes, edges, selectionById } = useMemo(
-		() => buildGraph(roomId, runs),
-		[roomId, runs],
+		() => buildGraph(roomId, roomName, runs, engineInfo),
+		[roomId, roomName, runs, engineInfo],
 	);
 
 	const [selectedNodeId, setSelectedNodeId] = useState<string>("room-root");
@@ -937,10 +963,18 @@ export const AgentRunGraph = ({ roomId, runs }: AgentRunGraphProps) => {
 			</div>
 			<div className="w-[380px] shrink-0 overflow-y-auto border-l bg-background p-4">
 				{selection?.kind === "run" && (
-					<RunDetailPanel run={selection.run} title="Agent run" />
+					<RunDetailPanel
+						run={selection.run}
+						title="Agent run"
+						engineInfo={engineInfo}
+					/>
 				)}
 				{selection?.kind === "subagent" && (
-					<RunDetailPanel run={selection.run} title="Sub-agent run" />
+					<RunDetailPanel
+						run={selection.run}
+						title="Sub-agent run"
+						engineInfo={engineInfo}
+					/>
 				)}
 				{selection?.kind === "subroom" && (
 					<SubroomDetailPanel
@@ -955,7 +989,11 @@ export const AgentRunGraph = ({ roomId, runs }: AgentRunGraphProps) => {
 					/>
 				)}
 				{(!selection || selection.kind === "room") && (
-					<RoomDetailPanel roomId={roomId} runs={runs} />
+					<RoomDetailPanel
+						roomId={roomId}
+						roomName={roomName}
+						runs={runs}
+					/>
 				)}
 			</div>
 		</div>

--- a/packages/client/src/pages/project/agent/claude-code-transcript.ts
+++ b/packages/client/src/pages/project/agent/claude-code-transcript.ts
@@ -1,0 +1,272 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import type {
+	AgentRunDetail,
+	TranscriptMessage,
+	TranscriptPart,
+} from "./agent-activity-types";
+import { toMs } from "./agent-activity-types";
+
+dayjs.extend(utc);
+
+/**
+ * Events returned by GetClaudeCodeTranscriptHistory ( roomId = ... ) - the
+ * room's Claude Code JSONL parsed through ClaudeCodeTranscriptParser. Runs on
+ * the claude_code harness only persist input/final-output room messages, so
+ * this transcript is the only source of their tool calls and results.
+ */
+export interface ClaudeCodeTranscriptEvent {
+	event: string;
+	uuid?: string;
+	parentUuid?: string | null;
+	sessionId?: string;
+	data?: unknown;
+}
+
+interface ClaudeCodeAssistantThinking {
+	thinking?: string | null;
+	redacted?: boolean;
+	model?: string;
+	timestamp?: string;
+}
+
+interface ClaudeCodeAssistantText {
+	text?: string;
+	model?: string;
+	timestamp?: string;
+}
+
+interface ClaudeCodeToolInvocation {
+	toolUseId?: string;
+	toolName?: string;
+	description?: string;
+	subagentType?: string | null;
+	timestamp?: string;
+}
+
+interface ClaudeCodeAssistantData {
+	thinking?: ClaudeCodeAssistantThinking[];
+	texts?: ClaudeCodeAssistantText[];
+	toolInvocations?: ClaudeCodeToolInvocation[];
+	model?: string;
+	stopReason?: string | null;
+}
+
+interface ClaudeCodeToolResultData {
+	toolUseId?: string | null;
+	status?: string;
+	durationMs?: number;
+	filePath?: string | null;
+	content?: string | null;
+	timestamp?: string;
+	stats?: Record<string, number>;
+}
+
+const eventTimestamp = (event: ClaudeCodeTranscriptEvent): string | null => {
+	const data = (event.data ?? {}) as Record<string, unknown>;
+	if (typeof data.timestamp === "string" && data.timestamp) {
+		return data.timestamp;
+	}
+	// Assistant events carry timestamps on their content items instead.
+	const assistant = data as ClaudeCodeAssistantData;
+	return (
+		assistant.toolInvocations?.[0]?.timestamp ??
+		assistant.texts?.[0]?.timestamp ??
+		assistant.thinking?.[0]?.timestamp ??
+		null
+	);
+};
+
+/** Clock-skew slack when matching JSONL timestamps to AGENT_RUN windows. */
+const RUN_WINDOW_SLACK_MS = 10_000;
+
+const isWithinRunWindow = (
+	event: ClaudeCodeTranscriptEvent,
+	run: AgentRunDetail,
+): boolean => {
+	const ts = eventTimestamp(event);
+	if (!ts) {
+		return false;
+	}
+	const eventMs = dayjs.utc(ts).valueOf();
+	if (!Number.isFinite(eventMs)) {
+		return false;
+	}
+	const startMs = toMs(run.startedAt ?? run.dateCreated);
+	if (Number.isFinite(startMs) && eventMs < startMs - RUN_WINDOW_SLACK_MS) {
+		return false;
+	}
+	const endMs = toMs(run.completedAt);
+	if (Number.isFinite(endMs) && eventMs > endMs + RUN_WINDOW_SLACK_MS) {
+		return false;
+	}
+	return true;
+};
+
+const toolCallArguments = (
+	invocation: ClaudeCodeToolInvocation,
+): Record<string, unknown> => {
+	const args: Record<string, unknown> = {};
+	if (invocation.description) {
+		args.description = invocation.description;
+	}
+	if (invocation.subagentType) {
+		args.subagent_type = invocation.subagentType;
+	}
+	return args;
+};
+
+/**
+ * Convert parsed Claude Code events into synthetic TranscriptMessages in the
+ * shape GetAgentRun returns for the semoss harness, so the activity graph,
+ * tool panels, and transcript tree consume both harnesses identically.
+ * Text-only assistant events are skipped - the final answer already exists as
+ * the run's final_output room message.
+ */
+const toTranscriptMessages = (
+	events: ClaudeCodeTranscriptEvent[],
+	runId: string,
+): TranscriptMessage[] => {
+	const messages: TranscriptMessage[] = [];
+
+	events.forEach((event, index) => {
+		const uuid = event.uuid || `evt-${index}`;
+
+		if (event.event === "assistant") {
+			const data = (event.data ?? {}) as ClaudeCodeAssistantData;
+			const thinking = data.thinking ?? [];
+			const toolInvocations = data.toolInvocations ?? [];
+			if (thinking.length === 0 && toolInvocations.length === 0) {
+				return;
+			}
+
+			const parts: TranscriptPart[] = [];
+			for (const item of thinking) {
+				if (item.thinking) {
+					parts.push({ type: "THINKING", thinking: item.thinking });
+				}
+			}
+			if (toolInvocations.length > 0) {
+				for (const item of data.texts ?? []) {
+					if (item.text) {
+						parts.push({ type: "TEXT", text: item.text });
+					}
+				}
+			}
+			toolInvocations.forEach((invocation, invocationIndex) => {
+				parts.push({
+					type: "TOOL_CALL",
+					toolCall: {
+						id:
+							invocation.toolUseId ||
+							`cc-${uuid}-call-${invocationIndex}`,
+						name: invocation.toolName || "tool",
+						arguments: toolCallArguments(invocation),
+						type: "tool_use",
+					},
+				});
+			});
+			if (parts.length === 0) {
+				return;
+			}
+
+			messages.push({
+				messageId: `cc-${uuid}`,
+				visible: true,
+				io: "OUTPUT",
+				type: "RESPONSE_TOOL",
+				dateCreated: eventTimestamp(event) ?? "",
+				ornaments: {
+					modelName: data.model ?? "",
+					agentRunRole: "assistant_tool",
+					agentRunId: runId,
+				},
+				parts,
+			});
+			return;
+		}
+
+		if (event.event === "tool_result") {
+			const data = (event.data ?? {}) as ClaudeCodeToolResultData;
+			if (!data.toolUseId) {
+				return;
+			}
+			const parameterValues: Record<string, unknown> = {};
+			if (data.filePath) {
+				parameterValues.filePath = data.filePath;
+			}
+			if (data.durationMs) {
+				parameterValues.durationMs = data.durationMs;
+			}
+
+			messages.push({
+				messageId: `cc-${uuid}-result`,
+				// Results render nested under their tool call, not as their
+				// own transcript step.
+				visible: false,
+				io: "INPUT",
+				type: "INPUT_TOOL_EXEC",
+				dateCreated: data.timestamp ?? "",
+				ornaments: {
+					modelName: "",
+					agentRunRole: "tool_result",
+					agentRunId: runId,
+				},
+				parts: [
+					{
+						type: "TOOL_RESULT",
+						toolResult: {
+							toolCallId: data.toolUseId,
+							toolName: "",
+							output: data.content ?? "",
+							toolParameterValues: parameterValues,
+							toolStatus: /error|fail/i.test(data.status ?? "")
+								? "error"
+								: "success",
+							serverTool: false,
+						},
+					},
+				],
+			});
+		}
+	});
+
+	return messages;
+};
+
+/**
+ * Merge a room's Claude Code transcript into a run's messages. When the room
+ * hosts multiple runs the events are first narrowed to the run's start/end
+ * window (the JSONL is per room, not per run). Existing room messages keep
+ * their place: input first, synthetic activity in the middle, final output
+ * last.
+ */
+export const mergeClaudeCodeTranscript = (
+	run: AgentRunDetail,
+	events: ClaudeCodeTranscriptEvent[],
+	filterToRunWindow: boolean,
+): AgentRunDetail => {
+	const relevant = filterToRunWindow
+		? events.filter((event) => isWithinRunWindow(event, run))
+		: events;
+	const synthetic = toTranscriptMessages(relevant, run.runId);
+	if (synthetic.length === 0) {
+		return run;
+	}
+
+	const existing = run.messages ?? [];
+	const inputs = existing.filter(
+		(message) => message.ornaments?.agentRunRole === "input",
+	);
+	const finals = existing.filter(
+		(message) => message.ornaments?.agentRunRole === "final_output",
+	);
+	const others = existing.filter(
+		(message) => !inputs.includes(message) && !finals.includes(message),
+	);
+
+	return {
+		...run,
+		messages: [...inputs, ...others, ...synthetic, ...finals],
+	};
+};

--- a/packages/client/src/pages/project/project.routes.tsx
+++ b/packages/client/src/pages/project/project.routes.tsx
@@ -15,6 +15,7 @@ import {
 	NewPromptBuilderAppPage,
 	ViewAppPage,
 } from "../app";
+import { AgentActivityPage } from "./agent/agent-activity-page";
 import { CreateAgentPage } from "./agent/create-agent-page";
 import { CreateAppPage } from "./app/create-app-page";
 import { ProjectDependenciesPage } from "./project-dependencies-page";
@@ -287,6 +288,15 @@ export const PROJECT_ROUTES: {
 										restrict: ["OWNER"],
 									},
 									{
+										name: "Agent Activity",
+										path: "agent-activity",
+										restrict: [
+											"OWNER",
+											"EDIT",
+											"READ_ONLY",
+										],
+									},
+									{
 										name: "Access Control",
 										path: "access-control",
 										restrict: ["OWNER", "EDIT"],
@@ -315,6 +325,10 @@ export const PROJECT_ROUTES: {
 							{
 								path: "github/select-repo",
 								element: <AppGithubSelectRepoPage />,
+							},
+							{
+								path: "agent-activity",
+								element: <AgentActivityPage />,
 							},
 							{
 								path: "access-control",


### PR DESCRIPTION
## Summary

Adds an **Agent Activity** tab to the agent workspace/project settings that lets a user browse every room (conversation) an agent has run in and drill into a node-graph visualization of that room's agent runs, sub-agent runs, and tool calls.

## What changed

- **New tab**: "Agent Activity" added to the agent workspace panel (`agent-workspace.tsx`) and the project detail tabs (`project-detail-tabs.tsx`), restricted to `OWNER`, `EDIT`, and `READ_ONLY`. Also wired into `project.routes.tsx` under `agent-activity`.
- **Room list** (`agent-activity-page.tsx`): fetches `GetAgentActivityLog`, groups runs by room, and lists rooms most-recently-active first with run count and last-completed time.
- **Run graph** (`agent-run-graph.tsx`): clicking a room recursively loads its run tree (`GetAgentRun` + `GetSubagentRuns`, capped at depth 5) and renders it as a React Flow graph: room → agent runs → tool calls / nested sub-agent runs, edges color-coded by status (success/failed/running/tool). A side detail panel shows the transcript (input → thinking → text → tool calls/results → final answer) as a tree view, plus run metadata (run ID, room, model, harness, duration).
- **Cross-harness support** (`claude-code-transcript.ts`): `claude_code`-harness runs don't persist tool activity as room messages — that only exists in the room's Claude Code JSONL transcript. This adds a parser/merge step (`GetClaudeCodeTranscriptHistory`) that converts JSONL events into the same `TranscriptMessage` shape `GetAgentRun` returns for the `semoss` harness, narrowing by time window when a room hosts multiple runs, so both harnesses render identically in the graph and detail panel.
- **Model name resolution**: model engine IDs on runs are resolved to display names via `GetEngineMetadata`, cached per engine ID across room clicks.
- **Shared types** (`agent-activity-types.ts`): request/response shapes for activity log, run detail, subagent runs, and transcript messages/parts, plus small helpers (`toMs`, `formatRunDuration`, `isFailureStatus`, `isActiveStatus`, JSON parse helpers).


