### PR TITLE
Model settings: match to a catalog entry + reset to catalog defaults

### DIFF
--- a/packages/client/src/components/engine/engine-metadata-display.tsx
+++ b/packages/client/src/components/engine/engine-metadata-display.tsx
@@ -69,6 +69,8 @@ export interface BuiltinToolSelection {
 export type ModelMetadata = {
 	engineId?: string;
 	modelId?: string | null;
+	/** meta/model.json entry the engine was matched to by hand, if any. */
+	catalogModelKey?: string | null;
 	/** Organization that created the model, e.g. ANTHROPIC. */
 	modelProvider?: string | null;
 	/** Platform serving the model, e.g. AWS_BEDROCK. */
@@ -930,7 +932,9 @@ export const SettingsWarning = ({
 	/** "danger" is for a documented hard requirement, not a hunch. */
 	tone?: "advisory" | "danger";
 }) => {
-	if (message === "") {
+	// null slips past the string type under lenient null checks, and an icon
+	// with no words next to it warns about nothing
+	if (!message) {
 		return null;
 	}
 

--- a/packages/client/src/components/engine/engine-model-settings.tsx
+++ b/packages/client/src/components/engine/engine-model-settings.tsx
@@ -1,7 +1,9 @@
+import { RotateCcw } from "lucide-react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { usePixel } from "@semoss/sdk/react";
 import type { Role } from "@semoss/shared";
 import {
+	Badge,
 	Button,
 	Card,
 	CardAction,
@@ -9,6 +11,12 @@ import {
 	CardDescription,
 	CardHeader,
 	CardTitle,
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
 	Field,
 	FieldDescription,
 	FieldGroup,
@@ -25,6 +33,11 @@ import {
 	ToggleGroupItem,
 	toast,
 } from "@semoss/ui/next";
+import type {
+	CatalogMatchState,
+	CatalogMatchSuggestion,
+} from "@/components/import/model/model-catalog-match";
+import { ModelCatalogMatch } from "@/components/import/model/model-catalog-match";
 import { useRootStore } from "@/hooks";
 import {
 	MODEL_PROVIDER_OPTIONS,
@@ -50,7 +63,6 @@ import {
 	getProviderOptions,
 	getReasoningSupportWarning,
 	getTokenLimitWarning,
-	hasCatalogEntry,
 	isReasoningMandatory,
 	MODALITIES,
 	type ModelMetadata,
@@ -73,6 +85,73 @@ import {
  * sentinel for their "Not set" option.
  */
 const VALUE_NONE = "__none__";
+
+/**
+ * Reader-facing names for the metadata fields ApplyModelCatalogMetadata can
+ * change, keyed the way its changedFields list reports them.
+ */
+const CATALOG_FIELD_LABELS: Record<string, string> = {
+	CATALOG_MODEL_KEY: "Catalog entry",
+	MODEL_PROVIDER: "Model provider",
+	FAMILY: "Model family",
+	CAPABILITY: "Capability",
+	INPUT_MODALITIES: "Input modalities",
+	OUTPUT_MODALITIES: "Output modalities",
+	REASONING: "Reasoning",
+	REASONING_CONFIG: "Reasoning configuration",
+	CONTEXT_WINDOW: "Context window",
+	MAX_TOKENS: "Max output tokens",
+	ATTACHMENT: "Attachments",
+	TOOL_CALL: "Tool calling",
+	STRUCTURED_OUTPUT: "Structured output",
+	TEMPERATURE: "Temperature",
+	KNOWLEDGE_CUTOFF: "Knowledge cutoff",
+	RELEASE_DATE: "Release date",
+	SUPPORTED_PARAMETERS: "Supported parameters",
+	BENCHMARKS: "Benchmarks",
+	PRICING: "Pricing",
+};
+
+const formatCatalogField = (field: string) =>
+	CATALOG_FIELD_LABELS[field] ?? formatEnumLabel(field);
+
+/**
+ * The change chips read best in the order the card lays the fields out, not
+ * whatever order the backend happened to diff them in. Unknown fields go last.
+ */
+const CATALOG_FIELD_ORDER = Object.keys(CATALOG_FIELD_LABELS);
+const sortCatalogFields = (fields: string[]) => {
+	const orderOf = (field: string) => {
+		const index = CATALOG_FIELD_ORDER.indexOf(field);
+		return index === -1 ? CATALOG_FIELD_ORDER.length : index;
+	};
+	return [...fields].sort((a, b) => orderOf(a) - orderOf(b));
+};
+
+/** The catalog entry name as a small inline code chip. */
+const CatalogEntryName = ({ name }: { name: string | null }) => (
+	<span className="rounded bg-muted px-1.5 py-0.5 font-mono text-foreground text-xs">
+		{name}
+	</span>
+);
+
+/** What ApplyModelCatalogMetadata's dry run reported for a pending action. */
+type CatalogApplyDryRun =
+	| { status: "LOADING" }
+	| { status: "ERROR"; message: string }
+	| { status: "SUCCESS"; changedFields: string[] };
+
+/**
+ * A catalog action waiting on the user's confirmation. "match" applies the
+ * entry named by catalogKey, "reset" reapplies the entry the engine already
+ * resolves to, and "clear" removes a hand-picked association without touching
+ * any metadata - which is why it is the one kind with no dry run.
+ */
+interface CatalogApplyAction {
+	kind: "match" | "reset" | "clear";
+	catalogKey: string | null;
+	dryRun: CatalogApplyDryRun | null;
+}
 
 const parseOptionalPositiveInteger = (label: string, value: string) => {
 	if (value === "") {
@@ -164,6 +243,10 @@ export const EngineModelSettings = ({
 
 	const [isSaving, setIsSaving] = useState(false);
 	const [discardRevision, setDiscardRevision] = useState(0);
+	const [catalogApply, setCatalogApply] = useState<CatalogApplyAction | null>(
+		null,
+	);
+	const [isApplyingCatalog, setIsApplyingCatalog] = useState(false);
 	const [form, setForm] = useState<ModelSettingsValues>(
 		toModelSettingsValues(undefined),
 	);
@@ -202,14 +285,21 @@ export const EngineModelSettings = ({
 		typeof getModelMetadata.data?.modelId === "string"
 			? getModelMetadata.data.modelId.trim()
 			: "";
+	const storedCatalogKey =
+		typeof getModelMetadata.data?.catalogModelKey === "string"
+			? getModelMetadata.data.catalogModelKey.trim()
+			: "";
 
 	// Curated catalog entry for this model, used only to advise on settings the
 	// model is not known to support. It is optional data - a sparse entry or a
 	// failed call just mean no advice, and a model the catalog has never heard
-	// of comes back as an empty map.
+	// of comes back as an empty map. The advisory checks read the entry the
+	// engine was matched to by hand when there is one; only otherwise does the
+	// raw model id speak for itself.
+	const staticLookupId = storedCatalogKey || modelId;
 	const getStaticModelMetadata = usePixel<StaticModelMetadata>(
-		isEditable && modelId
-			? `GetStaticModelMetadata(modelId=${JSON.stringify(modelId)});`
+		isEditable && staticLookupId
+			? `GetStaticModelMetadata(modelId=${JSON.stringify(staticLookupId)});`
 			: "",
 	);
 	const catalogModalities = useMemo(
@@ -249,11 +339,59 @@ export const EngineModelSettings = ({
 		),
 	);
 
-	// Only claimed once the lookup actually came back empty. A pending or failed
-	// call says nothing, so it stays quiet rather than crying wolf.
-	const isMissingFromCatalog =
-		getStaticModelMetadata.status === "SUCCESS" &&
-		!hasCatalogEntry(getStaticModelMetadata.data);
+	// How the provider model id relates to the catalog: resolved on its own,
+	// resolvable to ranked suggestions, or unknown. Fetched alongside the
+	// settings so the card can offer the entry browser in every state.
+	const getCatalogMatch = usePixel<{
+		exactMatch?: string;
+		matches?: CatalogMatchSuggestion[];
+		allKeys?: string[];
+	}>(
+		isEditable && modelId
+			? `MatchStaticModelMetadata(modelId=${JSON.stringify(modelId)});`
+			: "",
+	);
+	const catalogMatch = useMemo<CatalogMatchState | null>(() => {
+		if (!isEditable || !modelId) {
+			return null;
+		}
+		if (getCatalogMatch.status === "ERROR") {
+			return {
+				modelId,
+				status: "ERROR",
+				exactMatch: null,
+				suggestions: [],
+				allKeys: [],
+			};
+		}
+		if (getCatalogMatch.status !== "SUCCESS") {
+			return {
+				modelId,
+				status: "LOADING",
+				exactMatch: null,
+				suggestions: [],
+				allKeys: [],
+			};
+		}
+
+		const exactMatch = getCatalogMatch.data?.exactMatch?.trim() || null;
+		return {
+			modelId,
+			status: exactMatch ? "MATCHED" : "UNMATCHED",
+			exactMatch,
+			suggestions: Array.isArray(getCatalogMatch.data?.matches)
+				? getCatalogMatch.data.matches
+				: [],
+			allKeys: Array.isArray(getCatalogMatch.data?.allKeys)
+				? getCatalogMatch.data.allKeys
+				: [],
+		};
+	}, [isEditable, modelId, getCatalogMatch.status, getCatalogMatch.data]);
+
+	// Reset needs an entry to fall back on: one matched by hand, or a model id
+	// the catalog resolves on its own.
+	const canResetToCatalog =
+		!!storedCatalogKey || catalogMatch?.status === "MATCHED";
 
 	// Provider-hosted tools this engine's model can use, resolved from the
 	// built-in tools catalog by its serving and model providers. Optional
@@ -442,6 +580,150 @@ export const EngineModelSettings = ({
 		}
 	};
 
+	const buildApplyPixel = (catalogKey: string | null, dryRun: boolean) =>
+		`ApplyModelCatalogMetadata(engine=["${engineId}"]${
+			catalogKey ? `, catalogKey=[${JSON.stringify(catalogKey)}]` : ""
+		}${dryRun ? ", dryRun=[true]" : ""});`;
+
+	/**
+	 * Run a pixel and unwrap its first return, surfacing pixel-level failures
+	 * as thrown Errors so every caller handles them in one place.
+	 */
+	const runCatalogPixel = async (pixel: string, fallbackMessage: string) => {
+		const response = await configStore.runPixel(pixel);
+		const result = response.pixelReturn?.[0];
+
+		if (
+			response.errors.length > 0 ||
+			String(result?.operationType || "").includes("ERROR")
+		) {
+			throw new Error(
+				response.errors.join("") ||
+					String(result?.output || fallbackMessage),
+			);
+		}
+
+		return result?.output;
+	};
+
+	/**
+	 * Open the confirmation dialog for a catalog apply, running the dry run
+	 * that tells the user which settings the apply would overwrite.
+	 */
+	const openCatalogApply = async (
+		kind: "match" | "reset",
+		catalogKey: string | null,
+	) => {
+		setCatalogApply({ kind, catalogKey, dryRun: { status: "LOADING" } });
+
+		let dryRun: CatalogApplyDryRun;
+		try {
+			const output = (await runCatalogPixel(
+				buildApplyPixel(catalogKey, true),
+				"Unable to check the catalog entry.",
+			)) as { changedFields?: unknown };
+			dryRun = {
+				status: "SUCCESS",
+				changedFields: Array.isArray(output?.changedFields)
+					? output.changedFields.map(String)
+					: [],
+			};
+		} catch (error) {
+			dryRun = {
+				status: "ERROR",
+				message:
+					error instanceof Error
+						? error.message
+						: "Unable to check the catalog entry.",
+			};
+		}
+
+		// the dialog may have been cancelled, or reopened for another entry,
+		// while the dry run was in flight
+		setCatalogApply((previous) =>
+			previous &&
+			previous.kind === kind &&
+			previous.catalogKey === catalogKey &&
+			previous.dryRun?.status === "LOADING"
+				? { ...previous, dryRun }
+				: previous,
+		);
+	};
+
+	/**
+	 * Persist the pending catalog action and pull the settings back in sync.
+	 * Clearing only removes the hand-picked association - the metadata it
+	 * filled in stays put, so the form's unsaved edits survive it too.
+	 */
+	const confirmCatalogApply = async () => {
+		if (!catalogApply) {
+			return;
+		}
+		const isClear = catalogApply.kind === "clear";
+
+		try {
+			setIsApplyingCatalog(true);
+			await runCatalogPixel(
+				isClear
+					? `UpdateModelMetadata(engine=["${engineId}"], map=[${JSON.stringify(
+							{ CATALOG_MODEL_KEY: "" },
+						)}]);`
+					: buildApplyPixel(catalogApply.catalogKey, false),
+				isClear
+					? "Unable to clear the catalog entry."
+					: "Unable to apply the catalog metadata.",
+			);
+
+			if (!isClear) {
+				// drop any unsaved edits so the refetch is allowed to resync
+				// the form
+				setForm(initialForm);
+				setDiscardRevision((revision) => revision + 1);
+			}
+			setCatalogApply(null);
+			toast.success(
+				isClear
+					? "Catalog entry match removed"
+					: catalogApply.kind === "reset"
+						? "Model settings reset to the catalog defaults"
+						: "Catalog entry applied to the model settings",
+			);
+
+			getModelMetadata.refresh();
+			if (!isClear) {
+				// the model provider may have changed, and it is one of the
+				// keys the built-in tools catalog is looked up on
+				getModelBuiltinTools.refresh();
+			}
+			onUpdated?.();
+		} catch (error) {
+			toast.error(
+				error instanceof Error
+					? error.message
+					: "Error updating the catalog entry",
+			);
+		} finally {
+			setIsApplyingCatalog(false);
+		}
+	};
+
+	const handleCatalogPick = (catalogKey: string | null) => {
+		if (catalogKey === null) {
+			if (storedCatalogKey) {
+				setCatalogApply({
+					kind: "clear",
+					catalogKey: null,
+					dryRun: null,
+				});
+			}
+			return;
+		}
+		if (catalogKey === storedCatalogKey) {
+			return;
+		}
+		openCatalogApply("match", catalogKey);
+	};
+
 	if (getModelMetadata.status === "ERROR") {
 		return (
 			<p className="text-destructive text-sm">
@@ -458,467 +740,701 @@ export const EngineModelSettings = ({
 		);
 	}
 
+	const catalogDryRun = catalogApply?.dryRun ?? null;
+	// what a reset would look up: the hand-picked entry, else the model id's
+	// own match
+	const resetEntry =
+		storedCatalogKey ||
+		(catalogMatch?.status === "MATCHED" ? catalogMatch.exactMatch : null) ||
+		modelId;
+
 	return (
-		<Card>
-			<CardHeader className="border-b">
-				<CardTitle>Model Settings</CardTitle>
-				<CardDescription>
-					Identity, providers, capability, modalities, and token
-					limits for this model.
-				</CardDescription>
-				{/*
-				 * CardAction drops into the header's reserved second column and
-				 * spans both text rows, so showing it cannot change the card's
-				 * height or width.
-				 */}
-				{isEditable && isDirty && (
-					<CardAction className="flex gap-2 self-center">
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={handleDiscard}
-							disabled={isSaving}
-							data-testid="engine-model-settings--cancel-btn"
-						>
-							Discard
-						</Button>
-						<Button
-							size="sm"
-							onClick={handleSave}
-							disabled={isSaving}
-							data-testid="engine-model-settings--save-btn"
-						>
-							{isSaving ? <Spinner className="size-4" /> : "Save"}
-						</Button>
-					</CardAction>
-				)}
-			</CardHeader>
-			<CardContent>
-				{isEditable ? (
-					<FieldGroup>
-						{isMissingFromCatalog && (
-							<p
-								className="-mb-2 text-muted-foreground text-xs"
-								data-testid="engine-model-settings--catalog-missing"
-							>
-								This model is not in the model catalog, so none
-								of these values could be checked against it.
-								Worth confirming them against the provider.
-							</p>
-						)}
-
-						<Field>
-							<FieldLabel htmlFor={modelIdFieldId}>
-								Model ID
-							</FieldLabel>
-							<Input
-								id={modelIdFieldId}
-								value={modelId}
-								disabled
-								className="font-mono"
-							/>
-							<FieldDescription>
-								Assigned by the connected provider and cannot be
-								edited.
-							</FieldDescription>
-						</Field>
-
-						<div className="grid gap-7 sm:grid-cols-2 sm:gap-4">
-							<ProviderField
-								label="Model provider"
-								description="Organization that created the model."
-								value={form.modelProvider}
-								options={getProviderOptions(
-									MODEL_PROVIDER_OPTIONS,
-									form.modelProvider,
-								)}
-								format={formatModelProviderLabel}
-								onChange={(value) =>
-									updateForm("modelProvider", value)
-								}
-								testId="engine-model-settings--model-provider"
-							/>
-							<ProviderField
-								label="Serving provider"
-								description="Platform serving the model."
-								value={form.servingProvider}
-								options={getProviderOptions(
-									SERVING_PROVIDER_OPTIONS,
-									form.servingProvider,
-								)}
-								format={formatServingProviderLabel}
-								onChange={(value) =>
-									updateForm("servingProvider", value)
-								}
-								testId="engine-model-settings--serving-provider"
-							/>
-						</div>
-
-						<Field>
-							<FieldLabel>Capability</FieldLabel>
-							<Select
-								value={
-									form.capability !== ""
-										? form.capability
-										: VALUE_NONE
-								}
-								onValueChange={(value) =>
-									updateForm(
-										"capability",
-										value === VALUE_NONE ? "" : value,
-									)
-								}
-							>
-								<SelectTrigger
-									className="w-full"
-									data-testid="engine-model-settings--capability"
-								>
-									<SelectValue placeholder="Select a capability" />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value={VALUE_NONE}>
-										Not set
-									</SelectItem>
-									{CAPABILITIES.map((capability) => (
-										<SelectItem
-											key={capability}
-											value={capability}
-										>
-											{formatEnumLabel(capability)}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-							<FieldDescription>
-								The primary task this model is used for.
-							</FieldDescription>
-						</Field>
-
-						<Field>
-							<FieldLabel>Input modalities</FieldLabel>
-							<ToggleGroup
-								type="multiple"
+		<>
+			<Card>
+				<CardHeader className="border-b">
+					<CardTitle>Model Settings</CardTitle>
+					<CardDescription>
+						Identity, providers, capability, modalities, and token
+						limits for this model.
+					</CardDescription>
+					{/*
+					 * CardAction drops into the header's reserved second column and
+					 * spans both text rows, so showing it cannot change the card's
+					 * height or width.
+					 */}
+					{isEditable && isDirty && (
+						<CardAction className="flex gap-2 self-center">
+							<Button
 								variant="outline"
 								size="sm"
-								spacing={2}
-								className="flex-wrap"
-								value={form.inputModalities}
-								onValueChange={(value) =>
-									updateForm("inputModalities", value)
-								}
-								data-testid="engine-model-settings--input-modalities"
+								onClick={handleDiscard}
+								disabled={isSaving}
+								data-testid="engine-model-settings--cancel-btn"
 							>
-								{MODALITIES.map((modality) => (
-									<ToggleGroupItem
-										key={modality}
-										value={modality}
-										className={TOGGLE_ON_CLASS}
-									>
-										{formatModalityLabel(modality)}
-									</ToggleGroupItem>
-								))}
-							</ToggleGroup>
-							<FieldDescription>
-								Content types the model accepts as input.
-							</FieldDescription>
-							<SettingsWarning
-								message={inputModalityWarning}
-								testId="engine-model-settings--input-modalities-warning"
-							/>
-						</Field>
-
-						<Field>
-							<FieldLabel>Output modalities</FieldLabel>
-							<ToggleGroup
-								type="multiple"
-								variant="outline"
+								Discard
+							</Button>
+							<Button
 								size="sm"
-								spacing={2}
-								className="flex-wrap"
-								value={form.outputModalities}
-								onValueChange={(value) =>
-									updateForm("outputModalities", value)
-								}
-								data-testid="engine-model-settings--output-modalities"
+								onClick={handleSave}
+								disabled={isSaving}
+								data-testid="engine-model-settings--save-btn"
 							>
-								{MODALITIES.map((modality) => (
-									<ToggleGroupItem
-										key={modality}
-										value={modality}
-										className={TOGGLE_ON_CLASS}
-									>
-										{formatModalityLabel(modality)}
-									</ToggleGroupItem>
-								))}
-							</ToggleGroup>
-							<FieldDescription>
-								Content types the model can produce.
-							</FieldDescription>
-							<SettingsWarning
-								message={outputModalityWarning}
-								testId="engine-model-settings--output-modalities-warning"
-							/>
-						</Field>
-
-						<Field>
-							<div className="flex items-center justify-between gap-4">
-								<FieldLabel htmlFor={reasoningFieldId}>
-									Reasoning
+								{isSaving ? (
+									<Spinner className="size-4" />
+								) : (
+									"Save"
+								)}
+							</Button>
+						</CardAction>
+					)}
+				</CardHeader>
+				<CardContent>
+					{isEditable ? (
+						<FieldGroup>
+							<Field>
+								<FieldLabel htmlFor={modelIdFieldId}>
+									Model ID
 								</FieldLabel>
-								<Switch
-									id={reasoningFieldId}
-									checked={isReasoningEnabled}
-									onCheckedChange={(checked) =>
-										updateForm(
-											"reasoning",
-											checked ? "true" : "false",
-										)
+								<Input
+									id={modelIdFieldId}
+									value={modelId}
+									disabled
+									className="font-mono"
+								/>
+								<FieldDescription>
+									Assigned by the connected provider and
+									cannot be edited.
+								</FieldDescription>
+								<div className="mt-2 flex flex-col gap-2">
+									<ModelCatalogMatch
+										state={catalogMatch}
+										pickedKey={storedCatalogKey || null}
+										onPick={handleCatalogPick}
+										messages={{
+											picked: (
+												<>
+													Matched to catalog entry{" "}
+													<span className="font-mono text-foreground">
+														{storedCatalogKey}
+													</span>
+													. The settings below are
+													checked against it, and
+													resetting to defaults
+													reapplies its metadata.
+												</>
+											),
+											matched: (
+												<>
+													Recognized as{" "}
+													<span className="font-mono text-foreground">
+														{
+															catalogMatch?.exactMatch
+														}
+													</span>{" "}
+													in the model catalog. The
+													settings below are checked
+													against its metadata.
+												</>
+											),
+											unmatched: (
+												<>
+													<span className="font-mono text-foreground">
+														{modelId}
+													</span>{" "}
+													is not in the model catalog,
+													so these settings cannot be
+													checked against it. Pick the
+													entry it corresponds to and
+													the catalog metadata will
+													replace the settings below,
+													or leave this alone and
+													manage the settings
+													yourself.
+												</>
+											),
+											error: "Could not reach the model catalog. The settings below cannot be checked against it.",
+										}}
+									/>
+									{canResetToCatalog && (
+										<div>
+											<Button
+												type="button"
+												variant="outline"
+												size="sm"
+												className="gap-1.5"
+												disabled={isApplyingCatalog}
+												onClick={() =>
+													openCatalogApply(
+														"reset",
+														null,
+													)
+												}
+												data-testid="engine-model-settings--reset-to-catalog"
+											>
+												<RotateCcw className="size-3.5" />
+												Reset to catalog defaults
+											</Button>
+										</div>
+									)}
+								</div>
+							</Field>
+
+							<div className="grid gap-7 sm:grid-cols-2 sm:gap-4">
+								<ProviderField
+									label="Model provider"
+									description="Organization that created the model."
+									value={form.modelProvider}
+									options={getProviderOptions(
+										MODEL_PROVIDER_OPTIONS,
+										form.modelProvider,
+									)}
+									format={formatModelProviderLabel}
+									onChange={(value) =>
+										updateForm("modelProvider", value)
 									}
-									data-testid="engine-model-settings--reasoning"
+									testId="engine-model-settings--model-provider"
+								/>
+								<ProviderField
+									label="Serving provider"
+									description="Platform serving the model."
+									value={form.servingProvider}
+									options={getProviderOptions(
+										SERVING_PROVIDER_OPTIONS,
+										form.servingProvider,
+									)}
+									format={formatServingProviderLabel}
+									onChange={(value) =>
+										updateForm("servingProvider", value)
+									}
+									testId="engine-model-settings--serving-provider"
 								/>
 							</div>
-							<FieldDescription>
-								Whether the model thinks before answering.
-							</FieldDescription>
-							<SettingsWarning
-								message={mandatoryReasoningWarning}
-								tone="danger"
-								testId="engine-model-settings--reasoning-mandatory-warning"
-							/>
-							<SettingsWarning
-								message={reasoningSupportWarning}
-								testId="engine-model-settings--reasoning-warning"
-							/>
 
-							{/*
-							 * The effort fields only exist for models whose
-							 * stored config named efforts - there is nothing
-							 * useful to guess at for the rest - and only while
-							 * reasoning is on, since nothing asks for an effort
-							 * otherwise. The values are left untouched when
-							 * hidden, so switching reasoning back on restores
-							 * them.
-							 */}
-							{isReasoningEnabled &&
-								(storedEfforts.length > 0 ||
-									defaultEffortOptions.length > 0) && (
-									<div className="mt-2 flex flex-col gap-5 border-l pl-4">
-										{storedEfforts.length > 0 && (
-											<Field>
-												<FieldLabel>
-													Supported efforts
-												</FieldLabel>
-												<ToggleGroup
-													type="multiple"
-													variant="outline"
-													size="sm"
-													spacing={2}
-													className="flex-wrap"
-													value={
-														form.reasoningSupportedEfforts
-													}
-													onValueChange={
-														updateSupportedEfforts
-													}
-													data-testid="engine-model-settings--reasoning-supported-efforts"
-												>
-													{storedEfforts.map(
-														(effort) => (
-															<ToggleGroupItem
-																key={effort}
-																value={effort}
-																className={
-																	TOGGLE_ON_CLASS
-																}
-															>
-																{formatEffortLabel(
-																	effort,
-																)}
-															</ToggleGroupItem>
-														),
-													)}
-												</ToggleGroup>
-												<FieldDescription>
-													Effort levels the provider
-													accepts for this model.
-													{isReasoningEnabled &&
-														" At least one has to stay selected while reasoning is on."}
-												</FieldDescription>
-											</Field>
-										)}
+							<Field>
+								<FieldLabel>Capability</FieldLabel>
+								<Select
+									value={
+										form.capability !== ""
+											? form.capability
+											: VALUE_NONE
+									}
+									onValueChange={(value) =>
+										updateForm(
+											"capability",
+											value === VALUE_NONE ? "" : value,
+										)
+									}
+								>
+									<SelectTrigger
+										className="w-full"
+										data-testid="engine-model-settings--capability"
+									>
+										<SelectValue placeholder="Select a capability" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value={VALUE_NONE}>
+											Not set
+										</SelectItem>
+										{CAPABILITIES.map((capability) => (
+											<SelectItem
+												key={capability}
+												value={capability}
+											>
+												{formatEnumLabel(capability)}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FieldDescription>
+									The primary task this model is used for.
+								</FieldDescription>
+							</Field>
 
-										{defaultEffortOptions.length > 0 && (
-											<Field>
-												<FieldLabel>
-													Default effort
-												</FieldLabel>
-												{/*
-												 * No "not set" option on purpose:
-												 * the default has to be one of the
-												 * selected efforts. An empty value
-												 * only ever comes from a stored
-												 * config that never named one.
-												 */}
-												<Select
-													value={
-														form.reasoningDefaultEffort
-													}
-													onValueChange={(value) =>
-														updateForm(
-															"reasoningDefaultEffort",
-															value,
-														)
-													}
-												>
-													<SelectTrigger
-														className="w-full"
-														data-testid="engine-model-settings--reasoning-default-effort"
+							<Field>
+								<FieldLabel>Input modalities</FieldLabel>
+								<ToggleGroup
+									type="multiple"
+									variant="outline"
+									size="sm"
+									spacing={2}
+									className="flex-wrap"
+									value={form.inputModalities}
+									onValueChange={(value) =>
+										updateForm("inputModalities", value)
+									}
+									data-testid="engine-model-settings--input-modalities"
+								>
+									{MODALITIES.map((modality) => (
+										<ToggleGroupItem
+											key={modality}
+											value={modality}
+											className={TOGGLE_ON_CLASS}
+										>
+											{formatModalityLabel(modality)}
+										</ToggleGroupItem>
+									))}
+								</ToggleGroup>
+								<FieldDescription>
+									Content types the model accepts as input.
+								</FieldDescription>
+								<SettingsWarning
+									message={inputModalityWarning}
+									testId="engine-model-settings--input-modalities-warning"
+								/>
+							</Field>
+
+							<Field>
+								<FieldLabel>Output modalities</FieldLabel>
+								<ToggleGroup
+									type="multiple"
+									variant="outline"
+									size="sm"
+									spacing={2}
+									className="flex-wrap"
+									value={form.outputModalities}
+									onValueChange={(value) =>
+										updateForm("outputModalities", value)
+									}
+									data-testid="engine-model-settings--output-modalities"
+								>
+									{MODALITIES.map((modality) => (
+										<ToggleGroupItem
+											key={modality}
+											value={modality}
+											className={TOGGLE_ON_CLASS}
+										>
+											{formatModalityLabel(modality)}
+										</ToggleGroupItem>
+									))}
+								</ToggleGroup>
+								<FieldDescription>
+									Content types the model can produce.
+								</FieldDescription>
+								<SettingsWarning
+									message={outputModalityWarning}
+									testId="engine-model-settings--output-modalities-warning"
+								/>
+							</Field>
+
+							<Field>
+								<div className="flex items-center justify-between gap-4">
+									<FieldLabel htmlFor={reasoningFieldId}>
+										Reasoning
+									</FieldLabel>
+									<Switch
+										id={reasoningFieldId}
+										checked={isReasoningEnabled}
+										onCheckedChange={(checked) =>
+											updateForm(
+												"reasoning",
+												checked ? "true" : "false",
+											)
+										}
+										data-testid="engine-model-settings--reasoning"
+									/>
+								</div>
+								<FieldDescription>
+									Whether the model thinks before answering.
+								</FieldDescription>
+								<SettingsWarning
+									message={mandatoryReasoningWarning}
+									tone="danger"
+									testId="engine-model-settings--reasoning-mandatory-warning"
+								/>
+								<SettingsWarning
+									message={reasoningSupportWarning}
+									testId="engine-model-settings--reasoning-warning"
+								/>
+
+								{/*
+								 * The effort fields only exist for models whose
+								 * stored config named efforts - there is nothing
+								 * useful to guess at for the rest - and only while
+								 * reasoning is on, since nothing asks for an effort
+								 * otherwise. The values are left untouched when
+								 * hidden, so switching reasoning back on restores
+								 * them.
+								 */}
+								{isReasoningEnabled &&
+									(storedEfforts.length > 0 ||
+										defaultEffortOptions.length > 0) && (
+										<div className="mt-2 flex flex-col gap-5 border-l pl-4">
+											{storedEfforts.length > 0 && (
+												<Field>
+													<FieldLabel>
+														Supported efforts
+													</FieldLabel>
+													<ToggleGroup
+														type="multiple"
+														variant="outline"
+														size="sm"
+														spacing={2}
+														className="flex-wrap"
+														value={
+															form.reasoningSupportedEfforts
+														}
+														onValueChange={
+															updateSupportedEfforts
+														}
+														data-testid="engine-model-settings--reasoning-supported-efforts"
 													>
-														<SelectValue placeholder="Select an effort" />
-													</SelectTrigger>
-													<SelectContent>
-														{defaultEffortOptions.map(
+														{storedEfforts.map(
 															(effort) => (
-																<SelectItem
+																<ToggleGroupItem
 																	key={effort}
 																	value={
 																		effort
+																	}
+																	className={
+																		TOGGLE_ON_CLASS
 																	}
 																>
 																	{formatEffortLabel(
 																		effort,
 																	)}
-																</SelectItem>
+																</ToggleGroupItem>
 															),
 														)}
-													</SelectContent>
-												</Select>
-												<FieldDescription>
-													Effort used when a request
-													does not ask for one.
-												</FieldDescription>
-												<SettingsWarning
-													message={
-														defaultEffortWarning
-													}
-													testId="engine-model-settings--reasoning-default-effort-warning"
-												/>
-											</Field>
+													</ToggleGroup>
+													<FieldDescription>
+														Effort levels the
+														provider accepts for
+														this model.
+														{isReasoningEnabled &&
+															" At least one has to stay selected while reasoning is on."}
+													</FieldDescription>
+												</Field>
+											)}
+
+											{defaultEffortOptions.length >
+												0 && (
+												<Field>
+													<FieldLabel>
+														Default effort
+													</FieldLabel>
+													{/*
+													 * No "not set" option on purpose:
+													 * the default has to be one of the
+													 * selected efforts. An empty value
+													 * only ever comes from a stored
+													 * config that never named one.
+													 */}
+													<Select
+														value={
+															form.reasoningDefaultEffort
+														}
+														onValueChange={(
+															value,
+														) =>
+															updateForm(
+																"reasoningDefaultEffort",
+																value,
+															)
+														}
+													>
+														<SelectTrigger
+															className="w-full"
+															data-testid="engine-model-settings--reasoning-default-effort"
+														>
+															<SelectValue placeholder="Select an effort" />
+														</SelectTrigger>
+														<SelectContent>
+															{defaultEffortOptions.map(
+																(effort) => (
+																	<SelectItem
+																		key={
+																			effort
+																		}
+																		value={
+																			effort
+																		}
+																	>
+																		{formatEffortLabel(
+																			effort,
+																		)}
+																	</SelectItem>
+																),
+															)}
+														</SelectContent>
+													</Select>
+													<FieldDescription>
+														Effort used when a
+														request does not ask for
+														one.
+													</FieldDescription>
+													<SettingsWarning
+														message={
+															defaultEffortWarning
+														}
+														testId="engine-model-settings--reasoning-default-effort-warning"
+													/>
+												</Field>
+											)}
+										</div>
+									)}
+							</Field>
+
+							<div className="grid gap-7 sm:grid-cols-2 sm:gap-4">
+								<Field>
+									<FieldLabel htmlFor={contextWindowFieldId}>
+										Context window
+									</FieldLabel>
+									<Input
+										id={contextWindowFieldId}
+										type="text"
+										inputMode="numeric"
+										placeholder="e.g. 200,000"
+										value={formatDigits(form.contextWindow)}
+										onChange={(event) =>
+											updateForm(
+												"contextWindow",
+												event.target.value.replace(
+													/[^\d]/g,
+													"",
+												),
+											)
+										}
+									/>
+									<FieldDescription>
+										Total tokens the model can process in a
+										single request.
+									</FieldDescription>
+									<SettingsWarning
+										message={contextWindowWarning}
+										testId="engine-model-settings--context-window-warning"
+									/>
+								</Field>
+								<Field>
+									<FieldLabel
+										htmlFor={maxOutputTokensFieldId}
+									>
+										Max output tokens
+									</FieldLabel>
+									<Input
+										id={maxOutputTokensFieldId}
+										type="text"
+										inputMode="numeric"
+										placeholder="e.g. 64,000"
+										value={formatDigits(
+											form.maxOutputTokens,
 										)}
-									</div>
+										onChange={(event) =>
+											updateForm(
+												"maxOutputTokens",
+												event.target.value.replace(
+													/[^\d]/g,
+													"",
+												),
+											)
+										}
+									/>
+									<FieldDescription>
+										Upper bound on tokens generated per
+										response.
+									</FieldDescription>
+									<SettingsWarning
+										message={maxOutputTokensWarning}
+										testId="engine-model-settings--max-output-tokens-warning"
+									/>
+								</Field>
+							</div>
+
+							<Field>
+								<FieldLabel>Built-in tools</FieldLabel>
+								{/*
+								 * A stored selection stays editable even when the
+								 * catalog has nothing to offer, so it can still
+								 * be switched off.
+								 */}
+								{hasBuiltinToolsCatalog ||
+								Object.keys(form.builtinToolsConfig ?? {})
+									.length > 0 ? (
+									<EngineBuiltinToolsField
+										key={`builtin-tools-${discardRevision}`}
+										tools={builtinToolsCatalog}
+										value={form.builtinToolsConfig}
+										onChange={(next) =>
+											// Read mode renders names, so keep
+											// them in step with the selection
+											// keys.
+											setForm((prev) => ({
+												...prev,
+												builtinToolsConfig: next,
+												builtinTools: Object.keys(next),
+											}))
+										}
+										testId="engine-model-settings--builtin-tools"
+									/>
+								) : (
+									<p
+										className="text-muted-foreground text-sm"
+										data-testid="engine-model-settings--builtin-tools-empty"
+									>
+										{getModelBuiltinTools.status ===
+										"SUCCESS"
+											? "No provider-hosted tools are available for this model."
+											: "Checking for provider-hosted tools..."}
+									</p>
 								)}
-						</Field>
-
-						<div className="grid gap-7 sm:grid-cols-2 sm:gap-4">
-							<Field>
-								<FieldLabel htmlFor={contextWindowFieldId}>
-									Context window
-								</FieldLabel>
-								<Input
-									id={contextWindowFieldId}
-									type="text"
-									inputMode="numeric"
-									placeholder="e.g. 200,000"
-									value={formatDigits(form.contextWindow)}
-									onChange={(event) =>
-										updateForm(
-											"contextWindow",
-											event.target.value.replace(
-												/[^\d]/g,
-												"",
-											),
-										)
-									}
-								/>
 								<FieldDescription>
-									Total tokens the model can process in a
-									single request.
+									Provider-hosted tools this model can call
+									natively. Selections and their settings are
+									saved with the model.
 								</FieldDescription>
-								<SettingsWarning
-									message={contextWindowWarning}
-									testId="engine-model-settings--context-window-warning"
-								/>
 							</Field>
-							<Field>
-								<FieldLabel htmlFor={maxOutputTokensFieldId}>
-									Max output tokens
-								</FieldLabel>
-								<Input
-									id={maxOutputTokensFieldId}
-									type="text"
-									inputMode="numeric"
-									placeholder="e.g. 64,000"
-									value={formatDigits(form.maxOutputTokens)}
-									onChange={(event) =>
-										updateForm(
-											"maxOutputTokens",
-											event.target.value.replace(
-												/[^\d]/g,
-												"",
-											),
-										)
-									}
-								/>
-								<FieldDescription>
-									Upper bound on tokens generated per
-									response.
-								</FieldDescription>
-								<SettingsWarning
-									message={maxOutputTokensWarning}
-									testId="engine-model-settings--max-output-tokens-warning"
-								/>
-							</Field>
+						</FieldGroup>
+					) : (
+						<div className="grid gap-x-8 gap-y-6 sm:grid-cols-2">
+							<ModelMetadataFields
+								modelId={modelId}
+								values={form}
+							/>
 						</div>
+					)}
+				</CardContent>
+			</Card>
 
-						<Field>
-							<FieldLabel>Built-in tools</FieldLabel>
-							{/*
-							 * A stored selection stays editable even when the
-							 * catalog has nothing to offer, so it can still
-							 * be switched off.
-							 */}
-							{hasBuiltinToolsCatalog ||
-							Object.keys(form.builtinToolsConfig ?? {}).length >
-								0 ? (
-								<EngineBuiltinToolsField
-									key={`builtin-tools-${discardRevision}`}
-									tools={builtinToolsCatalog}
-									value={form.builtinToolsConfig}
-									onChange={(next) =>
-										// Read mode renders names, so keep
-										// them in step with the selection
-										// keys.
-										setForm((prev) => ({
-											...prev,
-											builtinToolsConfig: next,
-											builtinTools: Object.keys(next),
-										}))
-									}
-									testId="engine-model-settings--builtin-tools"
-								/>
+			<Dialog
+				open={catalogApply !== null}
+				onOpenChange={(open) => {
+					if (!open && !isApplyingCatalog) {
+						setCatalogApply(null);
+					}
+				}}
+			>
+				<DialogContent data-testid="engine-model-settings--catalog-apply-dialog">
+					<DialogHeader>
+						<DialogTitle>
+							{catalogApply?.kind === "reset"
+								? "Reset to catalog defaults"
+								: catalogApply?.kind === "clear"
+									? "Remove catalog match"
+									: "Apply catalog entry"}
+						</DialogTitle>
+						<DialogDescription>
+							{catalogApply?.kind === "reset" ? (
+								<>
+									The metadata the model catalog holds for{" "}
+									<CatalogEntryName name={resetEntry} /> will
+									overwrite these model settings and be saved
+									immediately.
+								</>
+							) : catalogApply?.kind === "clear" ? (
+								<>
+									The match to{" "}
+									<CatalogEntryName
+										name={storedCatalogKey || null}
+									/>{" "}
+									will be removed. The settings keep their
+									current values, but they will no longer be
+									checked against this entry, and resetting to
+									defaults will use whatever the model ID
+									resolves to on its own.
+								</>
+							) : (
+								<>
+									This model will be matched to{" "}
+									<CatalogEntryName
+										name={catalogApply?.catalogKey ?? null}
+									/>
+									, and the catalog metadata for that entry
+									will overwrite these model settings and be
+									saved immediately.
+								</>
+							)}
+						</DialogDescription>
+					</DialogHeader>
+
+					<div className="flex flex-col gap-3 text-sm">
+						{catalogDryRun?.status === "LOADING" && (
+							<div className="flex items-center gap-2 text-muted-foreground">
+								<Spinner className="size-4" />
+								Checking what would change...
+							</div>
+						)}
+						{catalogDryRun?.status === "ERROR" && (
+							<p
+								className="text-destructive"
+								data-testid="engine-model-settings--catalog-apply-error"
+							>
+								{catalogDryRun.message}
+							</p>
+						)}
+						{catalogDryRun?.status === "SUCCESS" &&
+							(catalogDryRun.changedFields.length > 0 ? (
+								<div
+									className="flex flex-col gap-2"
+									data-testid="engine-model-settings--catalog-apply-changes"
+								>
+									<p className="text-muted-foreground">
+										Settings that will change:
+									</p>
+									<div className="flex flex-wrap gap-1.5">
+										{sortCatalogFields(
+											catalogDryRun.changedFields,
+										).map((field) => (
+											<Badge
+												key={field}
+												variant="secondary"
+												className="font-normal"
+											>
+												{formatCatalogField(field)}
+											</Badge>
+										))}
+									</div>
+								</div>
 							) : (
 								<p
-									className="text-muted-foreground text-sm"
-									data-testid="engine-model-settings--builtin-tools-empty"
+									className="text-muted-foreground"
+									data-testid="engine-model-settings--catalog-apply-no-changes"
 								>
-									{getModelBuiltinTools.status === "SUCCESS"
-										? "No provider-hosted tools are available for this model."
-										: "Checking for provider-hosted tools..."}
+									Everything already matches the catalog
+									entry, so nothing will change.
 								</p>
-							)}
-							<FieldDescription>
-								Provider-hosted tools this model can call
-								natively. Selections and their settings are
-								saved with the model.
-							</FieldDescription>
-						</Field>
-					</FieldGroup>
-				) : (
-					<div className="grid gap-x-8 gap-y-6 sm:grid-cols-2">
-						<ModelMetadataFields modelId={modelId} values={form} />
+							))}
+						{/* clearing leaves the metadata - and any unsaved edits
+						 * to it - untouched, so there is nothing to warn about */}
+						{isDirty && catalogApply?.kind !== "clear" && (
+							<SettingsWarning
+								message="Your unsaved edits to these settings will be discarded."
+								testId="engine-model-settings--catalog-apply-dirty-warning"
+							/>
+						)}
 					</div>
-				)}
-			</CardContent>
-		</Card>
+
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setCatalogApply(null)}
+							disabled={isApplyingCatalog}
+							data-testid="engine-model-settings--catalog-apply-cancel"
+						>
+							Cancel
+						</Button>
+						<Button
+							onClick={confirmCatalogApply}
+							disabled={
+								isApplyingCatalog ||
+								(catalogApply?.kind !== "clear" &&
+									(catalogDryRun?.status !== "SUCCESS" ||
+										catalogDryRun.changedFields.length ===
+											0))
+							}
+							data-testid="engine-model-settings--catalog-apply-confirm"
+						>
+							{isApplyingCatalog ? (
+								<Spinner className="size-4" />
+							) : catalogApply?.kind === "reset" ? (
+								"Reset settings"
+							) : catalogApply?.kind === "clear" ? (
+								"Remove match"
+							) : (
+								"Apply entry"
+							)}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
 	);
 };

--- a/packages/client/src/components/import/model/model-catalog-match.tsx
+++ b/packages/client/src/components/import/model/model-catalog-match.tsx
@@ -1,4 +1,5 @@
 import { Check, ChevronsUpDown, X } from "lucide-react";
+import type { ReactNode } from "react";
 import { useState } from "react";
 import {
 	Badge,
@@ -39,11 +40,28 @@ export interface CatalogMatchState {
 	allKeys: string[];
 }
 
+/**
+ * Context-specific wording for each match outcome. Anything not provided falls
+ * back to the import-flow copy, where picking an entry fills the form fields
+ * below rather than saving anything.
+ */
+export interface CatalogMatchMessages {
+	/** note shown when an entry has been picked by hand */
+	picked?: ReactNode;
+	/** note shown when the ID resolved to a catalog entry on its own */
+	matched?: ReactNode;
+	/** note shown when the ID resolved to nothing */
+	unmatched?: ReactNode;
+	/** note shown when the catalog could not be reached */
+	error?: ReactNode;
+}
+
 interface ModelCatalogMatchProps {
 	state: CatalogMatchState | null;
 	/** the entry the user picked by hand, null while the ID stands on its own */
 	pickedKey: string | null;
 	onPick: (catalogKey: string | null) => void;
+	messages?: CatalogMatchMessages;
 }
 
 /** How many ranked suggestions to offer before falling back to the full list. */
@@ -61,7 +79,7 @@ const describeSuggestion = (suggestion: CatalogMatchSuggestion) => {
  * saved as CATALOG_MODEL_KEY.
  */
 export const ModelCatalogMatch = (props: ModelCatalogMatchProps) => {
-	const { state, pickedKey, onPick } = props;
+	const { state, pickedKey, onPick, messages } = props;
 	const [browserOpen, setBrowserOpen] = useState(false);
 
 	if (!state) {
@@ -124,12 +142,16 @@ export const ModelCatalogMatch = (props: ModelCatalogMatchProps) => {
 				data-testid="model-catalog-match-picked"
 			>
 				<Muted className="text-sm">
-					Using catalog entry{" "}
-					<span className="font-mono text-foreground">
-						{pickedKey}
-					</span>
-					. Its metadata has been filled in below and saved with this
-					model.
+					{messages?.picked ?? (
+						<>
+							Using catalog entry{" "}
+							<span className="font-mono text-foreground">
+								{pickedKey}
+							</span>
+							. Its metadata has been filled in below and saved
+							with this model.
+						</>
+					)}
 				</Muted>
 				<div className="flex flex-row items-center gap-2">
 					{catalogBrowser("Change entry")}
@@ -163,8 +185,8 @@ export const ModelCatalogMatch = (props: ModelCatalogMatchProps) => {
 	if (state.status === "ERROR") {
 		return (
 			<Muted className="text-sm" data-testid="model-catalog-match-error">
-				Could not reach the model catalog. Fill in the metadata fields
-				below yourself.
+				{messages?.error ??
+					"Could not reach the model catalog. Fill in the metadata fields below yourself."}
 			</Muted>
 		);
 	}
@@ -176,11 +198,15 @@ export const ModelCatalogMatch = (props: ModelCatalogMatchProps) => {
 				data-testid="model-catalog-match-exact"
 			>
 				<Muted className="text-sm">
-					Recognized as{" "}
-					<span className="font-mono text-foreground">
-						{state.exactMatch}
-					</span>
-					. The metadata below was filled in from the catalog.
+					{messages?.matched ?? (
+						<>
+							Recognized as{" "}
+							<span className="font-mono text-foreground">
+								{state.exactMatch}
+							</span>
+							. The metadata below was filled in from the catalog.
+						</>
+					)}
 				</Muted>
 				{catalogBrowser("Use a different entry")}
 			</div>
@@ -193,12 +219,16 @@ export const ModelCatalogMatch = (props: ModelCatalogMatchProps) => {
 			data-testid="model-catalog-match-unmatched"
 		>
 			<Muted className="text-sm">
-				<span className="font-mono text-foreground">
-					{state.modelId}
-				</span>{" "}
-				is not in the model catalog. Pick the entry it corresponds to
-				and its metadata will be filled in below, or leave this alone
-				and set the fields yourself.
+				{messages?.unmatched ?? (
+					<>
+						<span className="font-mono text-foreground">
+							{state.modelId}
+						</span>{" "}
+						is not in the model catalog. Pick the entry it
+						corresponds to and its metadata will be filled in below,
+						or leave this alone and set the fields yourself.
+					</>
+				)}
 			</Muted>
 			{state.suggestions.length > 0 && (
 				<div className="flex flex-col gap-1">


### PR DESCRIPTION
### Summary

The Add Model flow can already match a custom model ID against the
`meta/model.json` catalog and pre-fill metadata from the entry the user picks.
This PR brings the same capability to **existing** models on the engine
settings screen, plus a **Reset to catalog defaults** action - and puts a
confirmation dialog in front of anything that changes stored settings.

<!-- screenshot of the catalog block + confirmation dialog here -->

### What the user sees

Under the read-only Model ID field on the Model Settings card:

- **ID resolves in the catalog**: "Recognized as `<entry>`" with a browser to
  pick a different entry, plus a **Reset to catalog defaults** button.
- **ID does not resolve** (custom names like `gemini-2`): the closest catalog
  entries as clickable suggestions, plus a searchable browser over the full
  catalog - same UX as the import wizard.
- **Hand-matched engine**: "Matched to catalog entry `<entry>`" with *Change
  entry* and *Clear* actions.

Every mutating action confirms first:

- **Match / Reset** run `ApplyModelCatalogMetadata(..., dryRun=[true])` and the
  dialog lists exactly which settings will be overwritten (as badge chips, in
  the order the card lays fields out) before anything is saved. If the form has
  unsaved edits, the dialog warns they will be discarded. Confirm is disabled
  when nothing would change.
- **Clear** opens a "Remove catalog match" dialog explaining that the settings
  keep their values but are no longer checked against the entry, and that reset
  falls back to whatever the model ID resolves to. No dry run needed - clearing
  touches no metadata.

Advisory warnings (modalities, token limits, reasoning) now check against the
hand-matched entry when one exists, instead of only the raw model ID.

### Changes

- `engine-model-settings.tsx` - fetches `MatchStaticModelMetadata` for the
  engine's model ID, renders the catalog block + reset button, and adds the
  three-way (match / reset / clear) confirmation dialog. Match/reset persist
  via the new `ApplyModelCatalogMetadata` pixel; clear persists via
  `UpdateModelMetadata` with an empty `CATALOG_MODEL_KEY`.
- `model-catalog-match.tsx` - gains an optional `messages` prop so the settings
  screen can use its own wording for the picked / matched / unmatched / error
  states. The import flow's copy is untouched (defaults).
- `engine-metadata-display.tsx` - `ModelMetadata` type gains `catalogModelKey`
  (the pixel already returned it), and `SettingsWarning` now bails on any falsy
  message instead of only `""` (a `null` message used to render a bare warning
  icon with no text).

### Dependencies

- Requires the Semoss PR that adds the `ApplyModelCatalogMetadata` reactor.
  Without it, match/reset dialogs surface the pixel error; the rest of the
  settings card is unaffected.