### PR TITLE
fix(client): render SharePage at bare #/s/:appId share URL

### DIFF
--- a/packages/client/src/pages/router.tsx
+++ b/packages/client/src/pages/router.tsx
@@ -71,6 +71,7 @@ export const Router = observer(() => {
 			<Routes>
 				<Route path="/" element={<AuthenticatedLayout />}>
 					<Route path="s/:appId" element={<ProjectLayout />}>
+						<Route index element={<SharePage />} />
 						<Route path="*" element={<SharePage />} />
 					</Route>
 					<Route path="*" element={<PageLayout />}>


### PR DESCRIPTION
## Problem

Since #3549 (merged Aug 13), the URL copied by the **Share App** dialog — `<base>#/s/<appId>` — is broken: opening it renders `ProjectLayout` with an empty outlet and the shared app never appears. Users found that appending an extra segment (e.g. `/portals`) to the copied URL makes it work.

## Cause

#3549 restructured the share route from a single leaf splat route to a nested one:

```jsx
// before
<Route path="s/:appId/*" element={<SharePage />} />
// after
<Route path="s/:appId" element={<ProjectLayout />}>
    <Route path="*" element={<SharePage />} />
</Route>
```

In React Router 6, a nested `path="*"` child does **not** match the parent's bare path — an `index` route is required. Verified against the repo's `react-router-dom@6.30.3` with `matchRoutes`:

- `/s/abc` → matched only `/ > s/:appId` (SharePage never rendered)
- `/s/abc/portals` → matched `/ > s/:appId > *` (which is why appending `/portals` "fixed" it)

## Fix

Add an index child rendering the same `SharePage`:

```jsx
<Route path="s/:appId" element={<ProjectLayout />}>
    <Route index element={<SharePage />} />
    <Route path="*" element={<SharePage />} />
</Route>
```

After the fix, `matchRoutes` resolves `/s/abc`, `/s/abc/`, and `/s/abc/<anything>` to SharePage. The copied URL itself was always correct, so no change to the Share dialog is needed. `tsc --noEmit` on `packages/client` reports an identical error profile before and after the change (all pre-existing).