### PR TITLE
Model Catalog: redesign the model Overview tab

### DIFF
--- a/packages/client/src/components/engine/engine-metadata-display.test.ts
+++ b/packages/client/src/components/engine/engine-metadata-display.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildReasoningConfigPayload,
+	formatPrice,
+	formatPricingProviderLabel,
 	getDefaultEffortWarning,
 	getEffortOptions,
 	getMandatoryReasoningWarning,
@@ -12,6 +14,7 @@ import {
 	type ModelSettingsValues,
 	normalizeCatalogModalities,
 	normalizeCatalogTokenLimit,
+	normalizePricing,
 	pickNearestEffort,
 	sortEfforts,
 	toModelSettingsValues,
@@ -325,5 +328,123 @@ describe("buildReasoningConfigPayload", () => {
 
 	it("invents nothing for a model without a stored config", () => {
 		expect(buildReasoningConfigPayload(null, values)).toBeNull();
+	});
+});
+
+describe("normalizePricing", () => {
+	it("keeps valid entries in payload order", () => {
+		const result = normalizePricing([
+			{ servingProvider: "anthropic", input: 3, output: 15 },
+			{ servingProvider: "amazon-bedrock", input: 3 },
+		]);
+
+		expect(result).toHaveLength(2);
+		expect(result[0].servingProvider).toBe("anthropic");
+		expect(result[1].servingProvider).toBe("amazon-bedrock");
+	});
+
+	it("coerces numeric string rates", () => {
+		const result = normalizePricing([
+			{ servingProvider: "openai", input: "1.75" },
+		]);
+
+		expect(result[0].input).toBe(1.75);
+	});
+
+	it("never treats a null rate as zero", () => {
+		const result = normalizePricing([
+			{ servingProvider: "openai", input: null, output: 15 },
+		]);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].input).toBeUndefined();
+		expect(result[0].output).toBe(15);
+	});
+
+	it("keeps a zero rate", () => {
+		const result = normalizePricing([
+			{ servingProvider: "openai", input: 0 },
+		]);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].input).toBe(0);
+	});
+
+	it("drops entries without a provider", () => {
+		expect(
+			normalizePricing([
+				{ servingProvider: "  ", input: 3 },
+				{ input: 3 },
+			]),
+		).toEqual([]);
+	});
+
+	it("drops entries without a usable rate", () => {
+		expect(
+			normalizePricing([
+				{ servingProvider: "openai" },
+				{
+					servingProvider: "openai",
+					input: "abc",
+					output: Number.NaN,
+				},
+				{ servingProvider: "openai", input: -1 },
+			]),
+		).toEqual([]);
+	});
+
+	it("returns nothing for non-array payloads", () => {
+		expect(normalizePricing(undefined)).toEqual([]);
+		expect(normalizePricing(null)).toEqual([]);
+		expect(normalizePricing({ openai: { "gpt-5.2": {} } })).toEqual([]);
+		expect(normalizePricing("openai")).toEqual([]);
+	});
+
+	it("strips rate extras like tiers", () => {
+		const result = normalizePricing([
+			{ servingProvider: "google", input: 2, tiers: [{ input: 4 }] },
+		]);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).not.toHaveProperty("tiers");
+	});
+});
+
+describe("formatPrice", () => {
+	it("keeps whole-dollar rates reading as currency", () => {
+		expect(formatPrice(14)).toBe("$14.00");
+		expect(formatPrice(1.75)).toBe("$1.75");
+	});
+
+	it("keeps sub-cent rates meaningful", () => {
+		expect(formatPrice(0.175)).toBe("$0.175");
+		expect(formatPrice(0.058)).toBe("$0.058");
+		expect(formatPrice(0.0001)).toBe("$0.0001");
+	});
+
+	it("groups large rates", () => {
+		expect(formatPrice(1234.5)).toBe("$1,234.50");
+	});
+});
+
+describe("formatPricingProviderLabel", () => {
+	it("maps catalog keys onto the curated labels", () => {
+		expect(formatPricingProviderLabel("openai")).toBe("OpenAI");
+		expect(formatPricingProviderLabel("anthropic")).toBe("Anthropic");
+		expect(formatPricingProviderLabel("google")).toBe("Google");
+		expect(formatPricingProviderLabel("google-vertex")).toBe(
+			"Google Vertex AI",
+		);
+	});
+
+	it("title cases unknown keys", () => {
+		expect(formatPricingProviderLabel("amazon-bedrock")).toBe(
+			"Amazon Bedrock",
+		);
+		expect(formatPricingProviderLabel("azure")).toBe("Azure");
+	});
+
+	it("normalizes whitespace and case before the lookup", () => {
+		expect(formatPricingProviderLabel(" OPENAI ")).toBe("OpenAI");
 	});
 });

--- a/packages/client/src/components/engine/engine-metadata-display.tsx
+++ b/packages/client/src/components/engine/engine-metadata-display.tsx
@@ -1,14 +1,12 @@
 import dayjs from "dayjs";
 import { CheckIcon, TriangleAlert, XIcon } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import {
 	Badge,
 	Button,
-	Card,
-	CardContent,
-	CardHeader,
-	CardTitle,
 	cn,
+	Progress,
+	Separator,
 	Table,
 	TableBody,
 	TableCell,
@@ -94,6 +92,7 @@ export type ModelMetadata = {
 	supportedParameters?: string[] | null;
 	reasoningConfig?: Record<string, unknown> | null;
 	benchmarks?: Record<string, unknown>[] | null;
+	pricing?: ModelPricing[] | null;
 };
 
 /**
@@ -108,6 +107,20 @@ export interface ModelBenchmark {
 	variant?: string;
 	version?: string;
 	dataset?: string;
+}
+
+/**
+ * One provider's published rates for the model, in $ per 1M tokens. Entries
+ * arrive ordered with the preferred serving provider first. The backend also
+ * stores tiered/audio/reasoning rate extras, which are ignored here.
+ */
+export interface ModelPricing {
+	servingProvider: string;
+	modelId?: string;
+	input?: number;
+	output?: number;
+	cache_read?: number;
+	cache_write?: number;
 }
 
 export const CAPABILITIES = [
@@ -191,6 +204,22 @@ export const formatModelProviderLabel = (value: string) =>
 /** Display label for a serving provider, title cased for unknown values. */
 export const formatServingProviderLabel = (value: string) =>
 	SERVING_PROVIDER_LABELS[value] || formatEnumLabel(value);
+
+/**
+ * Display label for a pricing entry's provider. Pricing keys are catalog-style
+ * lowercase/hyphenated ("openai", "amazon-bedrock"), unlike the UPPER_SNAKE
+ * serving-provider enum, so the key is normalized before the label lookups and
+ * unknown keys fall back to title case.
+ */
+export const formatPricingProviderLabel = (value: string) => {
+	const normalized = value.trim().toUpperCase().replace(/-/g, "_");
+
+	return (
+		SERVING_PROVIDER_LABELS[normalized] ||
+		MODEL_PROVIDER_LABELS[normalized] ||
+		formatEnumLabel(normalized)
+	);
+};
 
 /**
  * The selectable provider values: the curated list, plus whatever is currently
@@ -525,6 +554,17 @@ export const formatDigits = (digits: string) => {
 	return Number.isFinite(parsed) ? parsed.toLocaleString() : digits;
 };
 
+/**
+ * Format a $-per-1M-token rate. Rates span ~0.0001 to 100+, so up to four
+ * fraction digits keep the cheap rates meaningful while whole-dollar rates
+ * still read as currency ("$14.00", "$0.175").
+ */
+export const formatPrice = (value: number): string =>
+	`$${value.toLocaleString(undefined, {
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 4,
+	})}`;
+
 export const normalizeStringArray = (value: unknown): string[] => {
 	const values = Array.isArray(value)
 		? value
@@ -559,6 +599,29 @@ export const formatMetadataDate = (value: unknown): string => {
 	}
 
 	return dayjs(trimmed).format("MMM D, YYYY");
+};
+
+/**
+ * Split a catalog date into the headline day ("Feb 19") and its year, for the
+ * overview stat strip. Same local-time parsing rationale as
+ * {@link formatMetadataDate}.
+ *
+ * @returns The parts, or null when the value is missing or unparseable.
+ */
+export const formatMetadataDateParts = (
+	value: unknown,
+): { day: string; year: string } | null => {
+	if (typeof value !== "string") {
+		return null;
+	}
+
+	const trimmed = value.trim();
+	if (trimmed === "" || !dayjs(trimmed).isValid()) {
+		return null;
+	}
+
+	const parsed = dayjs(trimmed);
+	return { day: parsed.format("MMM D"), year: parsed.format("YYYY") };
 };
 
 /** Boolean model traits, in the order they are displayed. */
@@ -619,6 +682,72 @@ export const normalizeBenchmarks = (value: unknown): ModelBenchmark[] => {
 				variant: optionalText(record.variant),
 				version: optionalText(record.version),
 				dataset: optionalText(record.dataset),
+			},
+		];
+	});
+};
+
+/**
+ * Coerce the loosely-typed pricing payload into usable entries, discarding
+ * anything without a provider and at least one finite rate. Non-array input
+ * (the pixel can send null, or the raw unordered catalog map) yields nothing,
+ * since only the ordered array shape carries the preferred-provider order.
+ */
+export const normalizePricing = (value: unknown): ModelPricing[] => {
+	if (!Array.isArray(value)) {
+		return [];
+	}
+
+	// A null or absent rate must stay undefined - "not published" renders as
+	// a dash, never as $0.00 - so bare Number() coercion is off the table.
+	const optionalRate = (raw: unknown): number | undefined => {
+		if (typeof raw === "number") {
+			return Number.isFinite(raw) && raw >= 0 ? raw : undefined;
+		}
+
+		if (typeof raw === "string" && raw.trim() !== "") {
+			const parsed = Number(raw);
+			return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+		}
+
+		return undefined;
+	};
+
+	const optionalText = (raw: unknown) => {
+		const text = typeof raw === "string" ? raw.trim() : "";
+		return text !== "" ? text : undefined;
+	};
+
+	return value.flatMap((entry) => {
+		if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+			return [];
+		}
+
+		const record = entry as Record<string, unknown>;
+		const servingProvider = optionalText(record.servingProvider);
+		const input = optionalRate(record.input);
+		const output = optionalRate(record.output);
+		const cacheRead = optionalRate(record.cache_read);
+		const cacheWrite = optionalRate(record.cache_write);
+
+		if (
+			!servingProvider ||
+			(input === undefined &&
+				output === undefined &&
+				cacheRead === undefined &&
+				cacheWrite === undefined)
+		) {
+			return [];
+		}
+
+		return [
+			{
+				servingProvider,
+				modelId: optionalText(record.modelId),
+				input,
+				output,
+				cache_read: cacheRead,
+				cache_write: cacheWrite,
 			},
 		];
 	});
@@ -1027,186 +1156,146 @@ export const ModelMetadataFields = ({
 /** How many benchmark rows show before the table has to be expanded. */
 const BENCHMARK_PREVIEW_COUNT = 5;
 
+/** One figure in the overview's headline stat strip. */
+interface OverviewStatItem {
+	label: string;
+	value: string;
+	/** The muted line under the value, e.g. "tokens" or a year. */
+	unit: string;
+}
+
 /**
- * Card shell for the overview panels. Cards flex to fill the row, so a model
- * with only one populated panel still spans the full width.
+ * The full-width strip of headline figures under the description: token
+ * limits, dates, and the preferred provider's rates. Divider lines only
+ * appear at xl, where the strip is guaranteed a single row.
  */
-const OverviewCard = ({
-	title,
-	children,
-}: React.PropsWithChildren<{ title: string }>) => (
-	<Card className="min-w-72 flex-1 gap-4 py-5">
-		<CardHeader className="px-5">
-			<CardTitle>{title}</CardTitle>
-		</CardHeader>
-		<CardContent className="px-5">{children}</CardContent>
-	</Card>
-);
-
-/** A headline number with its unit, e.g. the context window. */
-const StatValue = ({ label, value }: { label: string; value: string }) => (
-	<div className="flex flex-col gap-1">
-		<span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-			{label}
-		</span>
-		<span className="font-semibold text-2xl tabular-nums">
-			{formatDigits(value)}
-		</span>
-		<span className="text-muted-foreground text-xs">tokens</span>
+const OverviewStatStrip = ({ stats }: { stats: OverviewStatItem[] }) => (
+	<div className="grid grid-cols-2 gap-x-8 gap-y-6 border-y py-5 sm:grid-cols-3 xl:flex xl:gap-0 xl:divide-x">
+		{stats.map((stat) => (
+			<div
+				key={stat.label}
+				className="flex flex-col gap-1 xl:flex-1 xl:px-6 xl:last:pr-0 xl:first:pl-0"
+			>
+				<span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+					{stat.label}
+				</span>
+				<span className="font-semibold text-2xl tabular-nums">
+					{stat.value}
+				</span>
+				<span className="text-muted-foreground text-xs">
+					{stat.unit}
+				</span>
+			</div>
+		))}
 	</div>
 );
 
-/** A date value under a small muted label. */
-const DateValue = ({ label, value }: { label: string; value: string }) => (
-	<div className="flex flex-col gap-1">
+/** Section heading shared by the overview's flat sections. */
+const OverviewSectionTitle = ({ children }: React.PropsWithChildren) => (
+	<h3 className="font-semibold">{children}</h3>
+);
+
+/**
+ * One specification row: the uppercase label in a fixed left column with the
+ * value chips beside it, stacking on narrow screens.
+ */
+const SpecRow = ({
+	label,
+	children,
+}: React.PropsWithChildren<{ label: string }>) => (
+	<div className="grid gap-1.5 sm:grid-cols-[11rem_1fr] sm:items-center sm:gap-4">
 		<span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
 			{label}
 		</span>
-		<span className="text-base">{value}</span>
+		<div>{children}</div>
 	</div>
 );
 
 /**
- * Capability, modalities, and the boolean trait flags. Each block is dropped
+ * Capability, modalities, and the boolean trait flags. Each row is dropped
  * when the provider reported nothing for it.
  */
-const SpecificationCard = ({
+const SpecificationSection = ({
 	values,
 	capabilityFlags,
 }: {
 	values: ModelSettingsValues;
 	capabilityFlags: ReturnType<typeof getCapabilityFlags>;
 }) => (
-	<OverviewCard title="Specification">
-		<div className="flex flex-col gap-5">
-			{values.capability !== "" && (
-				<SettingsEntry label="Capability">
-					<Badge variant="outline" className={BADGE_TONES.blue}>
-						{formatEnumLabel(values.capability)}
-					</Badge>
-				</SettingsEntry>
-			)}
+	<section className="flex flex-col gap-4">
+		<OverviewSectionTitle>Specification</OverviewSectionTitle>
 
-			{values.inputModalities.length > 0 && (
-				<SettingsEntry label="Input modalities">
-					<BadgeList
-						values={values.inputModalities}
-						format={formatModalityLabel}
-						tone="violet"
-					/>
-				</SettingsEntry>
-			)}
+		{values.capability !== "" && (
+			<SpecRow label="Capability">
+				<Badge variant="outline" className={BADGE_TONES.blue}>
+					{formatEnumLabel(values.capability)}
+				</Badge>
+			</SpecRow>
+		)}
 
-			{values.outputModalities.length > 0 && (
-				<SettingsEntry label="Output modalities">
-					<BadgeList
-						values={values.outputModalities}
-						format={formatModalityLabel}
-						tone="teal"
-					/>
-				</SettingsEntry>
-			)}
+		{values.inputModalities.length > 0 && (
+			<SpecRow label="Input modalities">
+				<BadgeList
+					values={values.inputModalities}
+					format={formatModalityLabel}
+					tone="violet"
+				/>
+			</SpecRow>
+		)}
 
-			{values.builtinTools.length > 0 && (
-				<SettingsEntry label="Built-in tools">
-					<BadgeList values={values.builtinTools} mono />
-				</SettingsEntry>
-			)}
+		{values.outputModalities.length > 0 && (
+			<SpecRow label="Output modalities">
+				<BadgeList
+					values={values.outputModalities}
+					format={formatModalityLabel}
+					tone="teal"
+				/>
+			</SpecRow>
+		)}
 
-			{capabilityFlags.length > 0 && (
-				<SettingsEntry label="Supports">
-					<div className="flex flex-wrap gap-1.5">
-						{capabilityFlags.map((flag) => (
-							<Badge
-								key={flag.key}
-								variant="outline"
-								className={
-									flag.enabled
-										? BADGE_TONES.emerald
-										: "text-muted-foreground"
-								}
-							>
-								{flag.enabled ? (
-									<CheckIcon className="size-3" />
-								) : (
-									<XIcon className="size-3" />
-								)}
-								{flag.label}
-							</Badge>
-						))}
-					</div>
-				</SettingsEntry>
-			)}
-		</div>
-	</OverviewCard>
+		{values.builtinTools.length > 0 && (
+			<SpecRow label="Built-in tools">
+				<BadgeList values={values.builtinTools} mono />
+			</SpecRow>
+		)}
+
+		{capabilityFlags.length > 0 && (
+			<SpecRow label="Supports">
+				<div className="flex flex-wrap gap-1.5">
+					{capabilityFlags.map((flag) => (
+						<Badge
+							key={flag.key}
+							variant="outline"
+							className={
+								flag.enabled
+									? BADGE_TONES.emerald
+									: "text-muted-foreground"
+							}
+						>
+							{flag.enabled ? (
+								<CheckIcon className="size-3" />
+							) : (
+								<XIcon className="size-3" />
+							)}
+							{flag.label}
+						</Badge>
+					))}
+				</div>
+			</SpecRow>
+		)}
+	</section>
 );
-
-/** Token limits alongside the release and knowledge-cutoff dates. */
-const LimitsCard = ({
-	contextWindow,
-	maxOutputTokens,
-	releaseDate,
-	knowledgeCutoff,
-}: {
-	contextWindow: string;
-	maxOutputTokens: string;
-	releaseDate: string;
-	knowledgeCutoff: string;
-}) => {
-	const hasLimits = contextWindow !== "" || maxOutputTokens !== "";
-	const hasDates = releaseDate !== "" || knowledgeCutoff !== "";
-
-	return (
-		<OverviewCard
-			title={
-				hasLimits && hasDates
-					? "Limits & dates"
-					: hasLimits
-						? "Limits"
-						: "Dates"
-			}
-		>
-			<div className="flex flex-col gap-5">
-				{hasLimits && (
-					<div className="grid grid-cols-2 gap-4">
-						{contextWindow !== "" && (
-							<StatValue
-								label="Context window"
-								value={contextWindow}
-							/>
-						)}
-						{maxOutputTokens !== "" && (
-							<StatValue
-								label="Max output"
-								value={maxOutputTokens}
-							/>
-						)}
-					</div>
-				)}
-
-				{hasDates && (
-					<div className="grid grid-cols-2 gap-4">
-						{releaseDate !== "" && (
-							<DateValue label="Released" value={releaseDate} />
-						)}
-						{knowledgeCutoff !== "" && (
-							<DateValue
-								label="Knowledge cutoff"
-								value={knowledgeCutoff}
-							/>
-						)}
-					</div>
-				)}
-			</div>
-		</OverviewCard>
-	);
-};
 
 /**
  * Published benchmark scores, collapsed to a short preview when the provider
- * reported a long list.
+ * reported a long list. Scores on a 0-100 scale also render as a filled bar;
+ * open-ended scales (Elo-style ratings) stay numbers-only.
  */
-const BenchmarksCard = ({ benchmarks }: { benchmarks: ModelBenchmark[] }) => {
+const BenchmarksSection = ({
+	benchmarks,
+}: {
+	benchmarks: ModelBenchmark[];
+}) => {
 	const [isExpanded, setIsExpanded] = useState(false);
 
 	const ranked = useMemo(() => rankBenchmarks(benchmarks), [benchmarks]);
@@ -1217,57 +1306,14 @@ const BenchmarksCard = ({ benchmarks }: { benchmarks: ModelBenchmark[] }) => {
 	const visible = isExpanded ? ranked : preview;
 
 	return (
-		<OverviewCard title="Benchmarks">
-			<div className="flex flex-col gap-3">
-				<Table>
-					<TableHeader>
-						<TableRow className="hover:bg-transparent">
-							<TableHead className="h-auto px-0 pb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
-								Benchmark
-							</TableHead>
-							<TableHead className="h-auto px-2 pb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
-								Metric
-							</TableHead>
-							<TableHead className="h-auto px-0 pb-2 text-end font-medium text-muted-foreground text-xs uppercase tracking-wide">
-								Score
-							</TableHead>
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						{visible.map((benchmark, index) => {
-							const detail = formatBenchmarkDetail(benchmark);
-
-							return (
-								<TableRow
-									// Benchmarks have no id and the same name
-									// repeats across harnesses, so the rendered
-									// position is part of the key.
-									key={`${benchmark.name}-${detail}-${index}`}
-									className="hover:bg-transparent"
-								>
-									<TableCell className="whitespace-normal px-0">
-										{benchmark.name}
-									</TableCell>
-									<TableCell className="whitespace-normal px-2 text-muted-foreground text-xs">
-										{detail}
-									</TableCell>
-									<TableCell className="px-0 text-end font-semibold tabular-nums">
-										{benchmark.score.toLocaleString(
-											undefined,
-											{ maximumFractionDigits: 2 },
-										)}
-									</TableCell>
-								</TableRow>
-							);
-						})}
-					</TableBody>
-				</Table>
-
+		<section className="flex flex-col gap-4">
+			<div className="flex items-center justify-between gap-3">
+				<OverviewSectionTitle>Benchmarks</OverviewSectionTitle>
 				{ranked.length > preview.length && (
 					<Button
 						variant="link"
 						size="sm"
-						className="h-auto justify-start self-start p-0 text-xs"
+						className="h-auto p-0 text-xs"
 						onClick={() => setIsExpanded((prev) => !prev)}
 						data-testid="engine-overview--benchmarks-toggle"
 					>
@@ -1277,26 +1323,220 @@ const BenchmarksCard = ({ benchmarks }: { benchmarks: ModelBenchmark[] }) => {
 					</Button>
 				)}
 			</div>
-		</OverviewCard>
+
+			<Table>
+				<TableHeader>
+					<TableRow className="hover:bg-transparent">
+						<TableHead className="h-auto px-0 pb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+							Benchmark
+						</TableHead>
+						<TableHead className="h-auto px-2 pb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+							Metric
+						</TableHead>
+						{/* The score-bar column has no heading of its own. */}
+						<TableHead
+							className="hidden h-auto px-2 pb-2 md:table-cell"
+							aria-hidden
+						/>
+						<TableHead className="h-auto px-0 pb-2 text-end font-medium text-muted-foreground text-xs uppercase tracking-wide">
+							Score
+						</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{visible.map((benchmark, index) => {
+						const detail = formatBenchmarkDetail(benchmark);
+						const barValue =
+							benchmark.score >= 0 && benchmark.score <= 100
+								? benchmark.score
+								: null;
+
+						return (
+							<TableRow
+								// Benchmarks have no id and the same name
+								// repeats across harnesses, so the rendered
+								// position is part of the key.
+								key={`${benchmark.name}-${detail}-${index}`}
+								className="hover:bg-transparent"
+							>
+								<TableCell className="whitespace-normal px-0 font-medium">
+									{benchmark.name}
+								</TableCell>
+								<TableCell className="whitespace-normal px-2 text-muted-foreground text-xs">
+									{detail}
+								</TableCell>
+								<TableCell className="hidden w-1/3 px-2 md:table-cell">
+									{barValue !== null && (
+										<Progress
+											value={barValue}
+											className="h-1.5"
+										/>
+									)}
+								</TableCell>
+								<TableCell className="px-0 text-end font-semibold tabular-nums">
+									{benchmark.score.toLocaleString(undefined, {
+										maximumFractionDigits: 2,
+									})}
+								</TableCell>
+							</TableRow>
+						);
+					})}
+				</TableBody>
+			</Table>
+		</section>
 	);
 };
 
 /**
- * The overview's card row. Every card - and every field inside a card - is
- * omitted when the provider did not report it, so a sparse model renders a
- * short row instead of a wall of "Not set". Renders nothing at all when the
- * catalog knows none of these fields.
+ * Published per-provider rates, preferred serving provider first. The cache
+ * columns only render when at least one provider reports that rate, keeping
+ * the table narrow for the common input/output-only case.
  */
-export const ModelOverviewCards = ({
+const PricingSection = ({ pricing }: { pricing: ModelPricing[] }) => {
+	const hasCacheRead = pricing.some(
+		(entry) => entry.cache_read !== undefined,
+	);
+	const hasCacheWrite = pricing.some(
+		(entry) => entry.cache_write !== undefined,
+	);
+
+	const rate = (value: number | undefined) =>
+		value !== undefined ? formatPrice(value) : "—";
+
+	return (
+		<section className="flex flex-col gap-4">
+			<div className="flex flex-col gap-1">
+				<OverviewSectionTitle>Pricing</OverviewSectionTitle>
+				<p className="text-muted-foreground text-sm">$ per 1M tokens</p>
+			</div>
+			<Table>
+				<TableHeader>
+					<TableRow className="hover:bg-transparent">
+						<TableHead className="h-auto px-0 pb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+							Provider
+						</TableHead>
+						<TableHead className="h-auto px-2 pb-2 text-end font-medium text-muted-foreground text-xs uppercase tracking-wide">
+							Input
+						</TableHead>
+						<TableHead className="h-auto px-2 pb-2 text-end font-medium text-muted-foreground text-xs uppercase tracking-wide">
+							Output
+						</TableHead>
+						{hasCacheRead && (
+							<TableHead className="h-auto px-2 pb-2 text-end font-medium text-muted-foreground text-xs uppercase tracking-wide">
+								Cache read
+							</TableHead>
+						)}
+						{hasCacheWrite && (
+							<TableHead className="h-auto px-2 pb-2 text-end font-medium text-muted-foreground text-xs uppercase tracking-wide">
+								Cache write
+							</TableHead>
+						)}
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{pricing.map((entry, index) => (
+						<TableRow
+							// Providers can repeat across rows, so the
+							// rendered position is part of the key, matching
+							// BenchmarksSection.
+							key={`${entry.servingProvider}-${entry.modelId ?? ""}-${index}`}
+							className="hover:bg-transparent"
+						>
+							<TableCell className="whitespace-normal px-0">
+								{formatPricingProviderLabel(
+									entry.servingProvider,
+								)}
+							</TableCell>
+							<TableCell className="px-2 text-end tabular-nums">
+								{rate(entry.input)}
+							</TableCell>
+							<TableCell className="px-2 text-end tabular-nums">
+								{rate(entry.output)}
+							</TableCell>
+							{hasCacheRead && (
+								<TableCell className="px-2 text-end tabular-nums">
+									{rate(entry.cache_read)}
+								</TableCell>
+							)}
+							{hasCacheWrite && (
+								<TableCell className="px-2 text-end tabular-nums">
+									{rate(entry.cache_write)}
+								</TableCell>
+							)}
+						</TableRow>
+					))}
+				</TableBody>
+			</Table>
+		</section>
+	);
+};
+
+/**
+ * The overview's flat sections: the headline stat strip, then Specification,
+ * Benchmarks, and Pricing separated by rules. Every section - and every field
+ * inside one - is omitted when the provider did not report it, so a sparse
+ * model renders a short page instead of a wall of "Not set". Renders nothing
+ * at all when the catalog knows none of these fields.
+ */
+export const ModelOverviewSections = ({
 	metadata,
 }: {
 	metadata: ModelMetadata | undefined;
 }) => {
 	const values = toModelSettingsValues(metadata);
 	const capabilityFlags = getCapabilityFlags(metadata);
-	const releaseDate = formatMetadataDate(metadata?.releaseDate);
-	const knowledgeCutoff = formatMetadataDate(metadata?.knowledgeCutoff);
+	const releaseDate = formatMetadataDateParts(metadata?.releaseDate);
+	const knowledgeCutoff = formatMetadataDateParts(metadata?.knowledgeCutoff);
 	const benchmarks = normalizeBenchmarks(metadata?.benchmarks);
+	const pricing = normalizePricing(metadata?.pricing);
+
+	// The strip's headline rates come from the preferred serving provider,
+	// which the backend orders first.
+	const headlineRates = pricing.length > 0 ? pricing[0] : undefined;
+
+	const stats: OverviewStatItem[] = [];
+	if (values.contextWindow !== "") {
+		stats.push({
+			label: "Context window",
+			value: formatDigits(values.contextWindow),
+			unit: "tokens",
+		});
+	}
+	if (values.maxOutputTokens !== "") {
+		stats.push({
+			label: "Max output",
+			value: formatDigits(values.maxOutputTokens),
+			unit: "tokens",
+		});
+	}
+	if (releaseDate) {
+		stats.push({
+			label: "Released",
+			value: releaseDate.day,
+			unit: releaseDate.year,
+		});
+	}
+	if (knowledgeCutoff) {
+		stats.push({
+			label: "Knowledge cutoff",
+			value: knowledgeCutoff.day,
+			unit: knowledgeCutoff.year,
+		});
+	}
+	if (headlineRates?.input !== undefined) {
+		stats.push({
+			label: "Input price",
+			value: formatPrice(headlineRates.input),
+			unit: "per 1M tokens",
+		});
+	}
+	if (headlineRates?.output !== undefined) {
+		stats.push({
+			label: "Output price",
+			value: formatPrice(headlineRates.output),
+			unit: "per 1M tokens",
+		});
+	}
 
 	const hasSpecification =
 		values.capability !== "" ||
@@ -1304,35 +1544,52 @@ export const ModelOverviewCards = ({
 		values.outputModalities.length > 0 ||
 		values.builtinTools.length > 0 ||
 		capabilityFlags.length > 0;
-	const hasLimits =
-		values.contextWindow !== "" ||
-		values.maxOutputTokens !== "" ||
-		releaseDate !== "" ||
-		knowledgeCutoff !== "";
 
-	if (!hasSpecification && !hasLimits && benchmarks.length === 0) {
+	// The strip already carries the preferred provider's input/output rates,
+	// so the table only earns its keep with more than that: extra providers,
+	// or cache rates.
+	const showPricingTable =
+		pricing.length > 1 ||
+		pricing.some(
+			(entry) =>
+				entry.cache_read !== undefined ||
+				entry.cache_write !== undefined,
+		);
+
+	const sections: React.ReactElement[] = [];
+	if (hasSpecification) {
+		sections.push(
+			<SpecificationSection
+				key="specification"
+				values={values}
+				capabilityFlags={capabilityFlags}
+			/>,
+		);
+	}
+	if (benchmarks.length > 0) {
+		sections.push(
+			<BenchmarksSection key="benchmarks" benchmarks={benchmarks} />,
+		);
+	}
+	if (showPricingTable) {
+		sections.push(<PricingSection key="pricing" pricing={pricing} />);
+	}
+
+	if (stats.length === 0 && sections.length === 0) {
 		return null;
 	}
 
 	return (
-		<div className="flex flex-wrap items-start gap-4">
-			{hasSpecification && (
-				<SpecificationCard
-					values={values}
-					capabilityFlags={capabilityFlags}
-				/>
-			)}
-			{hasLimits && (
-				<LimitsCard
-					contextWindow={values.contextWindow}
-					maxOutputTokens={values.maxOutputTokens}
-					releaseDate={releaseDate}
-					knowledgeCutoff={knowledgeCutoff}
-				/>
-			)}
-			{benchmarks.length > 0 && (
-				<BenchmarksCard benchmarks={benchmarks} />
-			)}
+		<div className="flex flex-col gap-6">
+			{stats.length > 0 && <OverviewStatStrip stats={stats} />}
+			{sections.map((section, index) => (
+				// The strip's own bottom border already rules off the first
+				// section, so separators only go between sections.
+				<Fragment key={section.key}>
+					{index > 0 && <Separator />}
+					{section}
+				</Fragment>
+			))}
 		</div>
 	);
 };

--- a/packages/client/src/components/engine/engine-overview.tsx
+++ b/packages/client/src/components/engine/engine-overview.tsx
@@ -8,9 +8,9 @@ import { useRootStore } from "@/hooks";
 import { normalizeTagArray } from "@/utility";
 import { formatDateToLocal } from "@/utility/date";
 import {
+	formatServingProviderLabel,
 	type ModelMetadata,
-	ModelOverviewCards,
-	SettingsEntry,
+	ModelOverviewSections,
 	type StaticModelMetadata,
 } from "./engine-metadata-display";
 
@@ -122,6 +122,10 @@ export const EngineOverview = ({
 		const updatedOn = engine.engine_date_last_edited
 			? formatDateToLocal(engine.engine_date_last_edited)
 			: null;
+		const servingProvider =
+			typeof getModelMetadata.data?.servingProvider === "string"
+				? getModelMetadata.data.servingProvider.trim()
+				: "";
 
 		// Read-only by design: description is edited on Settings > Description,
 		// tags on Settings > Tags, and model metadata on Settings > Model Settings.
@@ -146,11 +150,12 @@ export const EngineOverview = ({
 					</div>
 				)}
 
-				<ModelOverviewCards metadata={getModelMetadata.data} />
+				<ModelOverviewSections metadata={getModelMetadata.data} />
 
 				<Separator />
 
-				<SettingsEntry label="Details">
+				<div className="flex flex-col gap-4">
+					<h3 className="font-semibold">Details</h3>
 					{markdown.trim() ? (
 						<Markdown>{markdown}</Markdown>
 					) : (
@@ -162,13 +167,17 @@ export const EngineOverview = ({
 							model.
 						</p>
 					)}
-				</SettingsEntry>
+				</div>
 
-				{(createdOn || updatedOn) && (
+				{(createdOn || updatedOn || servingProvider !== "") && (
 					<p className="text-muted-foreground text-xs">
 						{[
 							createdOn && `Created ${createdOn}`,
 							updatedOn && `Updated ${updatedOn}`,
+							servingProvider !== "" &&
+								`Served by ${formatServingProviderLabel(
+									servingProvider,
+								)}`,
 						]
 							.filter(Boolean)
 							.join(" · ")}


### PR DESCRIPTION
Replaces the card-based model overview with a flat, full-width layout, built from the
existing Tailwind tokens and `@semoss/ui/next` primitives.

### Changes

- **Headline stat strip** — Context window, Max output, Released, Knowledge cutoff, and
  Input/Output price (from the preferred provider's rates) in a divided band under the
  description. Unreported stats are omitted, keeping the "no wall of Not set" rule.
- **Specification** — now a flat section with horizontal rows: uppercase label column with
  the existing capability/modality/tool/supports chips beside it.
- **Benchmarks** — flat section with the "Show all N" toggle moved to the top-right and a
  new score-bar column (`Progress`). Bars only render for 0–100 scores, so Elo-style
  ratings stay numbers-only; the bar column hides on narrow screens.
- **Pricing** — headline rates moved into the stat strip; the full table only renders when
  it adds information (multiple providers or cache read/write rates).
- **Details & footer** — "Details" is a bold section heading, and the footer now includes
  the serving provider (e.g. `Created … · Served by Google`).
- `ModelOverviewCards` renamed to `ModelOverviewSections`; added `formatMetadataDateParts`.