### PR TITLE
Model Built-in Tools: provider-aware selection on engine settings & model import

### DIFF
--- a/packages/client/src/components/engine/engine-builtin-tools-field.tsx
+++ b/packages/client/src/components/engine/engine-builtin-tools-field.tsx
@@ -1,0 +1,489 @@
+import { useId, useState } from "react";
+import {
+	Badge,
+	Input,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	Switch,
+	Textarea,
+	ToggleGroup,
+	ToggleGroupItem,
+} from "@semoss/ui/next";
+import { CatalogTagInput } from "@/components/catalog";
+import type {
+	BuiltinToolDefinition,
+	BuiltinToolParam,
+	BuiltinToolSelection,
+} from "./engine-metadata-display";
+
+/** Shape returned by the GetModelBuiltinTools pixel. */
+export interface ModelBuiltinTools {
+	engineId?: string;
+	modelId?: string;
+	modelProvider?: string;
+	servingProvider?: string;
+	tools?: Record<string, BuiltinToolDefinition>;
+	selected?: Record<string, BuiltinToolSelection> | string[];
+}
+
+/**
+ * The selection written when a tool is switched on: the catalog definition
+ * copied verbatim, so whatever later reads the stored JSON knows the tool's
+ * options, defaults, and display names without a second catalog lookup.
+ * Parameters only gain a `value` once the user changes them.
+ */
+const buildDefaultSelection = (
+	definition: BuiltinToolDefinition,
+): BuiltinToolSelection => ({
+	...definition,
+	params: (definition.params ?? []).map((param) => ({ ...param })),
+});
+
+/**
+ * The selection shown before any edit when only the legacy name list is
+ * stored: names the catalog knows get their defaults, the rest carry no
+ * configuration. Nothing is saved until the user actually edits.
+ */
+const seedSelection = (
+	tools: Record<string, BuiltinToolDefinition>,
+	legacyNames: string[],
+): Record<string, BuiltinToolSelection> => {
+	const seeded: Record<string, BuiltinToolSelection> = {};
+	for (const name of legacyNames) {
+		seeded[name] = tools[name] ? buildDefaultSelection(tools[name]) : {};
+	}
+	return seeded;
+};
+
+interface EngineBuiltinToolsFieldProps {
+	/** Catalog tools offered for this engine's providers, keyed by tool name */
+	tools: Record<string, BuiltinToolDefinition>;
+
+	/** Stored selection; null when only the legacy name list exists */
+	value: Record<string, BuiltinToolSelection> | null;
+
+	/** Legacy tool names used to seed the selection when no config is stored */
+	legacyNames: string[];
+
+	/** Called with the full selection object on every edit */
+	onChange: (next: Record<string, BuiltinToolSelection>) => void;
+
+	/** Test id prefix; each tool switch gets `${testId}--${toolKey}` */
+	testId: string;
+}
+
+/**
+ * Selectable list of the provider-hosted built-in tools a model can use, with
+ * per-tool parameter editors driven by the catalog's parameter schemas. The
+ * selection is reported as the keyed JSON object stored in BUILTIN_TOOLS.
+ */
+export const EngineBuiltinToolsField = ({
+	tools,
+	value,
+	legacyNames,
+	onChange,
+	testId,
+}: EngineBuiltinToolsFieldProps) => {
+	const selection = value ?? seedSelection(tools, legacyNames);
+
+	/**
+	 * Rebuild the selection with catalog tools in catalog order, so the same
+	 * choices always serialize identically for the parent's dirty check.
+	 */
+	const orderSelection = (next: Record<string, BuiltinToolSelection>) => {
+		const ordered: Record<string, BuiltinToolSelection> = {};
+		for (const toolKey of Object.keys(tools)) {
+			if (toolKey in next) {
+				ordered[toolKey] = next[toolKey];
+			}
+		}
+		for (const toolKey of Object.keys(next)) {
+			if (!(toolKey in ordered)) {
+				ordered[toolKey] = next[toolKey];
+			}
+		}
+		return ordered;
+	};
+
+	const toggleTool = (toolKey: string, enabled: boolean) => {
+		const next = { ...selection };
+		if (enabled) {
+			next[toolKey] = tools[toolKey]
+				? buildDefaultSelection(tools[toolKey])
+				: {};
+		} else {
+			delete next[toolKey];
+		}
+		onChange(orderSelection(next));
+	};
+
+	/**
+	 * Set (or clear, with undefined) one parameter's value. The stored tool
+	 * is rewritten from the current catalog definition each time, so a copy
+	 * saved against an older catalog picks up fresh metadata on edit.
+	 */
+	const updateParam = (
+		toolKey: string,
+		paramAlias: string,
+		paramValue: unknown,
+	) => {
+		const definition = tools[toolKey];
+		if (!definition) {
+			return;
+		}
+		const stored = selection[toolKey];
+		const params = (definition.params ?? []).map((param) => {
+			const value =
+				param.alias === paramAlias
+					? paramValue
+					: stored?.params?.find(
+							(storedParam) => storedParam.alias === param.alias,
+						)?.value;
+			return value === undefined ? { ...param } : { ...param, value };
+		});
+		onChange(
+			orderSelection({
+				...selection,
+				[toolKey]: { ...definition, params },
+			}),
+		);
+	};
+
+	/**
+	 * The value a parameter editor shows: the stored value when the user set
+	 * one, the catalog default otherwise.
+	 */
+	const currentParamValue = (toolKey: string, param: BuiltinToolParam) => {
+		const storedValue = selection[toolKey]?.params?.find(
+			(storedParam) => storedParam.alias === param.alias,
+		)?.value;
+		return storedValue !== undefined ? storedValue : param.default;
+	};
+
+	// Tools saved on the model that its provider no longer offers. They stay
+	// visible so they can be switched off, but expose nothing to configure.
+	const unknownSelectedKeys = Object.keys(selection).filter(
+		(toolKey) => !tools[toolKey],
+	);
+
+	return (
+		<div className="flex flex-col gap-2" data-testid={testId}>
+			{Object.entries(tools).map(([toolKey, definition]) => {
+				const isSelected = toolKey in selection;
+				const uiParams = (definition.params ?? []).filter(
+					(param) => param.show_in_ui !== false,
+				);
+
+				return (
+					<div key={toolKey} className="rounded-md border">
+						<div className="flex items-start justify-between gap-4 p-3">
+							<div className="flex flex-col gap-1">
+								<div className="flex flex-wrap items-center gap-2">
+									<span className="font-medium text-sm">
+										{definition.display_name || toolKey}
+									</span>
+									<Badge
+										variant="outline"
+										className="font-mono text-xs"
+									>
+										{definition.alias}
+									</Badge>
+								</div>
+								{definition.description && (
+									<p className="text-muted-foreground text-xs">
+										{definition.description}
+									</p>
+								)}
+							</div>
+							<Switch
+								checked={isSelected}
+								onCheckedChange={(checked) =>
+									toggleTool(toolKey, checked)
+								}
+								data-testid={`${testId}--${toolKey}`}
+							/>
+						</div>
+
+						{isSelected && uiParams.length > 0 && (
+							<div className="flex flex-col gap-4 border-t p-3">
+								{uiParams.map((param) => (
+									<BuiltinToolParamInput
+										key={param.alias}
+										param={param}
+										value={currentParamValue(
+											toolKey,
+											param,
+										)}
+										onCommit={(paramValue) =>
+											updateParam(
+												toolKey,
+												param.alias,
+												paramValue,
+											)
+										}
+										testId={`${testId}--${toolKey}--${param.alias}`}
+									/>
+								))}
+							</div>
+						)}
+					</div>
+				);
+			})}
+
+			{unknownSelectedKeys.map((toolKey) => (
+				<div
+					key={toolKey}
+					className="flex items-center justify-between gap-4 rounded-md border border-dashed p-3"
+				>
+					<div className="flex flex-col gap-1">
+						<span className="font-mono text-sm">{toolKey}</span>
+						<p className="text-muted-foreground text-xs">
+							Saved on this model but not offered for its
+							provider. Switch off to remove it.
+						</p>
+					</div>
+					<Switch
+						checked
+						onCheckedChange={() => toggleTool(toolKey, false)}
+						data-testid={`${testId}--${toolKey}`}
+					/>
+				</div>
+			))}
+		</div>
+	);
+};
+
+/** Shared label + description shell for a single parameter editor. */
+const ParamShell = ({
+	param,
+	control,
+	inline,
+}: {
+	param: BuiltinToolParam;
+	control: React.ReactNode;
+	/** Render the control on the label row (switches) instead of below it. */
+	inline?: boolean;
+}) => (
+	<div className="flex flex-col gap-1.5">
+		<div
+			className={
+				inline ? "flex items-center justify-between gap-4" : undefined
+			}
+		>
+			<span className="font-medium text-muted-foreground text-xs">
+				{param.display_name || param.alias}
+				{param.type === "required" && (
+					<span className="text-destructive"> *</span>
+				)}
+			</span>
+			{inline && control}
+		</div>
+		{!inline && control}
+	</div>
+);
+
+/**
+ * Editor for one tool parameter, shaped by the catalog's `input` kind:
+ * switches for booleans, selects and toggle groups where the options are
+ * enumerated, tags for free lists, and raw JSON for maps.
+ */
+const BuiltinToolParamInput = ({
+	param,
+	value,
+	onCommit,
+	testId,
+}: {
+	param: BuiltinToolParam;
+	value: unknown;
+	onCommit: (value: unknown) => void;
+	testId: string;
+}) => {
+	const inputId = useId();
+	// Raw text being edited for a JSON parameter. Committed once it parses;
+	// kept as typed so invalid intermediate states are not thrown away.
+	const [jsonDraft, setJsonDraft] = useState<string | null>(null);
+
+	const options = (param.options ?? []).map((option) => String(option));
+
+	if (param.input === "boolean") {
+		return (
+			<ParamShell
+				param={param}
+				inline
+				control={
+					<Switch
+						checked={value === true}
+						onCheckedChange={(checked) => onCommit(checked)}
+						data-testid={testId}
+					/>
+				}
+			/>
+		);
+	}
+
+	if (param.input === "number") {
+		return (
+			<ParamShell
+				param={param}
+				control={
+					<Input
+						id={inputId}
+						type="text"
+						inputMode="numeric"
+						value={
+							value === undefined || value === null
+								? ""
+								: String(value)
+						}
+						onChange={(event) => {
+							const digits = event.target.value.replace(
+								/[^\d]/g,
+								"",
+							);
+							onCommit(
+								digits === "" ? undefined : Number(digits),
+							);
+						}}
+						data-testid={testId}
+					/>
+				}
+			/>
+		);
+	}
+
+	if (param.input === "list") {
+		const values = Array.isArray(value) ? value.map(String) : [];
+
+		if (options.length > 0) {
+			return (
+				<ParamShell
+					param={param}
+					control={
+						<ToggleGroup
+							type="multiple"
+							variant="outline"
+							size="sm"
+							spacing={2}
+							className="flex-wrap"
+							value={values}
+							onValueChange={(next) => onCommit(next)}
+							data-testid={testId}
+						>
+							{options.map((option) => (
+								<ToggleGroupItem key={option} value={option}>
+									{option}
+								</ToggleGroupItem>
+							))}
+						</ToggleGroup>
+					}
+				/>
+			);
+		}
+
+		return (
+			<ParamShell
+				param={param}
+				control={
+					<CatalogTagInput
+						value={values}
+						onChange={(next) => onCommit(next)}
+						placeholder="Press enter to add a value"
+						testId={testId}
+					/>
+				}
+			/>
+		);
+	}
+
+	if (param.input === "string" && options.length > 0) {
+		return (
+			<ParamShell
+				param={param}
+				control={
+					<Select
+						value={typeof value === "string" ? value : ""}
+						onValueChange={(next) => onCommit(next)}
+					>
+						<SelectTrigger className="w-full" data-testid={testId}>
+							<SelectValue placeholder="Select a value" />
+						</SelectTrigger>
+						<SelectContent>
+							{options.map((option) => (
+								<SelectItem key={option} value={option}>
+									{option}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				}
+			/>
+		);
+	}
+
+	if (param.input === "string") {
+		return (
+			<ParamShell
+				param={param}
+				control={
+					<Input
+						id={inputId}
+						type="text"
+						value={typeof value === "string" ? value : ""}
+						onChange={(event) => {
+							const next = event.target.value;
+							onCommit(next === "" ? undefined : next);
+						}}
+						data-testid={testId}
+					/>
+				}
+			/>
+		);
+	}
+
+	// "map" and anything unrecognized edit as raw JSON.
+	const committedText = JSON.stringify(value ?? {}, null, 2);
+	const text = jsonDraft ?? committedText;
+	let isInvalid = false;
+	if (jsonDraft !== null) {
+		try {
+			JSON.parse(jsonDraft);
+		} catch {
+			isInvalid = true;
+		}
+	}
+
+	return (
+		<ParamShell
+			param={param}
+			control={
+				<div className="flex flex-col gap-1">
+					<Textarea
+						value={text}
+						rows={4}
+						className="font-mono text-xs"
+						onChange={(event) => {
+							const nextText = event.target.value;
+							setJsonDraft(nextText);
+							try {
+								onCommit(JSON.parse(nextText));
+							} catch {
+								// keep typing - the draft is committed once
+								// it parses
+							}
+						}}
+						data-testid={testId}
+					/>
+					{isInvalid && (
+						<p className="text-destructive text-xs">
+							Not valid JSON. The last valid value is what gets
+							saved.
+						</p>
+					)}
+				</div>
+			}
+		/>
+	);
+};

--- a/packages/client/src/components/engine/engine-builtin-tools-field.tsx
+++ b/packages/client/src/components/engine/engine-builtin-tools-field.tsx
@@ -26,7 +26,7 @@ export interface ModelBuiltinTools {
 	modelProvider?: string;
 	servingProvider?: string;
 	tools?: Record<string, BuiltinToolDefinition>;
-	selected?: Record<string, BuiltinToolSelection> | string[];
+	selected?: Record<string, BuiltinToolSelection>;
 }
 
 /**
@@ -42,31 +42,12 @@ const buildDefaultSelection = (
 	params: (definition.params ?? []).map((param) => ({ ...param })),
 });
 
-/**
- * The selection shown before any edit when only the legacy name list is
- * stored: names the catalog knows get their defaults, the rest carry no
- * configuration. Nothing is saved until the user actually edits.
- */
-const seedSelection = (
-	tools: Record<string, BuiltinToolDefinition>,
-	legacyNames: string[],
-): Record<string, BuiltinToolSelection> => {
-	const seeded: Record<string, BuiltinToolSelection> = {};
-	for (const name of legacyNames) {
-		seeded[name] = tools[name] ? buildDefaultSelection(tools[name]) : {};
-	}
-	return seeded;
-};
-
 interface EngineBuiltinToolsFieldProps {
 	/** Catalog tools offered for this engine's providers, keyed by tool name */
 	tools: Record<string, BuiltinToolDefinition>;
 
-	/** Stored selection; null when only the legacy name list exists */
+	/** Stored selection; null when nothing has been saved yet */
 	value: Record<string, BuiltinToolSelection> | null;
-
-	/** Legacy tool names used to seed the selection when no config is stored */
-	legacyNames: string[];
 
 	/** Called with the full selection object on every edit */
 	onChange: (next: Record<string, BuiltinToolSelection>) => void;
@@ -83,11 +64,10 @@ interface EngineBuiltinToolsFieldProps {
 export const EngineBuiltinToolsField = ({
 	tools,
 	value,
-	legacyNames,
 	onChange,
 	testId,
 }: EngineBuiltinToolsFieldProps) => {
-	const selection = value ?? seedSelection(tools, legacyNames);
+	const selection = value ?? {};
 
 	/**
 	 * Rebuild the selection with catalog tools in catalog order, so the same

--- a/packages/client/src/components/engine/engine-metadata-display.tsx
+++ b/packages/client/src/components/engine/engine-metadata-display.tsx
@@ -52,8 +52,7 @@ export interface BuiltinToolDefinition {
  * Stored selection for one provider built-in tool: the catalog definition
  * copied as-is, with a `value` on any parameter the user changed from its
  * default. Kept catalog-shaped on purpose, so whatever reads the stored
- * JSON can render the tool's options without a second catalog lookup. All
- * fields are optional because a legacy name-list entry stores nothing.
+ * JSON can render the tool's options without a second catalog lookup.
  */
 export interface BuiltinToolSelection {
 	alias?: string;
@@ -73,8 +72,8 @@ export type ModelMetadata = {
 	contextWindow?: number | null;
 	maxInputTokens?: number | null;
 	maxOutputTokens?: number | null;
-	/** Legacy flat name list, or the keyed selection object. */
-	builtinTools?: string[] | Record<string, BuiltinToolSelection> | null;
+	/** Selected built-in tools, keyed by canonical tool name. */
+	builtinTools?: Record<string, BuiltinToolSelection> | null;
 	family?: string | null;
 	attachment?: boolean | null;
 	reasoning?: boolean | null;
@@ -506,28 +505,6 @@ export const normalizeStringArray = (value: unknown): string[] => {
 };
 
 /**
- * Tool names from either stored built-in tools shape - the legacy flat list
- * or the keyed selection object.
- */
-export const normalizeBuiltinToolNames = (value: unknown): string[] => {
-	if (value && typeof value === "object" && !Array.isArray(value)) {
-		return Object.keys(value);
-	}
-	return normalizeStringArray(value);
-};
-
-/**
- * The stored selection object, or null when the legacy name list (or
- * nothing) is stored.
- */
-export const toBuiltinToolsConfig = (
-	value: unknown,
-): Record<string, BuiltinToolSelection> | null =>
-	value && typeof value === "object" && !Array.isArray(value)
-		? (value as Record<string, BuiltinToolSelection>)
-		: null;
-
-/**
  * Format a catalog date ("2026-04-23") for display. Parsed in local time on
  * purpose: these are calendar dates, not instants, so a UTC->local conversion
  * would shift them a day backwards for western timezones.
@@ -723,8 +700,8 @@ export const toModelSettingsValues = (
 			metadata?.maxOutputTokens !== undefined
 				? String(metadata.maxOutputTokens)
 				: "",
-		builtinTools: normalizeBuiltinToolNames(metadata?.builtinTools),
-		builtinToolsConfig: toBuiltinToolsConfig(metadata?.builtinTools),
+		builtinTools: Object.keys(metadata?.builtinTools ?? {}),
+		builtinToolsConfig: metadata?.builtinTools ?? null,
 	};
 };
 

--- a/packages/client/src/components/engine/engine-metadata-display.tsx
+++ b/packages/client/src/components/engine/engine-metadata-display.tsx
@@ -17,6 +17,52 @@ import {
 	TableRow,
 } from "@semoss/ui/next";
 
+/**
+ * One configurable parameter of a provider built-in tool, as written in the
+ * meta/builtin-tools.json catalog. Unknown keys pass through untouched.
+ */
+export interface BuiltinToolParam {
+	alias: string;
+	display_name?: string;
+	type?: "required" | "optional";
+	input?: "string" | "number" | "boolean" | "list" | "map";
+	options?: (string | number | boolean)[];
+	default?: unknown;
+	show_in_ui?: boolean;
+	/** The user's chosen value; the catalog `default` applies when absent. */
+	value?: unknown;
+	[key: string]: unknown;
+}
+
+/**
+ * One provider built-in tool from the meta/builtin-tools.json catalog.
+ * Unknown keys pass through untouched, which also makes a definition
+ * directly storable as a {@link BuiltinToolSelection}.
+ */
+export interface BuiltinToolDefinition {
+	alias: string;
+	display_name?: string;
+	description?: string;
+	params?: BuiltinToolParam[];
+	constraints?: { api?: string; models?: string[]; regions?: string[] };
+	[key: string]: unknown;
+}
+
+/**
+ * Stored selection for one provider built-in tool: the catalog definition
+ * copied as-is, with a `value` on any parameter the user changed from its
+ * default. Kept catalog-shaped on purpose, so whatever reads the stored
+ * JSON can render the tool's options without a second catalog lookup. All
+ * fields are optional because a legacy name-list entry stores nothing.
+ */
+export interface BuiltinToolSelection {
+	alias?: string;
+	display_name?: string;
+	description?: string;
+	params?: BuiltinToolParam[];
+	[key: string]: unknown;
+}
+
 /** Shape returned by the GetModelMetadata pixel. */
 export type ModelMetadata = {
 	engineId?: string;
@@ -27,7 +73,8 @@ export type ModelMetadata = {
 	contextWindow?: number | null;
 	maxInputTokens?: number | null;
 	maxOutputTokens?: number | null;
-	builtinTools?: string[] | null;
+	/** Legacy flat name list, or the keyed selection object. */
+	builtinTools?: string[] | Record<string, BuiltinToolSelection> | null;
 	family?: string | null;
 	attachment?: boolean | null;
 	reasoning?: boolean | null;
@@ -459,6 +506,28 @@ export const normalizeStringArray = (value: unknown): string[] => {
 };
 
 /**
+ * Tool names from either stored built-in tools shape - the legacy flat list
+ * or the keyed selection object.
+ */
+export const normalizeBuiltinToolNames = (value: unknown): string[] => {
+	if (value && typeof value === "object" && !Array.isArray(value)) {
+		return Object.keys(value);
+	}
+	return normalizeStringArray(value);
+};
+
+/**
+ * The stored selection object, or null when the legacy name list (or
+ * nothing) is stored.
+ */
+export const toBuiltinToolsConfig = (
+	value: unknown,
+): Record<string, BuiltinToolSelection> | null =>
+	value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, BuiltinToolSelection>)
+		: null;
+
+/**
  * Format a catalog date ("2026-04-23") for display. Parsed in local time on
  * purpose: these are calendar dates, not instants, so a UTC->local conversion
  * would shift them a day backwards for western timezones.
@@ -607,6 +676,12 @@ export interface ModelSettingsValues {
 	contextWindow: string;
 	maxOutputTokens: string;
 	builtinTools: string[];
+	/**
+	 * Keyed tool selection when the stored value carries configurations;
+	 * null for the legacy name list, which keeps `builtinTools` above
+	 * authoritative for display.
+	 */
+	builtinToolsConfig: Record<string, BuiltinToolSelection> | null;
 }
 
 /**
@@ -648,7 +723,8 @@ export const toModelSettingsValues = (
 			metadata?.maxOutputTokens !== undefined
 				? String(metadata.maxOutputTokens)
 				: "",
-		builtinTools: normalizeStringArray(metadata?.builtinTools),
+		builtinTools: normalizeBuiltinToolNames(metadata?.builtinTools),
+		builtinToolsConfig: toBuiltinToolsConfig(metadata?.builtinTools),
 	};
 };
 

--- a/packages/client/src/components/engine/engine-model-settings.tsx
+++ b/packages/client/src/components/engine/engine-model-settings.tsx
@@ -30,6 +30,10 @@ import {
 import { CatalogTagInput } from "@/components/catalog";
 import { useRootStore } from "@/hooks";
 import {
+	EngineBuiltinToolsField,
+	type ModelBuiltinTools,
+} from "./engine-builtin-tools-field";
+import {
 	buildReasoningConfigPayload,
 	CAPABILITIES,
 	formatDigits,
@@ -151,6 +155,7 @@ export const EngineModelSettings = ({
 	const reasoningFieldId = `${fieldId}-reasoning`;
 
 	const [isSaving, setIsSaving] = useState(false);
+	const [discardRevision, setDiscardRevision] = useState(0);
 	const [form, setForm] = useState<ModelSettingsValues>(
 		toModelSettingsValues(undefined),
 	);
@@ -242,6 +247,19 @@ export const EngineModelSettings = ({
 		getStaticModelMetadata.status === "SUCCESS" &&
 		!hasCatalogEntry(getStaticModelMetadata.data);
 
+	// Provider-hosted tools this engine's model can use, resolved from the
+	// built-in tools catalog by its serving and model providers. Optional
+	// data - no catalog entry or a failed call just leaves the free-text
+	// editor in place.
+	const getModelBuiltinTools = usePixel<ModelBuiltinTools>(
+		isEditable ? `GetModelBuiltinTools(engine=["${engineId}"]);` : "",
+	);
+	const builtinToolsCatalog =
+		getModelBuiltinTools.status === "SUCCESS"
+			? (getModelBuiltinTools.data?.tools ?? {})
+			: {};
+	const hasBuiltinToolsCatalog = Object.keys(builtinToolsCatalog).length > 0;
+
 	// The stored config drives the effort fields. It is kept whole so unedited
 	// provider keys survive the save.
 	const reasoningConfig = useMemo(
@@ -318,10 +336,24 @@ export const EngineModelSettings = ({
 	};
 
 	/**
-	 * Drop any unsaved edits and go back to the persisted values.
+	 * Whether the built-in tools selection differs from the persisted values,
+	 * across both the legacy name list and the keyed configuration.
+	 */
+	const isBuiltinToolsDirty = () =>
+		JSON.stringify([form.builtinTools, form.builtinToolsConfig]) !==
+		JSON.stringify([
+			initialForm.builtinTools,
+			initialForm.builtinToolsConfig,
+		]);
+
+	/**
+	 * Drop any unsaved edits and go back to the persisted values. The
+	 * revision bump remounts the built-in tools editor, which holds raw JSON
+	 * drafts that would otherwise survive the reset.
 	 */
 	const handleDiscard = () => {
 		setForm(initialForm);
+		setDiscardRevision((revision) => revision + 1);
 	};
 
 	/**
@@ -356,7 +388,17 @@ export const EngineModelSettings = ({
 					"Max output tokens",
 					form.maxOutputTokens,
 				),
-				BUILTIN_TOOLS: normalizeStringArray(form.builtinTools),
+				// Only sent when edited: the update merges, and rewriting an
+				// untouched selection could downgrade a stored configuration
+				// to a bare name list while the tool catalog is still
+				// loading.
+				...(isBuiltinToolsDirty()
+					? {
+							BUILTIN_TOOLS: hasBuiltinToolsCatalog
+								? (form.builtinToolsConfig ?? {})
+								: normalizeStringArray(form.builtinTools),
+						}
+					: {}),
 			};
 
 			const response = await configStore.runPixel(
@@ -792,17 +834,38 @@ export const EngineModelSettings = ({
 
 						<Field>
 							<FieldLabel>Built-in tools</FieldLabel>
-							<CatalogTagInput
-								value={form.builtinTools}
-								onChange={(value) =>
-									updateForm("builtinTools", value)
-								}
-								placeholder="Press enter to add a tool"
-								testId="engine-model-settings--builtin-tools"
-							/>
+							{hasBuiltinToolsCatalog ? (
+								<EngineBuiltinToolsField
+									key={`builtin-tools-${discardRevision}`}
+									tools={builtinToolsCatalog}
+									value={form.builtinToolsConfig}
+									legacyNames={form.builtinTools}
+									onChange={(next) =>
+										// The name list shadows the selection
+										// keys so read mode and the dirty
+										// check stay coherent.
+										setForm((prev) => ({
+											...prev,
+											builtinToolsConfig: next,
+											builtinTools: Object.keys(next),
+										}))
+									}
+									testId="engine-model-settings--builtin-tools"
+								/>
+							) : (
+								<CatalogTagInput
+									value={form.builtinTools}
+									onChange={(value) =>
+										updateForm("builtinTools", value)
+									}
+									placeholder="Press enter to add a tool"
+									testId="engine-model-settings--builtin-tools"
+								/>
+							)}
 							<FieldDescription>
-								Provider-hosted tools the model can call
-								natively.
+								{hasBuiltinToolsCatalog
+									? "Provider-hosted tools this model can call natively. Selections and their settings are saved with the model."
+									: "Provider-hosted tools the model can call natively."}
 							</FieldDescription>
 						</Field>
 					</FieldGroup>

--- a/packages/client/src/components/engine/engine-model-settings.tsx
+++ b/packages/client/src/components/engine/engine-model-settings.tsx
@@ -27,7 +27,6 @@ import {
 	ToggleGroupItem,
 	toast,
 } from "@semoss/ui/next";
-import { CatalogTagInput } from "@/components/catalog";
 import { useRootStore } from "@/hooks";
 import {
 	EngineBuiltinToolsField,
@@ -336,15 +335,11 @@ export const EngineModelSettings = ({
 	};
 
 	/**
-	 * Whether the built-in tools selection differs from the persisted values,
-	 * across both the legacy name list and the keyed configuration.
+	 * Whether the built-in tools selection differs from the persisted value.
 	 */
 	const isBuiltinToolsDirty = () =>
-		JSON.stringify([form.builtinTools, form.builtinToolsConfig]) !==
-		JSON.stringify([
-			initialForm.builtinTools,
-			initialForm.builtinToolsConfig,
-		]);
+		JSON.stringify(form.builtinToolsConfig) !==
+		JSON.stringify(initialForm.builtinToolsConfig);
 
 	/**
 	 * Drop any unsaved edits and go back to the persisted values. The
@@ -393,11 +388,7 @@ export const EngineModelSettings = ({
 				// to a bare name list while the tool catalog is still
 				// loading.
 				...(isBuiltinToolsDirty()
-					? {
-							BUILTIN_TOOLS: hasBuiltinToolsCatalog
-								? (form.builtinToolsConfig ?? {})
-								: normalizeStringArray(form.builtinTools),
-						}
+					? { BUILTIN_TOOLS: form.builtinToolsConfig ?? {} }
 					: {}),
 			};
 
@@ -834,16 +825,22 @@ export const EngineModelSettings = ({
 
 						<Field>
 							<FieldLabel>Built-in tools</FieldLabel>
-							{hasBuiltinToolsCatalog ? (
+							{/*
+							 * A stored selection stays editable even when the
+							 * catalog has nothing to offer, so it can still
+							 * be switched off.
+							 */}
+							{hasBuiltinToolsCatalog ||
+							Object.keys(form.builtinToolsConfig ?? {}).length >
+								0 ? (
 								<EngineBuiltinToolsField
 									key={`builtin-tools-${discardRevision}`}
 									tools={builtinToolsCatalog}
 									value={form.builtinToolsConfig}
-									legacyNames={form.builtinTools}
 									onChange={(next) =>
-										// The name list shadows the selection
-										// keys so read mode and the dirty
-										// check stay coherent.
+										// Read mode renders names, so keep
+										// them in step with the selection
+										// keys.
 										setForm((prev) => ({
 											...prev,
 											builtinToolsConfig: next,
@@ -853,19 +850,19 @@ export const EngineModelSettings = ({
 									testId="engine-model-settings--builtin-tools"
 								/>
 							) : (
-								<CatalogTagInput
-									value={form.builtinTools}
-									onChange={(value) =>
-										updateForm("builtinTools", value)
-									}
-									placeholder="Press enter to add a tool"
-									testId="engine-model-settings--builtin-tools"
-								/>
+								<p
+									className="text-muted-foreground text-sm"
+									data-testid="engine-model-settings--builtin-tools-empty"
+								>
+									{getModelBuiltinTools.status === "SUCCESS"
+										? "No provider-hosted tools are available for this model."
+										: "Checking for provider-hosted tools..."}
+								</p>
 							)}
 							<FieldDescription>
-								{hasBuiltinToolsCatalog
-									? "Provider-hosted tools this model can call natively. Selections and their settings are saved with the model."
-									: "Provider-hosted tools the model can call natively."}
+								Provider-hosted tools this model can call
+								natively. Selections and their settings are
+								saved with the model.
 							</FieldDescription>
 						</Field>
 					</FieldGroup>

--- a/packages/client/src/components/engine/index.ts
+++ b/packages/client/src/components/engine/index.ts
@@ -1,4 +1,5 @@
 export * from "./engine-access-button";
+export * from "./engine-builtin-tools-field";
 export * from "./engine-description-settings";
 export * from "./engine-export-button";
 export * from "./engine-grid-item";

--- a/packages/client/src/components/import/model/model-import-form.tsx
+++ b/packages/client/src/components/import/model/model-import-form.tsx
@@ -2,8 +2,9 @@
 /** biome-ignore-all lint/a11y/noStaticElementInteractions: legacy click handlers */
 
 import { ChevronDown, ChevronUp, TriangleAlert, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Controller, useForm, useWatch } from "react-hook-form";
+import { usePixel } from "@semoss/sdk/react";
 import {
 	Button,
 	Checkbox,
@@ -28,6 +29,12 @@ import {
 	toast,
 } from "@semoss/ui/next";
 import { uploadFile } from "@/api";
+import { CatalogTagInput } from "@/components/catalog";
+import {
+	EngineBuiltinToolsField,
+	type ModelBuiltinTools,
+} from "@/components/engine/engine-builtin-tools-field";
+import type { BuiltinToolSelection } from "@/components/engine/engine-metadata-display";
 import { useRootStore, useStepper } from "@/hooks";
 import { useNavigate } from "@/hooks/useNavigate";
 import { formatToDataTestId } from "@/utility";
@@ -117,7 +124,13 @@ const getModelFieldTestId = (
 const getDefaultFieldValue = (field: FieldDefinition) =>
 	field.default ??
 	field.value ??
-	(field.type === "boolean" ? false : field.type === "multiselect" ? [] : "");
+	(field.type === "boolean"
+		? false
+		: field.type === "multiselect"
+			? []
+			: field.type === "builtin-tools"
+				? null
+				: "");
 
 export const hasSelectedMultiselectValue = (value: unknown) =>
 	Array.isArray(value) && value.length > 0;
@@ -194,6 +207,73 @@ export const ModelImportForm = (props: ModelImportFormProps) => {
 
 		reset(defaults, { keepDirtyValues: true, keepErrors: true });
 	}, [fields, advanced, reset]);
+
+	// The provider pair drives which built-in tools the catalog can offer.
+	// Both selects are user-editable, so the live form values are what count.
+	const [watchedServingProvider, watchedModelProvider, watchedModelId] =
+		useWatch({
+			control,
+			name: ["SERVING_PROVIDER", "MODEL_PROVIDER", "MODEL"],
+		});
+
+	// Let a typed model id settle before asking the catalog about it.
+	const [settledModelId, setSettledModelId] = useState("");
+	useEffect(() => {
+		const modelId =
+			typeof watchedModelId === "string" ? watchedModelId.trim() : "";
+		const timeout = setTimeout(
+			() => setSettledModelId(modelId),
+			MODEL_ID_LOOKUP_DEBOUNCE_MS,
+		);
+		return () => clearTimeout(timeout);
+	}, [watchedModelId]);
+
+	const hasBuiltinToolsField = [...fields, ...advanced].some(
+		(f) => f.type === "builtin-tools",
+	);
+
+	// Provider-hosted tools for the picked providers, fetched while the engine
+	// does not exist yet. An "OTHER" model provider is withheld so the backend
+	// infers the maker from the model id instead. Optional data - no match
+	// just leaves the free-text editor in place.
+	const builtinToolsPixel = useMemo(() => {
+		if (!hasBuiltinToolsField) {
+			return "";
+		}
+		const args: string[] = [];
+		const servingProvider =
+			typeof watchedServingProvider === "string"
+				? watchedServingProvider.trim()
+				: "";
+		const modelProvider =
+			typeof watchedModelProvider === "string"
+				? watchedModelProvider.trim()
+				: "";
+		if (servingProvider !== "") {
+			args.push(`servingProvider=[${JSON.stringify(servingProvider)}]`);
+		}
+		if (modelProvider !== "" && modelProvider !== "OTHER") {
+			args.push(`modelProvider=[${JSON.stringify(modelProvider)}]`);
+		}
+		if (settledModelId !== "") {
+			args.push(`modelId=[${JSON.stringify(settledModelId)}]`);
+		}
+		return args.length > 0
+			? `GetModelBuiltinTools(${args.join(", ")});`
+			: "";
+	}, [
+		hasBuiltinToolsField,
+		watchedServingProvider,
+		watchedModelProvider,
+		settledModelId,
+	]);
+
+	const getModelBuiltinTools = usePixel<ModelBuiltinTools>(builtinToolsPixel);
+	const builtinToolsCatalog =
+		getModelBuiltinTools.status === "SUCCESS"
+			? (getModelBuiltinTools.data?.tools ?? {})
+			: {};
+	const hasBuiltinToolsCatalog = Object.keys(builtinToolsCatalog).length > 0;
 
 	const getHelperText = (error, val) => {
 		if (!error) return val.helperText || "";
@@ -847,6 +927,54 @@ export const ModelImportForm = (props: ModelImportFormProps) => {
 									/>
 								</Field>
 							);
+						case "builtin-tools": {
+							const selection =
+								field.value &&
+								typeof field.value === "object" &&
+								!Array.isArray(field.value)
+									? (field.value as Record<
+											string,
+											BuiltinToolSelection
+										>)
+									: null;
+							const legacyNames = Array.isArray(field.value)
+								? field.value.map(String)
+								: [];
+							return (
+								<Field data-testid={fieldWrapperTestId}>
+									<FieldLabel htmlFor={f.key}>
+										{f.label}
+									</FieldLabel>
+									{hasBuiltinToolsCatalog ? (
+										<EngineBuiltinToolsField
+											tools={builtinToolsCatalog}
+											value={selection}
+											legacyNames={legacyNames}
+											onChange={(next) =>
+												field.onChange(next)
+											}
+											testId={fieldInputTestId}
+										/>
+									) : (
+										<CatalogTagInput
+											value={legacyNames}
+											onChange={(value) =>
+												field.onChange(value)
+											}
+											placeholder="Press enter to add a tool"
+											testId={fieldInputTestId}
+										/>
+									)}
+									{f.helperText && (
+										<FieldDescription
+											data-testid={fieldErrorTestId}
+										>
+											{f.helperText}
+										</FieldDescription>
+									)}
+								</Field>
+							);
+						}
 						case "select":
 							return (
 								<Field data-testid={fieldWrapperTestId}>

--- a/packages/client/src/components/import/model/model-import-form.tsx
+++ b/packages/client/src/components/import/model/model-import-form.tsx
@@ -29,7 +29,6 @@ import {
 	toast,
 } from "@semoss/ui/next";
 import { uploadFile } from "@/api";
-import { CatalogTagInput } from "@/components/catalog";
 import {
 	EngineBuiltinToolsField,
 	type ModelBuiltinTools,
@@ -937,9 +936,6 @@ export const ModelImportForm = (props: ModelImportFormProps) => {
 											BuiltinToolSelection
 										>)
 									: null;
-							const legacyNames = Array.isArray(field.value)
-								? field.value.map(String)
-								: [];
 							return (
 								<Field data-testid={fieldWrapperTestId}>
 									<FieldLabel htmlFor={f.key}>
@@ -949,21 +945,20 @@ export const ModelImportForm = (props: ModelImportFormProps) => {
 										<EngineBuiltinToolsField
 											tools={builtinToolsCatalog}
 											value={selection}
-											legacyNames={legacyNames}
 											onChange={(next) =>
 												field.onChange(next)
 											}
 											testId={fieldInputTestId}
 										/>
 									) : (
-										<CatalogTagInput
-											value={legacyNames}
-											onChange={(value) =>
-												field.onChange(value)
-											}
-											placeholder="Press enter to add a tool"
-											testId={fieldInputTestId}
-										/>
+										<p
+											className="text-muted-foreground text-sm"
+											data-testid={fieldInputTestId}
+										>
+											No provider-hosted tools are
+											available for this provider and
+											model.
+										</p>
 									)}
 									{f.helperText && (
 										<FieldDescription

--- a/packages/client/src/components/import/model/model-import.constants.ts
+++ b/packages/client/src/components/import/model/model-import.constants.ts
@@ -10,7 +10,8 @@ type FieldType =
 	| "boolean"
 	| "multiselect"
 	| "textarea"
-	| "file-upload";
+	| "file-upload"
+	| "builtin-tools";
 
 type categoryType = "General" | "Credentials" | "Settings";
 

--- a/packages/client/src/pages/import/model-import-page.tsx
+++ b/packages/client/src/pages/import/model-import-page.tsx
@@ -519,12 +519,10 @@ export const buildModelMetadataFields = (
 		{
 			key: "BUILTIN_TOOLS",
 			label: "Built-in Tools",
-			type: "text",
+			type: "builtin-tools",
 			required: false,
 			category: "Settings",
-			default: "",
-			helperText:
-				"Optional comma-separated canonical names, such as web_search, image_generation.",
+			helperText: "Provider-hosted tools the model can call natively.",
 		},
 	];
 


### PR DESCRIPTION
## Summary

The engine settings page and the model import page now offer the tools a model's provider actually hosts (web search, web fetch, image generation, code execution, ...), let the user toggle them on and configure their parameters, and save the selection to the engine's model metadata.

This replaces the old free-text "Built-in tools" chip input, which accepted any string and had no knowledge of what a provider supports.

> **Depends on the Semoss backend PR** (`builtin-tools-meta`): the `GetModelBuiltinTools` reactor, the `meta/builtin-tools.json` catalog, and the `BUILTINTOOLS` storage contract. Without it, both pages degrade gracefully to a "no provider-hosted tools available" empty state and never write the column.

---

## What's in here

### `EngineBuiltinToolsField` (new shared component)

A selectable list of the provider-hosted tools available to a model, driven entirely by the catalog's parameter schemas — no hardcoded per-tool UI:

- Each tool renders as a bordered row with display name, provider alias badge, description, and an on/off switch.
- Enabling a tool stores the **catalog definition verbatim**; editing a parameter adds a `value` beside the catalog `default` (effective value = `value ?? default`). This keeps the stored JSON self-describing, so anything reading model metadata can render the options without a second catalog lookup.
- Parameter editors are chosen by the param's `input` kind: switch (boolean), select (string with options), toggle group (list with options), tag input (free list), and a JSON textarea with non-blocking validation for maps.
- Hidden required params (`show_in_ui: false`, e.g. Anthropic's versioned `type`) ride along automatically and never render.
- Edits rewrite the stored tool from the **live** catalog definition, so a selection saved against an older catalog refreshes itself the next time someone touches it.
- A stored tool the catalog no longer offers renders on a dashed row so it can still be switched off — catalog drift never strands data.

### Engine settings page (`engine-model-settings.tsx`)

- Fetches availability with `GetModelBuiltinTools(engine=["<id>"]);` (edit mode only) and renders the selector in place of the old chip input; shows a muted empty-state note when the provider hosts nothing.
- `BUILTIN_TOOLS` is only included in the `UpdateModelMetadata` payload when the selection was actually edited — the update merges, so an untouched selection can never be clobbered by a save made while the catalog was still loading.
- Discard remounts the selector so in-progress JSON parameter drafts reset with the rest of the form.
- Read mode and the overview cards keep rendering tool names as badges (names derive from the selection's keys).

### Model import page (`model-import-page.tsx`, `model-import-form.tsx`, `model-import.constants.ts`)

- New `"builtin-tools"` member in the `FieldType` union with its own `renderField` case; the synthesized `BUILTIN_TOOLS` field definition switches from `type: "text"` to it.
- No engine exists at import time, so the form watches the live `SERVING_PROVIDER`, `MODEL_PROVIDER`, and `MODEL` values (both provider selects are user-editable — the form values are authoritative, not the card name), debounces the typed model id 400 ms like the existing catalog lookup, and calls the reactor in provider mode:
  `GetModelBuiltinTools(servingProvider=[...], modelProvider=[...], modelId=[...]);`
  A `MODEL_PROVIDER` of `OTHER` is withheld so the backend infers the maker from the model id.
- The selection flows into `CreateModelEngine(modelDetails=[...])` untouched — the submit handler already serializes the whole form verbatim, and the backend runs the same normalizer, so no extra payload plumbing was needed.
- Untouched field submits as `null` (stored as SQL NULL).

### Types (`engine-metadata-display.tsx`)

- `BuiltinToolParam`, `BuiltinToolDefinition`, and `BuiltinToolSelection` interfaces with passthrough index signatures (unknown catalog keys survive round trips; a definition is directly storable as a selection).
- `ModelMetadata.builtinTools` is typed as the keyed selection object — the flat `string[]` shape is gone end to end (pre-release feature, no legacy support; the backend rejects non-object writes and reads old shapes as unset).