### PR TITLE
Notebook catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,10 @@ These rules apply to **all** packages. They are adopted incrementally — see
   (it holds most shared components, utilities, and types), then the other libs.
 - Comment non-obvious code. Add TSDoc (`/** ... */`) to all functions and document component
   props on their type/interface.
+- Do not use files, components, hooks, or APIs marked `@deprecated` in their TSDoc. Use the
+  replacement named in the deprecation notice instead — e.g. `@semoss/ui/next` components over
+  the legacy `@semoss/ui` exports, and `@semoss/sdk` primitives over the deprecated client
+  `monolithStore`. Migrate any deprecated usage you touch.
 
 ### TypeScript
 
@@ -247,6 +251,18 @@ Standard `src/` layout (use only the folders a package needs):
 - **`turbo.json`** - Affects build caching and task dependencies
 - **`biome.json`** - Changes affect all packages
 - **Root `package.json`** - Engine constraints affect all developers
+
+### Mandatory Audit Before Handoff
+
+Before marking work complete, always perform and report a quick audit for touched files:
+- **Standards audit**: confirm naming, exports, Tailwind/style rules, TypeScript safety,
+  API-call patterns, and accessibility requirements from this guide.
+- **Deprecation audit**: confirm no new usage of `@deprecated` files/components/hooks/APIs
+  was introduced; migrate touched deprecated usage when in scope.
+- **Risk audit**: call out possible regressions, edge cases, and missing tests.
+- **Validation audit**: run relevant checks/tests for the scope and summarize outcomes.
+
+Do not skip this audit, even for small changes.
 
 ### Testing Changes
 

--- a/libs/shared/src/components/file/file-editor.tsx
+++ b/libs/shared/src/components/file/file-editor.tsx
@@ -106,6 +106,7 @@ export const FileEditor: React.FC<FileEditorProps> = ({
 						onChange={onChange}
 						onRun={onRun}
 						leadingToolbar={leadingToolbar}
+						readOnly={readOnly}
 					/>
 				)}
 		</div>

--- a/libs/shared/src/types.ts
+++ b/libs/shared/src/types.ts
@@ -45,7 +45,13 @@ export interface Project {
 	project_id: string;
 	project_name: string;
 	project_display_name?: string;
-	project_type: "SKILL" | "WORKSPACE" | "BLOCKS" | "CODE" | "INSIGHT";
+	project_type:
+		| "SKILL"
+		| "WORKSPACE"
+		| "BLOCKS"
+		| "CODE"
+		| "INSIGHT"
+		| "NOTEBOOK";
 	project_cost?: string;
 	project_global?: string;
 	project_created_by?: string;

--- a/packages/client/src/components/agent-workspace/agent-workspace.tsx
+++ b/packages/client/src/components/agent-workspace/agent-workspace.tsx
@@ -9,7 +9,11 @@ import { useWorkspace } from "@/hooks";
 import type { WorkspaceOptions } from "../../stores";
 import { CodeWorkspaceActions } from "../code-workspace/code-workspace-actions";
 import { MCPJsonEditor } from "../shared";
-import { WorkspaceManager, WorkspaceTerminal } from "../workspace";
+import {
+	WorkspaceManager,
+	WorkspaceNavbar,
+	WorkspaceTerminal,
+} from "../workspace";
 import { AgentEditor } from "./agent-editor";
 
 const DEFAULT_BORDER_SIZE = 300;
@@ -221,11 +225,13 @@ export const AgentWorkspace: React.FC = observer(() => {
 	};
 
 	return (
-		<WorkspaceManager
-			navbarActions={<CodeWorkspaceActions />}
-			options={DEFAULT_OPTIONS}
-			factory={FACTORY}
-			onAction={handleAction}
-		/>
+		<>
+			<WorkspaceNavbar actions={<CodeWorkspaceActions />} />
+			<WorkspaceManager
+				options={DEFAULT_OPTIONS}
+				factory={FACTORY}
+				onAction={handleAction}
+			/>
+		</>
 	);
 });

--- a/packages/client/src/components/app-workspace/app-file-editor.tsx
+++ b/packages/client/src/components/app-workspace/app-file-editor.tsx
@@ -9,10 +9,13 @@ interface AppFileEditorProps {
 
 	/** App */
 	app: string;
+
+	/** Render the file in read-only, view-only mode */
+	readOnly?: boolean;
 }
 
 export const AppFileEditor: React.FC<AppFileEditorProps> = observer(
-	({ node, app }) => {
+	({ node, app, readOnly = false }) => {
 		const config: {
 			name: string;
 			path: string;
@@ -29,6 +32,7 @@ export const AppFileEditor: React.FC<AppFileEditorProps> = observer(
 					app: app,
 				}}
 				path={config.path}
+				readOnly={readOnly}
 				leadingToolbar={
 					isDriverFile ? <MetadataHelpDialog compact /> : undefined
 				}

--- a/packages/client/src/components/app-workspace/app-file-explorer.tsx
+++ b/packages/client/src/components/app-workspace/app-file-explorer.tsx
@@ -33,10 +33,13 @@ interface AppFileExplorerProps {
 
 	/** Initial directory path to open to (defaults to "/") */
 	initialPath?: string;
+
+	/** Render the explorer in read-only, browse-only mode */
+	readOnly?: boolean;
 }
 
 export const AppFileExplorer: React.FC<AppFileExplorerProps> = observer(
-	({ layout, node, app, initialPath }) => {
+	({ layout, node, app, initialPath, readOnly = false }) => {
 		const insight = useInsight();
 
 		const [isPublishing, setIsPublishing] = useState(false);
@@ -335,46 +338,49 @@ export const AppFileExplorer: React.FC<AppFileExplorerProps> = observer(
 					app: app,
 				}}
 				initialPath={initialPath}
+				readOnly={readOnly}
 				headerActions={
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								variant="ghost"
-								size="icon-sm"
-								onClick={async () => {
-									try {
-										setIsPublishing(true);
+					readOnly ? undefined : (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									onClick={async () => {
+										try {
+											setIsPublishing(true);
 
-										// Seperate calls so we reload successfully compiled classes before publishing
-										await insight.actions.run(
-											`ReloadInsightClasses(project='${app}', release=false);`,
-										);
+											// Seperate calls so we reload successfully compiled classes before publishing
+											await insight.actions.run(
+												`ReloadInsightClasses(project='${app}', release=false);`,
+											);
 
-										await insight.actions.run(
-											`PublishProject(project='${app}', release=true);`,
-										);
+											await insight.actions.run(
+												`PublishProject(project='${app}', release=true);`,
+											);
 
-										toast.success(
-											"Successfully compiled and published",
-										);
-									} catch (e) {
-										toast.error(`Error: ${e}`);
-									} finally {
-										setIsPublishing(false);
-									}
-								}}
-							>
-								{isPublishing ? (
-									<Spinner className="size-3" />
-								) : (
-									<CloudUploadIcon className="size-3" />
-								)}
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>
-							Compile and publish the app
-						</TooltipContent>
-					</Tooltip>
+											toast.success(
+												"Successfully compiled and published",
+											);
+										} catch (e) {
+											toast.error(`Error: ${e}`);
+										} finally {
+											setIsPublishing(false);
+										}
+									}}
+								>
+									{isPublishing ? (
+										<Spinner className="size-3" />
+									) : (
+										<CloudUploadIcon className="size-3" />
+									)}
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>
+								Compile and publish the app
+							</TooltipContent>
+						</Tooltip>
+					)
 				}
 				onItemSelect={(item) => {
 					// don't open directories
@@ -407,7 +413,7 @@ export const AppFileExplorer: React.FC<AppFileExplorerProps> = observer(
 						MCP.DRIVER_PATHS.some((f) => item.path === f);
 					return (
 						<FileExplorerItem
-							draggable={item.type !== "directory"}
+							draggable={!readOnly && item.type !== "directory"}
 							item={item}
 							refresh={refresh}
 							onDragStart={(e) => {
@@ -458,7 +464,7 @@ export const AppFileExplorer: React.FC<AppFileExplorerProps> = observer(
 							}}
 							{...otherProps}
 							actions={[
-								isDriverFile
+								!readOnly && isDriverFile
 									? {
 											name: "Create",
 											icon: <HammerIcon />,
@@ -483,9 +489,11 @@ export const AppFileExplorer: React.FC<AppFileExplorerProps> = observer(
 											},
 										}
 									: null,
+								!readOnly &&
 								MCP.JSON_PATHS.some((f) =>
 									item.path.startsWith(f),
-								) && item.type !== "directory"
+								) &&
+								item.type !== "directory"
 									? {
 											name: "Edit",
 											icon: <PencilIcon />,
@@ -537,21 +545,23 @@ export const AppFileExplorer: React.FC<AppFileExplorerProps> = observer(
 											},
 										}
 									: null,
-								{
-									name: "Delete",
-									action: async (item) => {
-										await insight.actions.run(
-											`DeleteAppAssets(project=["${app}"], filePath=["${item.path}"]);`,
-										);
+								readOnly
+									? null
+									: {
+											name: "Delete",
+											action: async (item) => {
+												await insight.actions.run(
+													`DeleteAppAssets(project=["${app}"], filePath=["${item.path}"]);`,
+												);
 
-										removeDeletedTabs(
-											item.path,
-											item.type === "directory",
-										);
+												removeDeletedTabs(
+													item.path,
+													item.type === "directory",
+												);
 
-										refresh();
-									},
-								},
+												refresh();
+											},
+										},
 							]}
 						/>
 					);

--- a/packages/client/src/components/app/app.types.ts
+++ b/packages/client/src/components/app/app.types.ts
@@ -7,6 +7,7 @@ export type AppType =
 	| "INSIGHT"
 	| "SKILL"
 	| "WORKSPACE"
+	| "NOTEBOOK"
 	| "";
 
 /**

--- a/packages/client/src/components/blocks-workspace/blocks-workspace.tsx
+++ b/packages/client/src/components/blocks-workspace/blocks-workspace.tsx
@@ -18,7 +18,7 @@ import { AppFileExplorer } from "@/components/app-workspace/app-file-explorer";
 import { ProjectDetailTabs } from "@/components/project";
 import { useWorkspace } from "@/hooks";
 import { DesignerStore, type WorkspaceOptions } from "@/stores";
-import { WorkspaceManager } from "../../components/workspace";
+import { WorkspaceManager, WorkspaceNavbar } from "../../components/workspace";
 import { WorkspaceTerminal } from "../../components/workspace/panels";
 import { DesignerContext } from "../../contexts";
 import { MCPJsonEditor } from "../shared";
@@ -469,8 +469,8 @@ export const BlocksWorkspace: React.FC = observer(() => {
 					designer: designer,
 				}}
 			>
+				<WorkspaceNavbar actions={<BlocksWorkspaceActions />} />
 				<WorkspaceManager
-					navbarActions={<BlocksWorkspaceActions />}
 					options={DEFAULT_OPTIONS}
 					factory={FACTORY}
 					onAction={handleAction}

--- a/packages/client/src/components/landing/landing-header.tsx
+++ b/packages/client/src/components/landing/landing-header.tsx
@@ -13,6 +13,7 @@ import Appcode from "@/assets/img/Appcode.svg";
 import AppcodeDark from "@/assets/img/Appcode-dark.svg";
 import Appdragdrop from "@/assets/img/Appdragdrop.svg";
 import AppdragdropDark from "@/assets/img/Appdragdrop-dark.svg";
+import Notebook from "@/assets/img/NOTEBOOK.svg";
 
 const CARDS = [
 	{
@@ -42,18 +43,27 @@ const CARDS = [
 		type: "agent",
 		testId: "new-app-agent-btn",
 	},
+	{
+		title: "Run interactive notebooks",
+		description:
+			"Write and execute code cells, visualize data, and document your analysis in a live, interactive notebook environment.",
+		image: Notebook,
+		darkImage: Notebook,
+		type: "notebook",
+		testId: "new-notebook-btn",
+	},
 ] as const;
 
 interface LandingHeaderProps {
 	/** Trigger creation of a new app */
-	onCreate: (type: "blocks" | "code" | "agent") => void;
+	onCreate: (type: "blocks" | "code" | "agent" | "notebook") => void;
 }
 
 export const LandingHeader: React.FC<LandingHeaderProps> = ({
 	onCreate = () => null,
 }) => {
 	return (
-		<div className="grid w-full grid-cols-1 gap-4 md:grid-cols-3">
+		<div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
 			{CARDS.map((card) => (
 				<Card
 					key={card.title}

--- a/packages/client/src/components/notebook-workspace/index.ts
+++ b/packages/client/src/components/notebook-workspace/index.ts
@@ -1,0 +1,2 @@
+export { NotebookViewWorkspace } from "./notebook-view-workspace";
+export { NotebookWorkspace } from "./notebook-workspace";

--- a/packages/client/src/components/notebook-workspace/notebook-view-workspace.tsx
+++ b/packages/client/src/components/notebook-workspace/notebook-view-workspace.tsx
@@ -1,0 +1,99 @@
+import { observer } from "mobx-react-lite";
+import { AppFileEditor } from "@/components/app-workspace/app-file-editor";
+import { AppFileExplorer } from "@/components/app-workspace/app-file-explorer";
+import { useWorkspace } from "@/hooks";
+import type { WorkspaceOptions } from "../../stores";
+import { WorkspaceManager } from "../workspace";
+
+const NOTEBOOK_MAIN_TAB_ID = "MAIN_IPYNB";
+
+const PUBLIC_ROOT_PATH = "/public";
+
+const DEFAULT_OPTIONS: WorkspaceOptions = {
+	version: "",
+	layout: {
+		global: {
+			tabEnableClose: false,
+			tabEnableRename: false,
+		},
+		borders: [
+			{
+				type: "border",
+				location: "left",
+				selected: 0,
+				size: 400,
+				children: [
+					{
+						id: "file-explorer",
+						type: "tab",
+						name: "Files",
+						component: "app-file-explorer",
+						enableClose: false,
+						config: {},
+					},
+				],
+			},
+		],
+		layout: {
+			type: "row",
+			weight: 100,
+			children: [
+				{
+					type: "tabset",
+					id: "main-tabset",
+					weight: 100,
+					selected: 0,
+					enableMaximize: true,
+					children: [
+						{
+							id: NOTEBOOK_MAIN_TAB_ID,
+							type: "tab",
+							name: "main.ipynb",
+							component: "app-file-editor",
+							config: {
+								name: "main.ipynb",
+								path: "/public/main.ipynb",
+							},
+							enableClose: true,
+						},
+					],
+				},
+			],
+		},
+	},
+};
+
+export const NotebookViewWorkspace: React.FC = observer(() => {
+	const { workspace } = useWorkspace();
+
+	const FACTORY: React.ComponentProps<typeof WorkspaceManager>["factory"] = (
+		node,
+		layout,
+	) => {
+		const component = node.getComponent();
+
+		if (component === "app-file-explorer") {
+			return (
+				<AppFileExplorer
+					node={node}
+					layout={layout}
+					app={workspace.appId}
+					initialPath={PUBLIC_ROOT_PATH}
+					readOnly
+				/>
+			);
+		} else if (component === "app-file-editor") {
+			return <AppFileEditor node={node} app={workspace.appId} readOnly />;
+		}
+
+		return <>{component}</>;
+	};
+
+	return (
+		<WorkspaceManager
+			readOnly
+			options={DEFAULT_OPTIONS}
+			factory={FACTORY}
+		/>
+	);
+});

--- a/packages/client/src/components/notebook-workspace/notebook-workspace.tsx
+++ b/packages/client/src/components/notebook-workspace/notebook-workspace.tsx
@@ -1,18 +1,20 @@
 import { observer } from "mobx-react-lite";
-import { useEffect } from "react";
-import { InsightProvider, useInsight } from "@semoss/sdk/react";
-import { FileExplorer, FlexLayout } from "@semoss/shared";
-import { Spinner } from "@semoss/ui/next";
+import { useInsight } from "@semoss/sdk/react";
+import { FlexLayout } from "@semoss/shared";
 import { AppFileEditor } from "@/components/app-workspace/app-file-editor";
 import { AppFileExplorer } from "@/components/app-workspace/app-file-explorer";
 import { ProjectDetailTabs } from "@/components/project";
 import { useWorkspace } from "@/hooks";
-import { WorkspaceManager, WorkspaceNavbar } from "../../components/workspace";
-import { WorkspaceTerminal } from "../../components/workspace/panels";
 import type { WorkspaceOptions } from "../../stores";
+import { CodeWorkspaceActions } from "../code-workspace/code-workspace-actions";
 import { MCPJsonEditor } from "../shared";
-import { CodeWorkspaceActions } from "./code-workspace-actions";
-import { RendererPanel } from "./panels";
+import {
+	WorkspaceManager,
+	WorkspaceNavbar,
+	WorkspaceTerminal,
+} from "../workspace";
+
+const NOTEBOOK_MAIN_TAB_ID = "MAIN_IPYNB";
 
 const DEFAULT_BORDER_SIZE = 300;
 
@@ -35,15 +37,6 @@ const DEFAULT_OPTIONS: WorkspaceOptions = {
 						type: "tab",
 						name: "Files",
 						component: "app-file-explorer",
-						enableClose: false,
-						config: {},
-					},
-
-					{
-						id: "insight-explorer",
-						type: "tab",
-						name: "Insight",
-						component: "insight-explorer",
 						enableClose: false,
 						config: {},
 					},
@@ -71,16 +64,21 @@ const DEFAULT_OPTIONS: WorkspaceOptions = {
 			children: [
 				{
 					type: "tabset",
-					weight: 50,
+					id: "main-tabset",
+					weight: 100,
 					selected: 0,
-					enableTabStrip: true,
+					enableMaximize: true,
 					children: [
 						{
-							id: "render",
+							id: NOTEBOOK_MAIN_TAB_ID,
 							type: "tab",
-							name: "App",
-							component: "renderer",
-							config: {},
+							name: "main.ipynb",
+							component: "app-file-editor",
+							config: {
+								name: "main.ipynb",
+								path: "/public/main.ipynb",
+							},
+							enableClose: true,
 						},
 					],
 				},
@@ -89,69 +87,9 @@ const DEFAULT_OPTIONS: WorkspaceOptions = {
 	},
 };
 
-/**
- * The "Insight" file explorer. Each terminal tab owns its own insight, so this
- * binds to the *active* terminal tab's insight (published to the store by the
- * terminal panel) via an adopting InsightProvider — `mode.INSIGHT` browsing and
- * uploads then land in the same workspace the terminal sees. `destroyOnUnmount`
- * is off so this pane never drops the insight the terminal owns. Its own
- * observer so it re-binds when the active terminal changes; shows a spinner
- * until a terminal insight is ready.
- */
-const InsightFilesPanel = observer(() => {
-	const { workspace } = useWorkspace();
-	const insightId = workspace.activeTerminalInsightId;
-
-	if (!insightId) {
-		return (
-			<div className="flex h-full w-full items-center justify-center bg-background">
-				<Spinner className="size-4" />
-			</div>
-		);
-	}
-
-	return (
-		<InsightProvider options={{ insightId }} destroyOnUnmount={false}>
-			<FileExplorer mode={{ type: "INSIGHT" }} onItemSelect={() => {}} />
-		</InsightProvider>
-	);
-});
-
-/**
- * Render the code workspace
- */
-export const CodeWorkspace: React.FC = observer(() => {
+export const NotebookWorkspace: React.FC = observer(() => {
 	const { workspace } = useWorkspace();
 	const insight = useInsight();
-
-	// Inject the Insight tab into the left border if it was loaded from a
-	// cached layout that pre-dates this tab. Runs once after the model loads.
-	useEffect(() => {
-		const model = workspace.model;
-		if (!model) return;
-		if (model.getNodeById("insight-explorer")) return; // already there
-
-		// Find the left border via the always-present file-explorer tab
-		const fileExplorerNode = model.getNodeById("file-explorer");
-		const leftBorder = fileExplorerNode?.getParent();
-		if (!leftBorder) return;
-
-		model.doAction(
-			FlexLayout.Actions.addNode(
-				{
-					id: "insight-explorer",
-					type: "tab",
-					name: "Insight",
-					component: "insight-explorer",
-					enableClose: false,
-					config: {},
-				},
-				leftBorder.getId(),
-				FlexLayout.DockLocation.CENTER,
-				-1,
-			),
-		);
-	}, [workspace.model]);
 
 	const FACTORY: React.ComponentProps<typeof WorkspaceManager>["factory"] = (
 		node,
@@ -172,8 +110,6 @@ export const CodeWorkspace: React.FC = observer(() => {
 			return <AppFileEditor node={node} app={workspace.appId} />;
 		} else if (component === "mcpJsonEditor") {
 			return <MCPJsonEditor dataMap={config.data} />;
-		} else if (component === "renderer") {
-			return <RendererPanel />;
 		} else if (component === "settings-panel") {
 			return (
 				<ProjectDetailTabs
@@ -195,11 +131,6 @@ export const CodeWorkspace: React.FC = observer(() => {
 							restrict: ["OWNER"],
 						},
 						{
-							name: "Settings",
-							component: "settings",
-							restrict: ["OWNER"],
-						},
-						{
 							name: "Access Control",
 							component: "access-control",
 							restrict: ["OWNER", "EDIT"],
@@ -212,15 +143,8 @@ export const CodeWorkspace: React.FC = observer(() => {
 					]}
 				/>
 			);
-		} else if (component === "insight-explorer") {
-			return <InsightFilesPanel />;
 		} else if (component === "terminal") {
-			return (
-				<WorkspaceTerminal
-					appId={workspace.appId}
-					onActiveInsightChange={workspace.setActiveTerminalInsightId}
-				/>
-			);
+			return <WorkspaceTerminal appId={workspace.appId} />;
 		}
 
 		return <>{component}</>;

--- a/packages/client/src/components/project/index.ts
+++ b/packages/client/src/components/project/index.ts
@@ -6,4 +6,5 @@ export { ProjectDetailTabs } from "./project-detail-tabs";
 export { ProjectEdit } from "./project-edit";
 export { ProjectGridItem } from "./project-grid-item";
 export { ProjectOverview } from "./project-overview";
+export { ProjectView } from "./project-view";
 export { UploadProjectDialog } from "./upload-project-dialog";

--- a/packages/client/src/components/project/project-catalog.tsx
+++ b/packages/client/src/components/project/project-catalog.tsx
@@ -61,6 +61,16 @@ const CATALOG_CONFIG = {
 
 		showSystemTab: false,
 	},
+	NOTEBOOK: {
+		name: "Notebook",
+		description:
+			"Write and execute code cells, visualize data, and document your analysis in a live, interactive notebook environment. Organize and share notebooks across your team.",
+		createPath: "/notebook/new",
+		basePath: "/notebook",
+		itemSubPath: "view",
+		pixelFilter: 'projectType=["NOTEBOOK"]',
+		showSystemTab: false,
+	},
 } as const;
 
 type TabMode = "Mine" | "Discoverable" | "System";

--- a/packages/client/src/components/project/project-view.tsx
+++ b/packages/client/src/components/project/project-view.tsx
@@ -1,0 +1,133 @@
+import { observer } from "mobx-react-lite";
+import { lazy, Suspense, useRef, useState } from "react";
+import { InsightProvider } from "@semoss/sdk/react";
+import type { FileItem } from "@semoss/shared";
+import { FileExplorer } from "@semoss/shared";
+import { Spinner } from "@semoss/ui/next";
+import { NotebookViewWorkspace } from "@/components/notebook-workspace";
+import { SkillFileViewer } from "@/components/skill";
+import { WorkspaceContext } from "@/contexts";
+import type { WorkspaceStore } from "@/stores";
+
+const Renderer = lazy(() =>
+	import("@semoss/renderer").then((m) => ({ default: m.Renderer })),
+);
+const CodeRenderer = lazy(() =>
+	import("@/components/code-workspace").then((m) => ({
+		default: m.CodeRenderer,
+	})),
+);
+
+const PUBLIC_ROOT_PATH = "/public";
+
+interface ProjectViewProps {
+	/** Loaded workspace whose read-only project view should be rendered */
+	workspace: WorkspaceStore;
+}
+
+/**
+ * Render the read-only view body for a loaded project, dispatching on its type.
+ *
+ * Intended for navbar-free surfaces (e.g. the share page): it renders only the
+ * project content and never the `Navbar*`/`usePage` chrome the full view pages use.
+ */
+export const ProjectView = observer(({ workspace }: ProjectViewProps) => {
+	// SKILL selection state — hooks stay unconditional even though only SKILL uses them
+	const [selectedPath, setSelectedPath] = useState<string | null>(null);
+	const hasAutoSelectedRef = useRef(false);
+
+	const loadingFallback = (
+		<div className="absolute inset-0 z-1501 flex items-center justify-center bg-background/50">
+			<Spinner className="size-4" />
+		</div>
+	);
+
+	/**
+	 * Auto-select SKILL.md the first time the /public root finishes loading
+	 */
+	const handleSkillItemsChange = (payload: {
+		path: string;
+		items: FileItem[];
+	}) => {
+		if (hasAutoSelectedRef.current) {
+			return;
+		}
+		if (payload.path !== PUBLIC_ROOT_PATH) {
+			return;
+		}
+
+		const skillMd = payload.items.find(
+			(item) => item.type !== "directory" && item.name === "SKILL.md",
+		);
+		if (skillMd) {
+			hasAutoSelectedRef.current = true;
+			setSelectedPath(skillMd.path);
+		}
+	};
+
+	switch (workspace.type) {
+		case "CODE":
+			return (
+				<div className="absolute inset-0">
+					<Suspense fallback={loadingFallback}>
+						<CodeRenderer appId={workspace.appId} />
+					</Suspense>
+				</div>
+			);
+		case "BLOCKS":
+			return (
+				<div className="absolute inset-0">
+					<Suspense fallback={loadingFallback}>
+						<Renderer
+							appId={workspace.appId}
+							insightId={workspace.insightId}
+						/>
+					</Suspense>
+				</div>
+			);
+		case "SKILL":
+			return (
+				<div className="h-full w-full overflow-auto p-2">
+					<InsightProvider
+						options={{ insightId: workspace.insightId }}
+						destroyOnUnmount={false}
+					>
+						<div className="mb-6 max-h-[35vh] overflow-auto rounded-md border border-border">
+							<FileExplorer
+								mode={{
+									type: "APP",
+									app: workspace.appId,
+								}}
+								initialPath={PUBLIC_ROOT_PATH}
+								readOnly
+								onItemSelect={(item) =>
+									setSelectedPath(item.path)
+								}
+								onVisibleItemsChange={handleSkillItemsChange}
+							/>
+						</div>
+						<SkillFileViewer
+							projectId={workspace.appId}
+							insightId={workspace.insightId}
+							path={selectedPath}
+						/>
+					</InsightProvider>
+				</div>
+			);
+		case "NOTEBOOK":
+			return (
+				<div className="absolute inset-0">
+					<WorkspaceContext.Provider value={{ workspace }}>
+						<InsightProvider
+							options={{ insightId: workspace.insightId }}
+							destroyOnUnmount={false}
+						>
+							<NotebookViewWorkspace />
+						</InsightProvider>
+					</WorkspaceContext.Provider>
+				</div>
+			);
+		default:
+			return null;
+	}
+});

--- a/packages/client/src/components/project/upload-project-dialog.tsx
+++ b/packages/client/src/components/project/upload-project-dialog.tsx
@@ -39,6 +39,9 @@ const DIALOG_CONFIG = {
 	AGENT: {
 		name: "Agent",
 	},
+	NOTEBOOK: {
+		name: "Notebook",
+	},
 } as const;
 
 /**

--- a/packages/client/src/components/settings/settings-tiles.tsx
+++ b/packages/client/src/components/settings/settings-tiles.tsx
@@ -208,6 +208,7 @@ export const SettingsTiles = (props: SettingsTilesProps) => {
 				};
 				const isWorkspace = projectData?.project_type === "WORKSPACE";
 				const isSkill = projectData?.project_type === "SKILL";
+				const isNotebook = projectData?.project_type === "NOTEBOOK";
 
 				if (isWorkspace) {
 					deletePixel = `DeleteWorkspace(workspaceId=['${id}']);`;
@@ -215,6 +216,9 @@ export const SettingsTiles = (props: SettingsTilesProps) => {
 				} else if (isSkill) {
 					deletePixel = `DeleteSkill(skillId=['${id}']);`;
 					entityLabel = "skill";
+				} else if (isNotebook) {
+					deletePixel = `DeleteProject(project=['${id}']);`;
+					entityLabel = "notebook";
 				} else {
 					deletePixel = `DeleteProject(project=['${id}']);`;
 					entityLabel = "app";

--- a/packages/client/src/components/shared/app-sidebar.tsx
+++ b/packages/client/src/components/shared/app-sidebar.tsx
@@ -7,6 +7,7 @@ import {
 	Database,
 	Home,
 	LayoutGrid,
+	NotebookText,
 	PanelLeftOpen,
 	Puzzle,
 	Settings,
@@ -77,6 +78,11 @@ const CATALOG_ROUTES = [
 		text: "Skills",
 		icon: <Puzzle className="size-4" />,
 		route: "/skill",
+	},
+	{
+		text: "Notebooks",
+		icon: <NotebookText className="size-4" />,
+		route: "/notebook",
 	},
 	{
 		text: "Guardrail",

--- a/packages/client/src/components/skill/skill-workspace.tsx
+++ b/packages/client/src/components/skill/skill-workspace.tsx
@@ -8,7 +8,11 @@ import { useWorkspace } from "@/hooks";
 import type { WorkspaceOptions } from "../../stores";
 import { CodeWorkspaceActions } from "../code-workspace/code-workspace-actions";
 import { MCPJsonEditor } from "../shared";
-import { WorkspaceManager, WorkspaceTerminal } from "../workspace";
+import {
+	WorkspaceManager,
+	WorkspaceNavbar,
+	WorkspaceTerminal,
+} from "../workspace";
 
 const SKILL_MD_TAB_ID = "SKILL_MD";
 
@@ -203,11 +207,13 @@ export const SkillWorkspace: React.FC = observer(() => {
 	};
 
 	return (
-		<WorkspaceManager
-			navbarActions={<CodeWorkspaceActions />}
-			options={DEFAULT_OPTIONS}
-			factory={FACTORY}
-			onAction={handleAction}
-		/>
+		<>
+			<WorkspaceNavbar actions={<CodeWorkspaceActions />} />
+			<WorkspaceManager
+				options={DEFAULT_OPTIONS}
+				factory={FACTORY}
+				onAction={handleAction}
+			/>
+		</>
 	);
 });

--- a/packages/client/src/components/workspace/index.ts
+++ b/packages/client/src/components/workspace/index.ts
@@ -2,5 +2,6 @@ export * from "./panels";
 export * from "./preview-dialog";
 export * from "./workspace";
 export * from "./workspace-manager";
+export * from "./workspace-navbar";
 export * from "./workspace-reset-button";
 export * from "./workspace-settings-toggle";

--- a/packages/client/src/components/workspace/workspace-manager.tsx
+++ b/packages/client/src/components/workspace/workspace-manager.tsx
@@ -74,7 +74,12 @@ type WorkspaceManagerProps = {
 };
 
 export const WorkspaceManager: React.FC<WorkspaceManagerProps> = observer(
-	({ options, factory = () => null, onAction, readOnly = false }) => {
+	({
+		options,
+		factory = () => null,
+		onAction = (action: FlexLayout.Action) => action,
+		readOnly = false,
+	}) => {
 		const { workspace } = useWorkspace();
 		const layoutRef = useRef<FlexLayout.Layout | null>(null);
 		const containerRef = useRef<HTMLDivElement | null>(null);

--- a/packages/client/src/components/workspace/workspace-manager.tsx
+++ b/packages/client/src/components/workspace/workspace-manager.tsx
@@ -1,7 +1,6 @@
 import {
 	Blocks,
 	Braces,
-	ChevronRightIcon,
 	FlaskConical,
 	Folder,
 	Layers,
@@ -16,20 +15,10 @@ import {
 import { observer } from "mobx-react-lite";
 import type React from "react";
 import { useEffect, useMemo, useRef } from "react";
-import { Link } from "react-router-dom";
 import { FlexLayout, getFileIconComponent } from "@semoss/shared";
-import {
-	Breadcrumb,
-	BreadcrumbItem,
-	BreadcrumbLink,
-	BreadcrumbList,
-	BreadcrumbPage,
-	BreadcrumbSeparator,
-	cn,
-} from "@semoss/ui/next";
-import { useProject, useTabBarScroll, useWorkspace } from "@/hooks";
+import { cn } from "@semoss/ui/next";
+import { useTabBarScroll, useWorkspace } from "@/hooks";
 import type { WorkspaceOptions } from "@/stores";
-import { NavbarHeader, NavbarLeft, NavbarRight } from "../shared";
 import { WorkspaceLoading } from "./WorkspaceLoading";
 import { WorkspaceResetButton } from "./workspace-reset-button";
 import { WorkspaceSettingsToggle } from "./workspace-settings-toggle";
@@ -68,9 +57,6 @@ const getWorkspaceTabIcon = (component: string, name: string) => {
 };
 
 type WorkspaceManagerProps = {
-	/** Actions to render in the navbar */
-	navbarActions?: React.ReactNode;
-
 	/** Options to load into the workspace */
 	options: WorkspaceOptions;
 
@@ -82,11 +68,13 @@ type WorkspaceManagerProps = {
 
 	/** Optional action handler — return the action to let FlexLayout process it, return undefined to consume it */
 	onAction?: (action: FlexLayout.Action) => FlexLayout.Action | undefined;
+
+	/** When true, the workspace is view-only: layout is not persisted to cache and the settings/reset controls are hidden */
+	readOnly?: boolean;
 };
 
 export const WorkspaceManager: React.FC<WorkspaceManagerProps> = observer(
-	({ navbarActions, options, factory = () => null, onAction }) => {
-		const { catalog, project } = useProject();
+	({ options, factory = () => null, onAction, readOnly = false }) => {
 		const { workspace } = useWorkspace();
 		const layoutRef = useRef<FlexLayout.Layout | null>(null);
 		const containerRef = useRef<HTMLDivElement | null>(null);
@@ -190,6 +178,13 @@ export const WorkspaceManager: React.FC<WorkspaceManagerProps> = observer(
 			// default options if not loaded from cache
 			const defaultOptions = JSON.parse(JSON.stringify(options));
 
+			// read-only workspaces always start from the passed options and never
+			// read/write the shared per-app layout cache (keyed by appId)
+			if (readOnly) {
+				workspace.load(defaultOptions);
+				return;
+			}
+
 			// set the workspace options
 			// try to load from cache
 			const isLoaded = workspace.loadFromCache();
@@ -199,85 +194,53 @@ export const WorkspaceManager: React.FC<WorkspaceManagerProps> = observer(
 		}, [options]);
 
 		return (
-			<>
-				<NavbarLeft>
-					<NavbarHeader logo={null} />
-					<Breadcrumb>
-						<BreadcrumbList>
-							<BreadcrumbItem>
-								<BreadcrumbLink asChild>
-									<Link to={catalog.path}>
-										{catalog.name} Catalog
-									</Link>
-								</BreadcrumbLink>
-							</BreadcrumbItem>
-							<BreadcrumbSeparator>
-								<ChevronRightIcon />
-							</BreadcrumbSeparator>
-							<BreadcrumbItem>
-								<BreadcrumbLink asChild>
-									<Link
-										to={`${catalog.path}/${project.project_id}`}
-									>
-										{project.project_display_name ||
-											project.project_name}
-									</Link>
-								</BreadcrumbLink>
-							</BreadcrumbItem>
-							<BreadcrumbSeparator>
-								<ChevronRightIcon />
-							</BreadcrumbSeparator>
-							<BreadcrumbItem>
-								<BreadcrumbPage>Edit</BreadcrumbPage>
-							</BreadcrumbItem>
-						</BreadcrumbList>
-					</Breadcrumb>
-				</NavbarLeft>
-				<NavbarRight>{navbarActions}</NavbarRight>
-				<div className="relative flex h-full w-full flex-col overflow-hidden">
-					<WorkspaceLoading />
-					<div
-						ref={containerRef}
-						className="flexlayout__theme_smss absolute inset-0 overflow-hidden"
-					>
-						{workspace.model ? (
-							<>
-								<FlexLayout.Layout
-									ref={layoutRef}
-									model={workspace.model}
-									factory={(node) => {
-										return factory(
-											node,
-											layoutRef.current as FlexLayout.Layout,
-										);
-									}}
-									icons={{
-										close: <XIcon className="size-4" />,
-									}}
-									onModelChange={() => {
+			<div className="relative flex h-full w-full flex-col overflow-hidden">
+				<WorkspaceLoading />
+				<div
+					ref={containerRef}
+					className="flexlayout__theme_smss absolute inset-0 overflow-hidden"
+				>
+					{workspace.model ? (
+						<>
+							<FlexLayout.Layout
+								ref={layoutRef}
+								model={workspace.model}
+								factory={(node) => {
+									return factory(
+										node,
+										layoutRef.current as FlexLayout.Layout,
+									);
+								}}
+								icons={{
+									close: <XIcon className="size-4" />,
+								}}
+								onModelChange={() => {
+									if (!readOnly) {
 										workspace.saveToCache();
-									}}
-									onAction={(action) => {
-										const external = onAction?.(action);
-										if (external === undefined) {
-											return undefined;
-										}
+									}
+								}}
+								onAction={(action) => {
+									const external = onAction?.(action);
+									if (external === undefined) {
+										return undefined;
+									}
 
-										return action;
-									}}
-									onRenderTab={(tabNode, renderValues) => {
-										const tabIcon = getWorkspaceTabIcon(
-											tabNode.getComponent() as string,
-											tabNode.getName(),
-										);
+									return action;
+								}}
+								onRenderTab={(tabNode, renderValues) => {
+									const tabIcon = getWorkspaceTabIcon(
+										tabNode.getComponent() as string,
+										tabNode.getName(),
+									);
 
-										if (tabIcon) {
-											renderValues.leading = tabIcon;
-										}
+									if (tabIcon) {
+										renderValues.leading = tabIcon;
+									}
 
-										return renderValues;
-									}}
-								/>
+									return renderValues;
+								}}
+							/>
+							{!readOnly && (
 								<div
 									className={cn(
 										"absolute left-2 z-10 flex flex-col gap-1",
@@ -293,11 +256,11 @@ export const WorkspaceManager: React.FC<WorkspaceManagerProps> = observer(
 										layout={options.layout}
 									/>
 								</div>
-							</>
-						) : null}
-					</div>
+							)}
+						</>
+					) : null}
 				</div>
-			</>
+			</div>
 		);
 	},
 );

--- a/packages/client/src/components/workspace/workspace-navbar.tsx
+++ b/packages/client/src/components/workspace/workspace-navbar.tsx
@@ -1,0 +1,67 @@
+import { ChevronRightIcon } from "lucide-react";
+import { observer } from "mobx-react-lite";
+import type React from "react";
+import { Link } from "react-router-dom";
+import {
+	Breadcrumb,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbList,
+	BreadcrumbPage,
+	BreadcrumbSeparator,
+} from "@semoss/ui/next";
+import { useProject } from "@/hooks";
+import { NavbarHeader, NavbarLeft, NavbarRight } from "../shared";
+
+interface WorkspaceNavbarProps {
+	/** Actions to render on the right side of the navbar */
+	actions?: React.ReactNode;
+
+	/** Final breadcrumb label for the workspace (defaults to "Edit") */
+	label?: string;
+}
+
+export const WorkspaceNavbar: React.FC<WorkspaceNavbarProps> = observer(
+	({ actions, label = "Edit" }) => {
+		const { catalog, project } = useProject();
+
+		return (
+			<>
+				<NavbarLeft>
+					<NavbarHeader logo={null} />
+					<Breadcrumb>
+						<BreadcrumbList>
+							<BreadcrumbItem>
+								<BreadcrumbLink asChild>
+									<Link to={catalog.path}>
+										{catalog.name} Catalog
+									</Link>
+								</BreadcrumbLink>
+							</BreadcrumbItem>
+							<BreadcrumbSeparator>
+								<ChevronRightIcon />
+							</BreadcrumbSeparator>
+							<BreadcrumbItem>
+								<BreadcrumbLink asChild>
+									<Link
+										to={`${catalog.path}/${project.project_id}`}
+									>
+										{project.project_display_name ||
+											project.project_name}
+									</Link>
+								</BreadcrumbLink>
+							</BreadcrumbItem>
+							<BreadcrumbSeparator>
+								<ChevronRightIcon />
+							</BreadcrumbSeparator>
+							<BreadcrumbItem>
+								<BreadcrumbPage>{label}</BreadcrumbPage>
+							</BreadcrumbItem>
+						</BreadcrumbList>
+					</Breadcrumb>
+				</NavbarLeft>
+				<NavbarRight>{actions}</NavbarRight>
+			</>
+		);
+	},
+);

--- a/packages/client/src/components/workspace/workspace.tsx
+++ b/packages/client/src/components/workspace/workspace.tsx
@@ -24,6 +24,11 @@ const AgentWorkspace = lazy(() =>
 		default: m.AgentWorkspace,
 	})),
 );
+const NotebookWorkspace = lazy(() =>
+	import("@/components/notebook-workspace").then((m) => ({
+		default: m.NotebookWorkspace,
+	})),
+);
 
 import { useRootStore } from "@/hooks";
 import type { WorkspaceStore } from "@/stores";
@@ -117,6 +122,7 @@ export const Workspace: React.FC<WorkspaceProps> = ({ app }) => {
 				{workspace.type === "BLOCKS" && <BlocksWorkspace />}
 				{workspace.type === "SKILL" && <SkillWorkspace />}
 				{workspace.type === "WORKSPACE" && <AgentWorkspace />}
+				{workspace.type === "NOTEBOOK" && <NotebookWorkspace />}
 			</Suspense>
 		</WorkspaceContext.Provider>
 	);

--- a/packages/client/src/pages/landing-page.tsx
+++ b/packages/client/src/pages/landing-page.tsx
@@ -130,6 +130,8 @@ export const LandingPage: React.FC = observer(() => {
 								});
 							} else if (type === "agent") {
 								navigate("/app/new/prompt");
+							} else if (type === "notebook") {
+								navigate("/notebook");
 							}
 						}}
 					/>

--- a/packages/client/src/pages/project/notebook/create-notebook-page.tsx
+++ b/packages/client/src/pages/project/notebook/create-notebook-page.tsx
@@ -1,6 +1,7 @@
 import { ChevronRight, UploadIcon, X } from "lucide-react";
 import { useId, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { runPixel } from "@semoss/sdk/react";
 import {
 	Badge,
 	Breadcrumb,
@@ -23,11 +24,9 @@ import {
 } from "@semoss/ui/next";
 import { UploadProjectDialog } from "@/components/project";
 import { NavbarHeader, NavbarLeft } from "@/components/shared";
-import { useRootStore } from "@/hooks";
 
 export const CreateNotebookPage = () => {
 	const navigate = useNavigate();
-	const { monolithStore } = useRootStore();
 	const [isUploadOpen, setIsUploadOpen] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
 	const [tagInput, setTagInput] = useState("");
@@ -59,13 +58,11 @@ export const CreateNotebookPage = () => {
 		try {
 			setIsLoading(true);
 
-			const { errors, pixelReturn } = await monolithStore.runQuery<
+			const { errors, pixelReturn } = await runPixel<
 				{
 					project_id: string;
 				}[]
-			>(
-				`CreateNotebook(project=[${JSON.stringify(form.name)}], notebookName=[/public/main.ipynb]);`,
-			);
+			>(`CreateNotebook(project=[${JSON.stringify(form.name)}]);`);
 
 			if (errors.length > 0) throw new Error(errors.join(","));
 
@@ -74,12 +71,11 @@ export const CreateNotebookPage = () => {
 
 			const hasMeta = form.tags.length > 0 || !!form.description;
 			if (hasMeta) {
-				const { pixelReturn: metaReturn } =
-					await monolithStore.runQuery(
-						`SetProjectMetadata(project=["${appId}"], meta=[${JSON.stringify(
-							{ tag: form.tags, description: form.description },
-						)}])`,
-					);
+				const { pixelReturn: metaReturn } = await runPixel(
+					`SetProjectMetadata(project=["${appId}"], meta=[${JSON.stringify(
+						{ tag: form.tags, description: form.description },
+					)}])`,
+				);
 
 				const operationType = metaReturn[0].operationType[0];
 				if (operationType.indexOf("ERROR") > -1) {

--- a/packages/client/src/pages/project/notebook/create-notebook-page.tsx
+++ b/packages/client/src/pages/project/notebook/create-notebook-page.tsx
@@ -1,0 +1,285 @@
+import { ChevronRight, UploadIcon, X } from "lucide-react";
+import { useId, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import {
+	Badge,
+	Breadcrumb,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbList,
+	BreadcrumbPage,
+	BreadcrumbSeparator,
+	Button,
+	Field,
+	FieldLabel,
+	H4,
+	Input,
+	Muted,
+	P,
+	Progress,
+	Separator,
+	Textarea,
+	toast,
+} from "@semoss/ui/next";
+import { UploadProjectDialog } from "@/components/project";
+import { NavbarHeader, NavbarLeft } from "@/components/shared";
+import { useRootStore } from "@/hooks";
+
+export const CreateNotebookPage = () => {
+	const navigate = useNavigate();
+	const { monolithStore } = useRootStore();
+	const [isUploadOpen, setIsUploadOpen] = useState(false);
+	const [isLoading, setIsLoading] = useState(false);
+	const [tagInput, setTagInput] = useState("");
+	const [form, setForm] = useState<{
+		name: string;
+		description: string;
+		tags: string[];
+	}>({
+		name: "",
+		description: "",
+		tags: [],
+	});
+
+	const nameId = useId();
+	const descId = useId();
+	const tagId = useId();
+
+	const isValid = form.name.trim().length > 0;
+
+	const navigateNotebook = (appId: string) => {
+		if (!appId) {
+			return;
+		}
+
+		navigate(`/notebook/${appId}/edit`);
+	};
+
+	const onSubmit = async () => {
+		try {
+			setIsLoading(true);
+
+			const { errors, pixelReturn } = await monolithStore.runQuery<
+				{
+					project_id: string;
+				}[]
+			>(
+				`CreateNotebook(project=[${JSON.stringify(form.name)}], notebookName=[/public/main.ipynb]);`,
+			);
+
+			if (errors.length > 0) throw new Error(errors.join(","));
+
+			const appId = pixelReturn[0].output.project_id;
+			if (!appId) throw new Error("Error creating notebook");
+
+			const hasMeta = form.tags.length > 0 || !!form.description;
+			if (hasMeta) {
+				const { pixelReturn: metaReturn } =
+					await monolithStore.runQuery(
+						`SetProjectMetadata(project=["${appId}"], meta=[${JSON.stringify(
+							{ tag: form.tags, description: form.description },
+						)}])`,
+					);
+
+				const operationType = metaReturn[0].operationType[0];
+				if (operationType.indexOf("ERROR") > -1) {
+					toast.error(String(metaReturn[0].output));
+					return;
+				}
+			}
+
+			navigateNotebook(appId);
+		} catch (e) {
+			console.error(e);
+			toast.error((e as Error).message || "Error creating notebook");
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	return (
+		<>
+			<NavbarLeft>
+				<NavbarHeader logo={null} />
+				<Breadcrumb>
+					<BreadcrumbList>
+						<BreadcrumbItem>
+							<BreadcrumbLink asChild>
+								<Link to="../">Notebook Catalog</Link>
+							</BreadcrumbLink>
+						</BreadcrumbItem>
+						<BreadcrumbSeparator>
+							<ChevronRight />
+						</BreadcrumbSeparator>
+						<BreadcrumbItem>
+							<BreadcrumbPage>New</BreadcrumbPage>
+						</BreadcrumbItem>
+					</BreadcrumbList>
+				</Breadcrumb>
+			</NavbarLeft>
+			<div className="flex flex-col gap-1">
+				<div className="flex flex-row items-center justify-between gap-2">
+					<H4>New Notebook</H4>
+					<Button
+						variant="outline"
+						onClick={() => setIsUploadOpen(true)}
+					>
+						<UploadIcon />
+						Upload
+					</Button>
+				</div>
+				<P className="mb-3 text-muted-foreground">
+					Create and manage notebooks to build reusable data
+					processing and analysis workflows. This page helps you
+					define, organize, and publish notebooks that agents can
+					leverage to perform complex computations and data tasks.
+				</P>
+				<form
+					className="my-4 w-full"
+					onSubmit={(e) => {
+						e.preventDefault();
+						if (!isValid || isLoading) return;
+						onSubmit();
+					}}
+					autoComplete="off"
+				>
+					<div className="mb-4 flex flex-col gap-4">
+						<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
+							<div className="flex flex-1 flex-col gap-1">
+								<H4 className="font-semibold text-base tracking-tight">
+									Details
+								</H4>
+								<Muted className="text-muted-foreground text-sm leading-6">
+									How this notebook appears in the catalog
+								</Muted>
+							</div>
+							<div className="flex flex-2 flex-col gap-3">
+								<Field>
+									<FieldLabel htmlFor={nameId}>
+										Name{" "}
+										<span className="text-destructive">
+											*
+										</span>
+									</FieldLabel>
+									<Input
+										id={nameId}
+										placeholder="My Notebook"
+										value={form.name}
+										onChange={(e) =>
+											setForm((prev) => ({
+												...prev,
+												name: e.target.value,
+											}))
+										}
+									/>
+								</Field>
+								<Field>
+									<FieldLabel htmlFor={descId}>
+										Description
+									</FieldLabel>
+									<Textarea
+										id={descId}
+										placeholder="Describe what this notebook does..."
+										rows={3}
+										className="max-h-40"
+										value={form.description}
+										onChange={(e) =>
+											setForm((prev) => ({
+												...prev,
+												description: e.target.value,
+											}))
+										}
+									/>
+								</Field>
+								<Field>
+									<FieldLabel htmlFor={tagId}>
+										Tags
+									</FieldLabel>
+									<Input
+										id={tagId}
+										placeholder="e.g., data-processing, ml (press Enter)"
+										value={tagInput}
+										onChange={(e) =>
+											setTagInput(e.target.value)
+										}
+										onKeyDown={(e) => {
+											if (e.key === "Enter") {
+												e.preventDefault();
+												const trimmed = tagInput.trim();
+												if (
+													trimmed &&
+													!form.tags.includes(trimmed)
+												) {
+													setForm((prev) => ({
+														...prev,
+														tags: [
+															...prev.tags,
+															trimmed,
+														],
+													}));
+												}
+												setTagInput("");
+											}
+										}}
+									/>
+									{form.tags.length > 0 && (
+										<div className="flex flex-wrap gap-1">
+											{form.tags.map((tag) => (
+												<Badge
+													key={tag}
+													variant="secondary"
+													className="gap-1"
+												>
+													{tag}
+													<button
+														type="button"
+														onClick={() =>
+															setForm((prev) => ({
+																...prev,
+																tags: prev.tags.filter(
+																	(t) =>
+																		t !==
+																		tag,
+																),
+															}))
+														}
+														className="hover:text-destructive"
+													>
+														<X className="size-3" />
+													</button>
+												</Badge>
+											))}
+										</div>
+									)}
+								</Field>
+							</div>
+						</div>
+						<Separator />
+					</div>
+					<div className="flex justify-end">
+						<Button
+							type="submit"
+							disabled={!isValid || isLoading}
+							className="w-full sm:w-auto"
+						>
+							Create
+						</Button>
+					</div>
+					{isLoading && <Progress className="h-1" />}
+				</form>
+			</div>
+			{isUploadOpen && (
+				<UploadProjectDialog
+					type="NOTEBOOK"
+					open={isUploadOpen}
+					handleClose={(appId) => {
+						if (appId) {
+							navigateNotebook(appId);
+						}
+						setIsUploadOpen(false);
+					}}
+				/>
+			)}
+		</>
+	);
+};

--- a/packages/client/src/pages/project/notebook/view-notebook-page.tsx
+++ b/packages/client/src/pages/project/notebook/view-notebook-page.tsx
@@ -1,0 +1,134 @@
+// biome-ignore-all lint/correctness/useExhaustiveDependencies: TODO
+
+import { ChevronRightIcon, InfoIcon, PencilIcon } from "lucide-react";
+import { observer } from "mobx-react-lite";
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { InsightProvider } from "@semoss/sdk/react";
+import {
+	Breadcrumb,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbList,
+	BreadcrumbPage,
+	BreadcrumbSeparator,
+	Button,
+	Spinner,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+	toast,
+} from "@semoss/ui/next";
+import { NotebookViewWorkspace } from "@/components/notebook-workspace";
+import { NavbarHeader, NavbarLeft, NavbarRight } from "@/components/shared";
+import { WorkspaceContext } from "@/contexts";
+import { usePage, useProject, useRootStore } from "@/hooks";
+import type { WorkspaceStore } from "@/stores";
+
+export const ViewNotebookPage = observer(() => {
+	const { configStore } = useRootStore();
+	const navigate = useNavigate();
+	const { project, catalog } = useProject();
+
+	const [workspace, setWorkspace] = useState<WorkspaceStore | null>(null);
+
+	usePage({
+		showNavbarLogo: false,
+	});
+
+	useEffect(() => {
+		// clear out the old workspace
+		setWorkspace(null);
+
+		configStore
+			.createWorkspace(project.project_id)
+			.then((loadedWorkspace) => {
+				setWorkspace(loadedWorkspace);
+			})
+			.catch((e) => {
+				toast.error(e.message);
+				navigate("/");
+			});
+	}, [project.project_id]);
+
+	if (!workspace || !project.project_id) {
+		return (
+			<div className="absolute inset-0 flex flex-1 items-center justify-center">
+				<Spinner />
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<NavbarLeft>
+				<NavbarHeader logo={null} />
+				<Breadcrumb>
+					<BreadcrumbList>
+						<BreadcrumbItem>
+							<BreadcrumbLink asChild>
+								<Link to={catalog.path}>
+									{catalog.name} Catalog
+								</Link>
+							</BreadcrumbLink>
+						</BreadcrumbItem>
+						<BreadcrumbSeparator>
+							<ChevronRightIcon />
+						</BreadcrumbSeparator>
+						<BreadcrumbItem>
+							<BreadcrumbPage
+								title={
+									project.project_display_name ||
+									project.project_name
+								}
+							>
+								{project.project_display_name ||
+									project.project_name}
+							</BreadcrumbPage>
+						</BreadcrumbItem>
+					</BreadcrumbList>
+				</Breadcrumb>
+			</NavbarLeft>
+			<NavbarRight>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon"
+							data-testid={"settings"}
+							asChild
+						>
+							<Link to={`..`}>
+								<InfoIcon className="size-4" />
+							</Link>
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Settings</TooltipContent>
+				</Tooltip>
+				{(workspace.role === "OWNER" || workspace.role === "EDIT") && (
+					<Button
+						variant="default"
+						size="sm"
+						data-testid={"viewNotebookPage-edit-btn"}
+						asChild
+					>
+						<Link to={`../edit`}>
+							<PencilIcon className="mr-1 size-4" />
+							Edit
+						</Link>
+					</Button>
+				)}
+			</NavbarRight>
+			<div className="absolute inset-0">
+				<WorkspaceContext.Provider value={{ workspace }}>
+					<InsightProvider
+						options={{ insightId: workspace.insightId }}
+						destroyOnUnmount={false}
+					>
+						<NotebookViewWorkspace />
+					</InsightProvider>
+				</WorkspaceContext.Provider>
+			</div>
+		</>
+	);
+});

--- a/packages/client/src/pages/project/project-layout.tsx
+++ b/packages/client/src/pages/project/project-layout.tsx
@@ -20,6 +20,10 @@ export const DETAIL_CONFIG = {
 		name: "Agent",
 		basePath: "/agent",
 	},
+	NOTEBOOK: {
+		name: "Notebook",
+		basePath: "/notebook",
+	},
 } as const;
 
 interface ProjectLayoutProps {

--- a/packages/client/src/pages/project/project.routes.tsx
+++ b/packages/client/src/pages/project/project.routes.tsx
@@ -18,6 +18,8 @@ import {
 import { AgentActivityPage } from "./agent/agent-activity-page";
 import { CreateAgentPage } from "./agent/create-agent-page";
 import { CreateAppPage } from "./app/create-app-page";
+import { CreateNotebookPage } from "./notebook/create-notebook-page";
+import { ViewNotebookPage } from "./notebook/view-notebook-page";
 import { ProjectDependenciesPage } from "./project-dependencies-page";
 import { ProjectLayout } from "./project-layout";
 import { ProjectOverviewPage } from "./project-overview-page";
@@ -190,6 +192,90 @@ export const PROJECT_ROUTES: {
 					{
 						path: "view",
 						element: <ViewSkillPage />,
+					},
+					{
+						path: "*",
+						element: (
+							<ProjectTabsLayout
+								tabs={[
+									{ name: "Overview", path: "" },
+									{
+										name: "Commits",
+										path: "commits",
+										restrict: ["OWNER", "EDIT"],
+									},
+									{
+										name: "GitHub",
+										path: "github",
+										restrict: ["OWNER"],
+									},
+									{
+										name: "Access Control",
+										path: "access-control",
+										restrict: ["OWNER", "EDIT"],
+									},
+									{
+										name: "SMSS",
+										path: "smss",
+										restrict: ["OWNER"],
+									},
+								]}
+							/>
+						),
+						children: [
+							{
+								path: "",
+								element: <ProjectOverviewPage />,
+							},
+							{
+								path: "commits",
+								element: <AppCommitsPage />,
+							},
+							{
+								path: "github",
+								element: <AppGithubPage />,
+							},
+							{
+								path: "github/select-repo",
+								element: <AppGithubSelectRepoPage />,
+							},
+							{
+								path: "access-control",
+								element: <ProjectAccessControl />,
+							},
+							{
+								path: "smss",
+								element: <AppSmssPage />,
+							},
+						],
+					},
+				],
+			},
+		],
+	},
+	{
+		path: "notebook",
+		element: <Outlet />,
+		children: [
+			{
+				path: "",
+				element: <ProjectCatalog type="NOTEBOOK" />,
+			},
+			{
+				path: "new",
+				element: <CreateNotebookPage />,
+			},
+			{
+				path: ":appId",
+				element: <ProjectLayout type="NOTEBOOK" />,
+				children: [
+					{
+						path: "edit",
+						element: <ProjectEdit />,
+					},
+					{
+						path: "view",
+						element: <ViewNotebookPage />,
 					},
 					{
 						path: "*",

--- a/packages/client/src/pages/settings/settings-layout.tsx
+++ b/packages/client/src/pages/settings/settings-layout.tsx
@@ -241,6 +241,9 @@ export const SettingsLayout = observer(() => {
 			if (projectType === "SKILL") {
 				return `/skill/${id}/edit`;
 			}
+			if (projectType === "NOTEBOOK") {
+				return `/notebook/${id}/edit`;
+			}
 			return `/app/${id}`;
 		}
 		return null;

--- a/packages/client/src/pages/share-page.tsx
+++ b/packages/client/src/pages/share-page.tsx
@@ -1,92 +1,63 @@
 import { observer } from "mobx-react-lite";
-import { lazy, Suspense, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { getUserProjectPermission as getUserProjectLevelPermission } from "@semoss/sdk";
-import { runPixel } from "@semoss/sdk/react";
 import { Spinner, toast } from "@semoss/ui/next";
-import type { AppMetadata, AppType } from "@/components/app";
+import { ProjectView } from "@/components/project";
 import { PlatformMessages } from "@/components/shared";
-import { useNavigate } from "@/hooks/useNavigate";
-
-const Renderer = lazy(() =>
-	import("@semoss/renderer").then((m) => ({ default: m.Renderer })),
-);
-const CodeRenderer = lazy(() =>
-	import("@/components/code-workspace").then((m) => ({
-		default: m.CodeRenderer,
-	})),
-);
-
 import { useRootStore } from "@/hooks";
+import { useNavigate } from "@/hooks/useNavigate";
+import type { WorkspaceStore } from "@/stores";
 
+/** Project types the share page can render a read-only view for. */
+const SHAREABLE_TYPES = new Set<WorkspaceStore["type"]>([
+	"CODE",
+	"BLOCKS",
+	"SKILL",
+	"NOTEBOOK",
+]);
+
+/**
+ * Render a shared project's read-only view (navbar-free) for the `#/s/:appId` route.
+ */
 export const SharePage = observer(() => {
 	// App ID Needed for pixel calls
 	const { appId } = useParams();
-	const { monolithStore } = useRootStore();
+	const { configStore } = useRootStore();
 
 	const navigate = useNavigate();
 
-	const [type, setType] = useState<AppType | null>(null);
-	const [insightId, setInsightId] = useState("");
+	const [workspace, setWorkspace] = useState<WorkspaceStore | null>(null);
 
-	/**
-	 * Load an app
-	 *
-	 * @param appId - id of app to load into the workspace
-	 */
-	const loadApp = async (appId: string) => {
-		try {
-			// clear the type
-			setType(null);
-
-			// get the role and throw an error if it is missing
-			const role = await getUserProjectLevelPermission(appId);
-			if (!role) {
-				throw new Error("Unauthorized");
-			}
-
-			const { insightId: iId } = await runPixel(
-				`SetContext("${appId}")`,
-				"new",
-			);
-			setInsightId(iId);
-
-			// get the metadata
-			const getAppInfo = await monolithStore.runQuery<[AppMetadata]>(
-				`ProjectInfo(project=["${appId}"]);`,
-				iId,
-			);
-
-			// throw the errors if there are any
-			if (getAppInfo.errors.length > 0) {
-				throw new Error(getAppInfo.errors.join(""));
-			}
-
-			const metadata = {
-				...getAppInfo.pixelReturn[0].output,
-			};
-
-			let type: AppType = "CODE";
-			// set it as blocks
-			if (metadata.project_type === "BLOCKS") {
-				type = "BLOCKS";
-			}
-
-			setType(type);
-		} catch (e) {
-			toast.error(e.message);
-			navigate("/");
-		}
-	};
-
-	// load the app
+	// load the shared project into a workspace
 	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — reruns on appId change only
 	useEffect(() => {
-		loadApp(appId);
+		if (!appId) {
+			navigate("/");
+			return;
+		}
+
+		// clear out the old workspace
+		setWorkspace(null);
+
+		configStore
+			.createWorkspace(appId)
+			.then((loadedWorkspace) => {
+				// only render project types that have a read-only view
+				if (!SHAREABLE_TYPES.has(loadedWorkspace.type)) {
+					toast.error("This project type cannot be shared.");
+					navigate("/");
+					return;
+				}
+				setWorkspace(loadedWorkspace);
+			})
+			.catch((e) => {
+				toast.error(e.message);
+				navigate("/");
+			});
 	}, [appId]);
 
 	// hide the screen while it loads
-	if (!type) {
+	if (!workspace) {
 		return (
 			<div className="flex h-screen w-screen items-center justify-center">
 				<Spinner />
@@ -95,19 +66,8 @@ export const SharePage = observer(() => {
 	}
 
 	return (
-		<div className="flex h-screen w-screen overflow-hidden">
-			<Suspense
-				fallback={
-					<div className="flex h-screen w-screen items-center justify-center">
-						<Spinner />
-					</div>
-				}
-			>
-				{type === "CODE" ? <CodeRenderer appId={appId} /> : null}
-				{type === "BLOCKS" ? (
-					<Renderer appId={appId} insightId={insightId} />
-				) : null}
-			</Suspense>
+		<div className="relative flex h-screen w-screen overflow-hidden">
+			<ProjectView workspace={workspace} />
 			<PlatformMessages />
 		</div>
 	);

--- a/packages/client/src/stores/config/config.store.ts
+++ b/packages/client/src/stores/config/config.store.ts
@@ -830,6 +830,8 @@ export class ConfigStore {
 			workspace.type = "SKILL";
 		} else if (metadata.project_type === "WORKSPACE") {
 			workspace.type = "WORKSPACE";
+		} else if (metadata.project_type === "NOTEBOOK") {
+			workspace.type = "NOTEBOOK";
 		}
 
 		// create the newly loaded workspace

--- a/packages/client/src/stores/workspace/workspace.store.ts
+++ b/packages/client/src/stores/workspace/workspace.store.ts
@@ -38,7 +38,7 @@ export interface WorkspaceStoreInterface {
 	/**
 	 * Type of the app
 	 */
-	type: "BLOCKS" | "CODE" | "SKILL" | "WORKSPACE";
+	type: "BLOCKS" | "CODE" | "SKILL" | "WORKSPACE" | "NOTEBOOK";
 
 	/**
 	 * Model associated with the layout
@@ -73,7 +73,7 @@ export interface WorkspaceConfigInterface {
 	/**
 	 * Type of the app
 	 */
-	type: "BLOCKS" | "CODE" | "SKILL" | "WORKSPACE";
+	type: "BLOCKS" | "CODE" | "SKILL" | "WORKSPACE" | "NOTEBOOK";
 
 	/**
 	 * Metadata associated with the loaded app

--- a/packages/client/src/utility/catalog.ts
+++ b/packages/client/src/utility/catalog.ts
@@ -10,7 +10,8 @@ export const isProjectType = (type?: string): boolean => {
 		type === "WORKSPACE" ||
 		type === "BLOCKS" ||
 		type === "CODE" ||
-		type === "INSIGHT"
+		type === "INSIGHT" ||
+		type === "NOTEBOOK"
 	);
 };
 
@@ -30,6 +31,8 @@ export const getProjectLabel = (type?: Project["project_type"]): string => {
 		return "Code";
 	} else if (type === "INSIGHT") {
 		return "Insight";
+	} else if (type === "NOTEBOOK") {
+		return "Notebook";
 	}
 
 	return "Project";


### PR DESCRIPTION
## Description

Adds **Notebook** as a first-class project type in SEMOSS with its own catalog,
create flow, and read-only view. Notebooks are interactive `.ipynb` apps (edit +
run code cells, visualize data, document analysis) built on the existing
WorkspaceManager/AppFileExplorer/AppFileEditor pattern. Along the way, the
workspace navbar is extracted out of `WorkspaceManager` into a standalone
`WorkspaceNavbar`, and a reusable read-only mode is added to the shared file
editor/explorer.

## Changes Made

**New `NOTEBOOK` project type**
**Catalog, routes & pages**
**Notebook workspaces**
- New `components/notebook-workspace/`: `notebook-workspace.tsx` (edit — Files
  explorer + terminal + `main.ipynb` tab) and `notebook-view-workspace.tsx`
  (read-only), with a barrel. Primary file: `/public/main.ipynb`.
**Read-only file editing**
- `readOnly` added to shared `FileEditor`, `AppFileEditor`, and
  `AppFileExplorer` (gates publish, Create/Edit/Delete actions, and drag).
**Landing page**
- New "Run interactive notebooks" card (`NOTEBOOK.svg`), `onCreate` supports
  `"notebook"` → navigate to `/notebook`; grid expands to 4 columns.

**Misc**
- `config.store.ts` / `workspace.store.ts` support notebook workspaces;
  `AGENTS.md` gains deprecation guidance + a "Mandatory Audit Before Handoff"
  section.

## How to Test

1. From the landing page, click **Run interactive notebooks** (or go to
   `/notebook`) to open the Notebook Catalog.
2. Click **New**, enter a name (description/tags optional), and **Create** — it
   should create the notebook and open `/notebook/:appId/edit`.
3. In the edit workspace, confirm `main.ipynb` opens, the left **Files** panel
   and **Terminal** work, and adding/running cells + saving/publishing succeed.
4. Open the notebook's **view** route (`/notebook/:appId/view`) and confirm it is
   read-only: no publish button, no Create/Edit/Delete/drag on files, editor
   read-only, and an **Edit** button appears only for OWNER/EDIT roles.
5. Regression-check the other workspaces (code/agent/blocks/skill): navbar still
   renders and settings/reset toggles still work after the `WorkspaceNavbar`
   extraction.

**Expected outcomes:** Notebooks are created, edited, and viewed through the new
catalog; the view is fully read-only; existing workspaces are unaffected; and
NOTEBOOK projects show the "Notebook" label in catalog, sidebar, share, and
settings.

## Notes

- Requires backend support for the `CreateNotebook` pixel and the `NOTEBOOK`
  project type.
- **Breaking change:** `WorkspaceManager` no longer owns the navbar — consumers
  must render `WorkspaceNavbar` themselves.
- `WorkspaceManager` `readOnly` intentionally disables layout-cache persistence
  because the cache key is per-`appId`, so view + edit would otherwise clobber
  each other.
- Notebook file paths assume `/public/main.ipynb` (edit Files root `/`, view root
  `/public`); a backend path change would be a one-line update in both workspace
  files.