### PR TITLE
fix(sdk): skip CSRF handshake for Basic-auth requests

### DIFF
--- a/libs/sdk/src/utility/fetch.ts
+++ b/libs/sdk/src/utility/fetch.ts
@@ -87,8 +87,11 @@ const interceptors: {
 			};
 		}
 
+		// Basic auth isn't cookie-based, so it isn't CSRF-forgeable — skip the handshake.
+		const usingBasicAuth = Boolean(Env.ACCESS_KEY && Env.SECRET_KEY);
+
 		// only set if enabled
-		if (CSRF.isEnabled || Env.CSRF) {
+		if (!usingBasicAuth && (CSRF.isEnabled || Env.CSRF)) {
 			if (options.method === "POST") {
 				// use the token if it is there otherwise fetch it
 				if (!CSRF.token) {


### PR DESCRIPTION
## Description
Basic-auth (access/secret key) requests were failing CSRF validation on instances with CSRF protection enabled, because the CSRF handshake relies on a session cookie being paired with the token — a flow that only works reliably in a browser and breaks for headless/Node consumers of the SDK.

## Changes Made
- `libs/sdk/src/utility/fetch.ts`: skip the CSRF token handshake when the request is authenticated via `Env.ACCESS_KEY`/`SECRET_KEY` (Basic auth).

## How to Test
Self explanatory.

## Notes
CSRF protection exists to stop a third-party page from forging a request that rides on a victim's cookies, which browsers attach automatically. A request authenticated via an explicit `Authorization: Basic` header isn't vulnerable to that — a forged cross-site request can't set that header — so skipping the handshake for this auth path doesn't weaken CSRF protection for cookie/session-based logins, which are unaffected.