### PR TITLE
Add Cache-Aware "Token + Cache" Usage Limit Type

### DIFF
--- a/libs/i18n/src/resources/locales/en/shared/members.json
+++ b/libs/i18n/src/resources/locales/en/shared/members.json
@@ -24,6 +24,7 @@
 		"usageLimitType": "Usage Limit Type",
 		"none": "None",
 		"token": "Token",
+		"tokenCache": "Token + Cache",
 		"computeTime": "Compute time",
 		"maxTokens": "Max Tokens",
 		"maxResponseTime": "Max Response Time",

--- a/libs/shared/src/components/members/add-members.tsx
+++ b/libs/shared/src/components/members/add-members.tsx
@@ -191,7 +191,8 @@ export const AddMembersOverlay = ({
 				...(restriction !== "null" && {
 					usageRestriction: restriction,
 				}),
-				...(restriction === "token" && {
+				...((restriction === "token" ||
+					restriction === "token_cache") && {
 					maxTokens: Number(maxTokens),
 				}),
 				...(restriction === "compute" && {

--- a/libs/shared/src/components/members/members-list.tsx
+++ b/libs/shared/src/components/members/members-list.tsx
@@ -81,6 +81,7 @@ const formatValue = (input?: string) => {
 	if (!input) return "—";
 	const mappings: Record<string, string> = {
 		TOKEN: "Token",
+		TOKEN_CACHE: "Token + Cache",
 		COMPUTE: "Compute time",
 		DAY: "Daily",
 		WEEK: "Weekly",
@@ -215,7 +216,11 @@ export const MembersList = ({
 			const r = user.usage_restriction;
 			if (r && r !== "null") {
 				payload.usageRestriction = r;
-				if (r.toUpperCase() === "TOKEN" && user.max_tokens != null)
+				if (
+					(r.toUpperCase() === "TOKEN" ||
+						r.toUpperCase() === "TOKEN_CACHE") &&
+					user.max_tokens != null
+				)
 					payload.maxTokens = user.max_tokens;
 				if (
 					r.toUpperCase() === "COMPUTE" &&
@@ -545,12 +550,15 @@ export const MembersList = ({
 										</TableCell>
 										{type === "MODEL" &&
 											(() => {
+												const restriction =
+													user.usage_restriction?.toUpperCase();
 												const limitValue =
-													user.usage_restriction?.toUpperCase() ===
-													"COMPUTE"
+													restriction === "COMPUTE"
 														? `${user.max_response_time?.toLocaleString() ?? "—"} ms`
-														: user.usage_restriction?.toUpperCase() ===
-																"TOKEN"
+														: restriction ===
+																	"TOKEN" ||
+																restriction ===
+																	"TOKEN_CACHE"
 															? (user.max_tokens?.toLocaleString() ??
 																"—")
 															: "—";

--- a/libs/shared/src/components/members/members-table.tsx
+++ b/libs/shared/src/components/members/members-table.tsx
@@ -133,7 +133,10 @@ export const MembersTable = ({
 			if (editRestriction !== "null") {
 				payload.usageRestriction = editRestriction;
 			}
-			if (editRestriction === "token") {
+			if (
+				editRestriction === "token" ||
+				editRestriction === "token_cache"
+			) {
 				payload.maxTokens = Number(editMaxTokens);
 			}
 			if (editRestriction === "compute") {
@@ -314,6 +317,9 @@ export const MembersTable = ({
 												<SelectItem value="token">
 													Token
 												</SelectItem>
+												<SelectItem value="token_cache">
+													Token + Cache
+												</SelectItem>
 												<SelectItem value="compute">
 													Compute time
 												</SelectItem>
@@ -321,7 +327,8 @@ export const MembersTable = ({
 										</Select>
 									</div>
 
-									{editRestriction === "token" && (
+									{(editRestriction === "token" ||
+										editRestriction === "token_cache") && (
 										<div className="flex flex-col gap-1.5">
 											<Label>Max Tokens</Label>
 											<Input

--- a/libs/shared/src/components/members/model-restriction-fields.tsx
+++ b/libs/shared/src/components/members/model-restriction-fields.tsx
@@ -79,13 +79,16 @@ export const ModelRestrictionFields = ({
 							<SelectItem value="token">
 								{t("restrictions.token")}
 							</SelectItem>
+							<SelectItem value="token_cache">
+								{t("restrictions.tokenCache")}
+							</SelectItem>
 							<SelectItem value="compute">
 								{t("restrictions.computeTime")}
 							</SelectItem>
 						</SelectContent>
 					</Select>
 				</div>
-				{restriction === "token" && (
+				{(restriction === "token" || restriction === "token_cache") && (
 					<div className="flex flex-col gap-1.5">
 						<Label>{t("restrictions.maxTokens")}</Label>
 						<Input

--- a/packages/client/src/components/engine/engine-metadata-display.tsx
+++ b/packages/client/src/components/engine/engine-metadata-display.tsx
@@ -27,6 +27,10 @@ export type ModelMetadata = {
 	contextWindow?: number | null;
 	maxInputTokens?: number | null;
 	maxOutputTokens?: number | null;
+	/** Percentage of a normal token a cache-read token counts as toward a member's token usage limit. */
+	cacheReadWeight?: number | null;
+	/** Percentage of a normal token a cache-write (creation) token counts as toward a member's token usage limit. */
+	cacheWriteWeight?: number | null;
 	builtinTools?: string[] | null;
 	family?: string | null;
 	attachment?: boolean | null;
@@ -606,6 +610,9 @@ export interface ModelSettingsValues {
 	/** Digits only; formatted with separators at render time. */
 	contextWindow: string;
 	maxOutputTokens: string;
+	/** Digits only, 0-1000. Empty means the 100% default applies. */
+	cacheReadWeight: string;
+	cacheWriteWeight: string;
 	builtinTools: string[];
 }
 
@@ -647,6 +654,16 @@ export const toModelSettingsValues = (
 			metadata?.maxOutputTokens !== null &&
 			metadata?.maxOutputTokens !== undefined
 				? String(metadata.maxOutputTokens)
+				: "",
+		cacheReadWeight:
+			metadata?.cacheReadWeight !== null &&
+			metadata?.cacheReadWeight !== undefined
+				? String(metadata.cacheReadWeight)
+				: "",
+		cacheWriteWeight:
+			metadata?.cacheWriteWeight !== null &&
+			metadata?.cacheWriteWeight !== undefined
+				? String(metadata.cacheWriteWeight)
 				: "",
 		builtinTools: normalizeStringArray(metadata?.builtinTools),
 	};
@@ -762,6 +779,17 @@ const TokenValue = ({ value }: { value: string }) =>
 	);
 
 /**
+ * Cache token weight as a percentage. Unlike token limits, an empty value is
+ * not "not set" - it is the 100% default, so it is shown rather than treated
+ * as missing.
+ */
+const WeightValue = ({ value }: { value: string }) => (
+	<span className="text-sm">
+		{value !== "" ? formatDigits(value) : "100"}%
+	</span>
+);
+
+/**
  * Read-only rendering of the model settings fields. Shared between the
  * Overview page (always read-only) and the Model Settings card (read mode)
  * so the two never drift apart.
@@ -855,6 +883,14 @@ export const ModelMetadataFields = ({
 
 		<SettingsEntry label="Max output tokens">
 			<TokenValue value={values.maxOutputTokens} />
+		</SettingsEntry>
+
+		<SettingsEntry label="Cache read weight">
+			<WeightValue value={values.cacheReadWeight} />
+		</SettingsEntry>
+
+		<SettingsEntry label="Cache write weight">
+			<WeightValue value={values.cacheWriteWeight} />
 		</SettingsEntry>
 	</>
 );

--- a/packages/client/src/components/engine/engine-model-settings.tsx
+++ b/packages/client/src/components/engine/engine-model-settings.tsx
@@ -88,6 +88,28 @@ const parseOptionalPositiveInteger = (label: string, value: string) => {
 };
 
 /**
+ * Cache weights are percentages, so unlike a token limit, 0 is a valid value
+ * (e.g. cache reads counting for nothing toward the limit). The 1000% ceiling
+ * matches the backend's validation in SecurityModelMetadataUtils.
+ */
+const parseOptionalWeightPercentage = (label: string, value: string) => {
+	if (value === "") {
+		return null;
+	}
+
+	if (!/^\d+$/.test(value)) {
+		throw new Error(`${label} must be a whole number.`);
+	}
+
+	const parsed = Number(value);
+	if (parsed > 1000) {
+		throw new Error(`${label} must be between 0 and 1000.`);
+	}
+
+	return parsed;
+};
+
+/**
  * Advisory note under a field. Purely informational - nothing is disabled and
  * saving is never blocked, since the catalog is hand-curated and a deployment
  * can legitimately differ from it.
@@ -148,6 +170,8 @@ export const EngineModelSettings = ({
 	const modelIdFieldId = `${fieldId}-model-id`;
 	const contextWindowFieldId = `${fieldId}-context-window`;
 	const maxOutputTokensFieldId = `${fieldId}-max-output-tokens`;
+	const cacheReadWeightFieldId = `${fieldId}-cache-read-weight`;
+	const cacheWriteWeightFieldId = `${fieldId}-cache-write-weight`;
 	const reasoningFieldId = `${fieldId}-reasoning`;
 
 	const [isSaving, setIsSaving] = useState(false);
@@ -355,6 +379,14 @@ export const EngineModelSettings = ({
 				MAX_TOKENS: parseOptionalPositiveInteger(
 					"Max output tokens",
 					form.maxOutputTokens,
+				),
+				CACHE_READ_WEIGHT: parseOptionalWeightPercentage(
+					"Cache read weight",
+					form.cacheReadWeight,
+				),
+				CACHE_WRITE_WEIGHT: parseOptionalWeightPercentage(
+					"Cache write weight",
+					form.cacheWriteWeight,
 				),
 				BUILTIN_TOOLS: normalizeStringArray(form.builtinTools),
 			};
@@ -787,6 +819,61 @@ export const EngineModelSettings = ({
 									message={maxOutputTokensWarning}
 									testId="engine-model-settings--max-output-tokens-warning"
 								/>
+							</Field>
+						</div>
+
+						<div className="grid gap-7 sm:grid-cols-2 sm:gap-4">
+							<Field>
+								<FieldLabel htmlFor={cacheReadWeightFieldId}>
+									Cache read weight
+								</FieldLabel>
+								<Input
+									id={cacheReadWeightFieldId}
+									type="text"
+									inputMode="numeric"
+									placeholder="e.g. 10"
+									value={formatDigits(form.cacheReadWeight)}
+									onChange={(event) =>
+										updateForm(
+											"cacheReadWeight",
+											event.target.value.replace(
+												/[^\d]/g,
+												"",
+											),
+										)
+									}
+								/>
+								<FieldDescription>
+									Percent of a normal token a cache-read token
+									counts as toward a member's token usage
+									limit. Blank uses 100%.
+								</FieldDescription>
+							</Field>
+							<Field>
+								<FieldLabel htmlFor={cacheWriteWeightFieldId}>
+									Cache write weight
+								</FieldLabel>
+								<Input
+									id={cacheWriteWeightFieldId}
+									type="text"
+									inputMode="numeric"
+									placeholder="e.g. 125"
+									value={formatDigits(form.cacheWriteWeight)}
+									onChange={(event) =>
+										updateForm(
+											"cacheWriteWeight",
+											event.target.value.replace(
+												/[^\d]/g,
+												"",
+											),
+										)
+									}
+								/>
+								<FieldDescription>
+									Percent of a normal token a cache-write
+									token counts as toward a member's token
+									usage limit. Blank uses 100%.
+								</FieldDescription>
 							</Field>
 						</div>
 

--- a/packages/client/src/components/settings/member-profile-form.tsx
+++ b/packages/client/src/components/settings/member-profile-form.tsx
@@ -37,6 +37,7 @@ interface ProfileForm {
 const RESTRICTION_LABELS: Record<string, string> = {
 	null: "None",
 	token: "Token",
+	token_cache: "Token + Cache",
 	compute: "Compute time",
 };
 
@@ -144,7 +145,8 @@ export const MemberProfileForm = ({
 				payload.model_usage_restriction = form.restriction;
 				payload.model_usage_frequency = form.frequency;
 				payload.model_max_tokens =
-					form.restriction === "token"
+					form.restriction === "token" ||
+					form.restriction === "token_cache"
 						? Number(form.maxTokens) || null
 						: null;
 				payload.model_max_response_time =
@@ -175,7 +177,8 @@ export const MemberProfileForm = ({
 							? undefined
 							: form.frequency,
 					model_max_tokens:
-						form.restriction === "token"
+						form.restriction === "token" ||
+						form.restriction === "token_cache"
 							? Number(form.maxTokens) || undefined
 							: undefined,
 					model_max_response_time:
@@ -343,7 +346,8 @@ export const MemberProfileForm = ({
 						</p>
 					) : (
 						<div className="grid grid-cols-2 gap-2.5">
-							{form.restriction === "token" ? (
+							{form.restriction === "token" ||
+							form.restriction === "token_cache" ? (
 								<Field label="Max Tokens">
 									<Input
 										type="number"

--- a/packages/client/src/components/settings/user-add-overlay.tsx
+++ b/packages/client/src/components/settings/user-add-overlay.tsx
@@ -184,6 +184,7 @@ export const UserAddOverlay = observer((props: UserAddOverlayProps) => {
 	const usageRestritctionTypes: Record<string, string> = {
 		null: "None",
 		token: "Token",
+		token_cache: "Token + Cache",
 		compute: "Compute time",
 	};
 	const frequencyTypes: Record<string, string> = {
@@ -214,7 +215,10 @@ export const UserAddOverlay = observer((props: UserAddOverlayProps) => {
 					  }
 					| null = null;
 
-				if (data.model_usage_restriction === "token") {
+				if (
+					data.model_usage_restriction === "token" ||
+					data.model_usage_restriction === "token_cache"
+				) {
 					data.model_max_response_time = null;
 				}
 				if (data.model_usage_restriction === "compute") {
@@ -671,7 +675,8 @@ export const UserAddOverlay = observer((props: UserAddOverlayProps) => {
 									);
 								}}
 							/>
-							{limitType === "token" && (
+							{(limitType === "token" ||
+								limitType === "token_cache") && (
 								<Controller
 									name="model_max_tokens"
 									control={control}


### PR DESCRIPTION
## Description
Adds a "Token + Cache" usage limit type so admins can restrict a member's model usage by a token budget that also counts cache read/creation tokens, weighted at a per-model percentage, instead of only plain prompt+completion tokens. Includes a new Cache read/write weight (%) config in Model Settings, backed by the backend's new CACHE_READ_WEIGHT/CACHE_WRITE_WEIGHT model metadata fields (see companion backend PR).

## Changes Made
1. engine-metadata-display.tsx: add cacheReadWeight/cacheWriteWeight to ModelMetadata/ModelSettingsValues, normalize on fetch, and render read-only in ModelMetadataFields

2. engine-model-settings.tsx: editable Cache read weight / Cache write weight inputs (0–1000%, blank = 100% default) next to Context window/Max output tokens, validated and included in the UpdateModelMetadata save payload

3. members-table.tsx (Edit Member modal), add-members.tsx / model-restriction-fields.tsx (Add Members), member-profile-form.tsx, user-add-overlay.tsx: add "Token + Cache" to the Usage Limit Type selector and extend the Max Tokens field's visibility/payload conditionals to include it (previously only "token" showed/sent Max Tokens)

4. members-list.tsx: recognize token_cache in the restriction label and Limit Value column (previously fell through to "—"), and carry max_tokens through on inline permission-only edits for this mode
libs/i18n/.../en/shared/members.json: add the tokenCache label ("Token + Cache")

## How to Test
1. Open a model's Settings page, set Cache read weight / Cache write weight (e.g. 10 / 200), Save, reload — values persist. Try a value over 1000 — should be rejected.
2. In that model's Access Control, open Edit Member for a user and confirm "Token + Cache" now appears in the Usage Limit Type dropdown, and selecting it reveals the Max Tokens field (same as plain "Token").
3. Set it to Token + Cache with a Max Tokens value, Save — reopen the modal and confirm it re-loads correctly, and check the members table shows "Token + Cache" in the restriction column with the correct Limit Value.
4. Repeat step 2–3 via the Add Members overlay's Model Limit Restrictions section, and via the org-level member profile form / Add User overlay — all four surfaces should offer and persist the same option consistently.
5. Confirm existing plain Token and Compute time flows are unaffected (regression check).

## Notes
1. This is UI/config plumbing only — actual enforcement (throwing when a member exceeds a Token + Cache limit) lives in the backend PR. This PR alone lets you configure and persist the setting; pair it with the backend PR to see it enforced live.

2. The Usage Limit Type dropdown is duplicated across 4 components (members-table.tsx, add-members.tsx/model-restriction-fields.tsx, member-profile-form.tsx, user-add-overlay.tsx) with independently-maintained label maps — already a pre-existing drift risk (e.g. label capitalization already differed slightly between two of them before this PR). Worth consolidating into one shared constant/component in a follow-up rather than continuing to add new options in four places.