### PR TITLE
Model import: render provider cards from the server's model catalog

### DIFF
--- a/packages/client/src/components/import/model/model-import-catalog.test.ts
+++ b/packages/client/src/components/import/model/model-import-catalog.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "vitest";
+import type { ModelVersionsByProvider } from "./model-import.constants";
+import {
+	type CatalogModelEntry,
+	fetchCatalogModels,
+	mergeCatalogModels,
+} from "./model-import-catalog";
+
+const SONNET: CatalogModelEntry = {
+	key: "claude-sonnet-5",
+	modelId: "claude-sonnet-5",
+	name: "Claude Sonnet 5",
+	description: "Balanced Claude model.",
+	provider: "anthropic",
+	releaseDate: "2026-05-01",
+	contextLimit: 1000000,
+	outputLimit: 64000,
+	inputModalities: ["text", "image"],
+	outputModalities: ["text"],
+};
+
+const HARDCODED: ModelVersionsByProvider = {
+	Anthropic: [
+		{
+			name: "claude-opus-4-6",
+			display: "Claude Opus 4.6",
+			icon: "/src/assets/img/CLAUDE_AI.svg",
+		},
+		{
+			name: "other-anthropic-model",
+			display: "Other Anthropic Model",
+			icon: "/src/assets/img/CLAUDE_AI.svg",
+		},
+	],
+	"Azure OpenAI": [
+		{
+			name: "azure-openai",
+			display: "Azure OpenAI",
+			icon: "/src/assets/img/OPEN_AI.svg",
+		},
+	],
+};
+
+describe("mergeCatalogModels", () => {
+	it("orders dated cards newest first, undated after, other- cards last", () => {
+		const merged = mergeCatalogModels(HARDCODED, { anthropic: [SONNET] });
+
+		// the hardcoded opus card has no catalog date, so it sinks below the
+		// dated addition but stays above the catch-all
+		expect(merged.Anthropic.map((m) => m.name)).toEqual([
+			"claude-sonnet-5",
+			"claude-opus-4-6",
+			"other-anthropic-model",
+		]);
+	});
+
+	it("interleaves hardcoded cards by the date of the catalog entry they matched", () => {
+		const merged = mergeCatalogModels(HARDCODED, {
+			anthropic: [
+				{
+					key: "claude-opus-4-6",
+					modelId: "claude-opus-4-6",
+					releaseDate: "2026-06-01",
+				},
+				SONNET, // 2026-05-01
+			],
+		});
+
+		// the opus catalog entry dedupes into the hardcoded card but donates
+		// its release date, putting the curated card ahead of the addition
+		expect(merged.Anthropic.map((m) => m.name)).toEqual([
+			"claude-opus-4-6",
+			"claude-sonnet-5",
+			"other-anthropic-model",
+		]);
+	});
+
+	it("dates qualified ids like Bedrock's from any host's catalog entries", () => {
+		const merged = mergeCatalogModels(
+			{
+				"AWS Bedrock": [
+					{
+						name: "anthropic.claude-opus-4-6-v1",
+						display: "Claude Opus 4.6 (Bedrock)",
+						icon: "/src/assets/img/CLAUDE_AI.svg",
+					},
+					{
+						name: "amazon.titan-embed-text-v1",
+						display: "Titan Text Embeddings",
+						icon: "/src/assets/img/BEDROCK.svg",
+					},
+				],
+			},
+			{
+				bedrock: [
+					{
+						key: "nova-lite",
+						modelId: "amazon.nova-lite-v1:0",
+						name: "Amazon Nova Lite",
+						releaseDate: "2024-12-03",
+					},
+				],
+				anthropic: [
+					{
+						key: "claude-opus-4-6",
+						modelId: "claude-opus-4-6",
+						releaseDate: "2026-06-01",
+					},
+				],
+			},
+		);
+
+		// the Bedrock claude card borrows claude-opus-4-6's date from the
+		// anthropic host list; the undated titan card sinks to the end
+		expect(merged["AWS Bedrock"].map((m) => m.name)).toEqual([
+			"anthropic.claude-opus-4-6-v1",
+			"amazon.nova-lite-v1:0",
+			"amazon.titan-embed-text-v1",
+		]);
+	});
+
+	it("maps catalog fields onto the card shape", () => {
+		const merged = mergeCatalogModels(HARDCODED, { anthropic: [SONNET] });
+		const card = merged.Anthropic.find((m) => m.name === "claude-sonnet-5");
+
+		expect(card).toMatchObject({
+			name: "claude-sonnet-5",
+			display: "Claude Sonnet 5",
+			description: "Balanced Claude model.",
+			icon: "/src/assets/img/CLAUDE_AI.svg",
+			modelBrand: "CLAUDE",
+			embedding: false,
+		});
+		expect(card?.formConfig?.fieldOverrides).toEqual(
+			expect.arrayContaining([
+				{ key: "MAX_TOKENS", patch: { default: 64000 } },
+				{ key: "CONTEXT_WINDOW", patch: { default: 1000000 } },
+			]),
+		);
+	});
+
+	it("skips token-limit defaults when the catalog has none", () => {
+		const merged = mergeCatalogModels(HARDCODED, {
+			anthropic: [
+				{ ...SONNET, contextLimit: undefined, outputLimit: undefined },
+			],
+		});
+		const card = merged.Anthropic.find((m) => m.name === "claude-sonnet-5");
+
+		expect(card?.formConfig).toBeUndefined();
+	});
+
+	it("dedupes Vertex @default catalog ids against bare hardcoded names", () => {
+		const merged = mergeCatalogModels(
+			{
+				"Google Gemini": [
+					{
+						name: "claude-sonnet-4-6",
+						display: "Claude Sonnet 4.6 (Vertex)",
+						icon: "/src/assets/img/CLAUDE_AI.svg",
+					},
+				],
+			},
+			{
+				google: [
+					{
+						key: "claude-sonnet-4-6",
+						modelId: "claude-sonnet-4-6@default",
+						provider: "anthropic",
+					},
+				],
+			},
+		);
+
+		expect(merged["Google Gemini"]).toHaveLength(1);
+		expect(merged["Google Gemini"][0].display).toBe(
+			"Claude Sonnet 4.6 (Vertex)",
+		);
+	});
+
+	it("gives hosted anthropic models the tab's AnthropicClient form config and Claude branding", () => {
+		const merged = mergeCatalogModels(
+			{ "Google Gemini": [] },
+			{
+				google: [
+					{
+						key: "claude-sonnet-5",
+						modelId: "claude-sonnet-5@default",
+						name: "Claude Sonnet 5",
+						provider: "anthropic",
+						releaseDate: "2026-05-01",
+						contextLimit: 1000000,
+						outputLimit: 64000,
+						outputModalities: ["text"],
+					},
+				],
+			},
+		);
+		const card = merged["Google Gemini"][0];
+
+		expect(card.icon).toBe("/src/assets/img/CLAUDE_AI.svg");
+		expect(card.modelBrand).toBe("CLAUDE");
+		const overrideKeys = card.formConfig?.fieldOverrides?.map((o) => o.key);
+		expect(overrideKeys).toContain("INIT_MODEL_ENGINE");
+		expect(overrideKeys).toContain("MAX_TOKENS");
+		expect(overrideKeys).toContain("CONTEXT_WINDOW");
+		expect(
+			card.formConfig?.appendFields?.some(
+				(f) => f.field.key === "PROVIDER",
+			),
+		).toBe(true);
+	});
+
+	it("drops catalog models a hardcoded card already covers, treating @ as -", () => {
+		const merged = mergeCatalogModels(
+			{
+				"Google Gemini": [
+					{
+						name: "claude-haiku-4-5@20251001",
+						display: "Claude Haiku 4.5",
+						icon: "/src/assets/img/CLAUDE_AI.svg",
+					},
+				],
+			},
+			{
+				google: [
+					{
+						key: "claude-haiku-4-5",
+						modelId: "claude-haiku-4-5-20251001",
+					},
+				],
+			},
+		);
+
+		expect(merged["Google Gemini"]).toHaveLength(1);
+	});
+
+	it("leaves providers without a catalog host untouched", () => {
+		const merged = mergeCatalogModels(HARDCODED, { anthropic: [SONNET] });
+
+		expect(merged["Azure OpenAI"]).toBe(HARDCODED["Azure OpenAI"]);
+	});
+
+	it("flags audio and image output modalities on the card", () => {
+		const merged = mergeCatalogModels(HARDCODED, {
+			anthropic: [
+				{
+					...SONNET,
+					outputModalities: ["text", "audio", "image"],
+				},
+			],
+		});
+		const card = merged.Anthropic.find((m) => m.name === "claude-sonnet-5");
+
+		expect(card?.audio).toBe(true);
+		expect(card?.image).toBe(true);
+	});
+});
+
+describe("fetchCatalogModels", () => {
+	it("returns the pixel output on success", async () => {
+		const catalog = { anthropic: [SONNET] };
+		const result = await fetchCatalogModels(async () => ({
+			pixelReturn: [{ output: catalog, operationType: ["OPERATION"] }],
+		}));
+
+		expect(result).toEqual(catalog);
+	});
+
+	it("returns null when the pixel errors", async () => {
+		const result = await fetchCatalogModels(async () => ({
+			pixelReturn: [
+				{ output: "no such reactor", operationType: ["ERROR"] },
+			],
+		}));
+
+		expect(result).toBeNull();
+	});
+
+	it("returns null when the request throws", async () => {
+		const result = await fetchCatalogModels(async () => {
+			throw new Error("network down");
+		});
+
+		expect(result).toBeNull();
+	});
+});

--- a/packages/client/src/components/import/model/model-import-catalog.ts
+++ b/packages/client/src/components/import/model/model-import-catalog.ts
@@ -1,0 +1,271 @@
+import {
+	AWS_BEDROCK_ANTHROPIC_FORM_CONFIG,
+	GOOGLE_ANTHROPIC_FORM_CONFIG,
+	type ModelFormConfig,
+	type ModelVersionDefinition,
+	type ModelVersionsByProvider,
+	withModelTokenLimits,
+} from "./model-import.constants";
+
+/**
+ * One importable model as returned by the ListStaticModelCatalog pixel: a
+ * meta/model.json entry paired with the exact model id a serving host uses
+ * for it. Everything but key/modelId is optional - the catalog is sparse.
+ */
+export interface CatalogModelEntry {
+	key: string;
+	modelId: string;
+	name?: string;
+	description?: string;
+	family?: string;
+	provider?: string;
+	releaseDate?: string;
+	contextLimit?: number;
+	outputLimit?: number;
+	inputModalities?: string[];
+	outputModalities?: string[];
+	reasoning?: boolean;
+	toolCall?: boolean;
+}
+
+export type CatalogModelsByHost = Record<string, CatalogModelEntry[]>;
+
+/**
+ * Which catalog serving host feeds each Add-Model provider tab. Tabs not
+ * listed here (Azure OpenAI, Self Hosted, Embedded, Model Router) stay fully
+ * hand-curated - the catalog cannot produce their model ids.
+ */
+const CATALOG_HOST_BY_PROVIDER: Record<string, string> = {
+	OpenAI: "openai",
+	Anthropic: "anthropic",
+	"Google Gemini": "google",
+	"AWS Bedrock": "bedrock",
+	"NVIDIA NIM": "nvidia",
+	Perplexity: "perplexity",
+};
+
+const CARD_PRESENTATION_BY_PROVIDER: Record<
+	string,
+	{ icon: string; modelBrand?: string }
+> = {
+	OpenAI: { icon: "/src/assets/img/OPEN_AI.svg", modelBrand: "OPEN_AI" },
+	Anthropic: { icon: "/src/assets/img/CLAUDE_AI.svg", modelBrand: "CLAUDE" },
+	"Google Gemini": {
+		icon: "/src/assets/img/GEMINI_COLOR.svg",
+		modelBrand: "GEMINI",
+	},
+	"AWS Bedrock": { icon: "/src/assets/img/BEDROCK.svg" },
+	"NVIDIA NIM": { icon: "/src/assets/img/NEMO.png", modelBrand: "NEMO" },
+	Perplexity: {
+		icon: "/src/assets/img/PERPLEXITY.svg",
+		modelBrand: "PERPLEXITY",
+	},
+};
+
+interface PixelResponse {
+	pixelReturn: {
+		output: unknown;
+		operationType: string | string[];
+	}[];
+}
+
+/**
+ * Fetch the catalog's importable models grouped by serving host. Returns null
+ * on any failure - an older server without the reactor, a missing catalog
+ * file, a network error - so the caller can fall back to the hardcoded cards.
+ */
+export const fetchCatalogModels = async (
+	runQuery: (pixel: string) => Promise<PixelResponse>,
+): Promise<CatalogModelsByHost | null> => {
+	try {
+		const response = await runQuery("ListStaticModelCatalog()");
+		const { output, operationType } = response.pixelReturn[0];
+		if (operationType.indexOf("ERROR") > -1) {
+			return null;
+		}
+		return (output as CatalogModelsByHost) ?? null;
+	} catch {
+		return null;
+	}
+};
+
+// hardcoded gemini ids and Vertex "@date" ids should collide with their
+// catalog spellings, so compare case-insensitively with @ treated as - and
+// Vertex's "@default"/"@latest" qualifiers treated as the bare id
+const normalizeCardName = (name: string) =>
+	name
+		.trim()
+		.toLowerCase()
+		.replace(/@(default|latest)$/, "")
+		.replace(/@/g, "-");
+
+/**
+ * Anthropic models hosted on another provider's tab need that tab's
+ * AnthropicClient init script, not the tab's default engine - a Vertex
+ * Claude card submitted with the Gemini init would not start.
+ */
+const ANTHROPIC_HOSTED_FORM_CONFIG: Record<string, ModelFormConfig> = {
+	"Google Gemini": GOOGLE_ANTHROPIC_FORM_CONFIG,
+	"AWS Bedrock": AWS_BEDROCK_ANTHROPIC_FORM_CONFIG,
+};
+
+/**
+ * A card name and the progressively more generic ids it also answers to,
+ * most specific first - qualifier prefixes, ":0"-style version suffixes, and
+ * date suffixes peeled off the way the server's catalog lookup does, so
+ * "anthropic.claude-opus-4-6-v1" can borrow the release date the catalog
+ * holds under "claude-opus-4-6".
+ */
+const nameVariants = (name: string): string[] => {
+	const variants = new Set<string>([normalizeCardName(name)]);
+	for (const variant of variants) {
+		let remainder = variant;
+		while (true) {
+			const stripped = remainder.replace(/^[a-z][a-z-]*\.(?=.)/, "");
+			if (stripped === remainder) break;
+			remainder = stripped;
+			variants.add(remainder);
+		}
+	}
+	for (const variant of variants) {
+		variants.add(variant.replace(/-v\d+(?::\d+)?$/, ""));
+	}
+	for (const variant of variants) {
+		variants.add(variant.replace(/-\d{4}-?\d{2}-?\d{2}$/, ""));
+	}
+	return [...variants];
+};
+
+/**
+ * Release dates for every id and alias the catalog response knows, across all
+ * hosts, so hardcoded cards can be dated too. On alias collisions the newest
+ * date wins - close enough for ordering a card grid.
+ */
+const buildReleaseDates = (
+	catalog: CatalogModelsByHost,
+): Map<string, string> => {
+	const dates = new Map<string, string>();
+	for (const entries of Object.values(catalog)) {
+		if (!Array.isArray(entries)) continue;
+		for (const entry of entries) {
+			if (!entry?.releaseDate) continue;
+			const aliases = new Set([
+				...nameVariants(entry.modelId ?? ""),
+				...nameVariants(entry.key ?? ""),
+			]);
+			for (const alias of aliases) {
+				if (!alias) continue;
+				const existing = dates.get(alias);
+				if (!existing || entry.releaseDate > existing) {
+					dates.set(alias, entry.releaseDate);
+				}
+			}
+		}
+	}
+	return dates;
+};
+
+const lookupReleaseDate = (
+	name: string,
+	dates: Map<string, string>,
+): string | undefined => {
+	for (const variant of nameVariants(name)) {
+		const date = dates.get(variant);
+		if (date) return date;
+	}
+	return undefined;
+};
+
+const toModelVersion = (
+	entry: CatalogModelEntry,
+	provider: string,
+): ModelVersionDefinition => {
+	const anthropicHosted =
+		entry.provider === "anthropic"
+			? ANTHROPIC_HOSTED_FORM_CONFIG[provider]
+			: undefined;
+	const presentation = anthropicHosted
+		? CARD_PRESENTATION_BY_PROVIDER.Anthropic
+		: CARD_PRESENTATION_BY_PROVIDER[provider];
+	const card: ModelVersionDefinition = {
+		name: entry.modelId,
+		display: entry.name || entry.modelId,
+		icon: presentation?.icon ?? "",
+		modelBrand: presentation?.modelBrand,
+		embedding: false,
+		description: entry.description,
+	};
+	if (entry.outputModalities?.includes("audio")) {
+		card.audio = true;
+	}
+	if (entry.outputModalities?.includes("image")) {
+		card.image = true;
+	}
+	if (entry.outputLimit && entry.contextLimit) {
+		card.formConfig = withModelTokenLimits(
+			anthropicHosted,
+			entry.outputLimit,
+			entry.contextLimit,
+		);
+	} else if (anthropicHosted) {
+		card.formConfig = anthropicHosted;
+	}
+	return card;
+};
+
+/**
+ * Merge catalog models into the hardcoded card lists. Hardcoded cards always
+ * win on a name collision (they carry curated descriptions and form configs),
+ * but the combined grid is ordered newest release first - hardcoded cards
+ * borrow their release date from the catalog entry they matched, cards the
+ * catalog cannot date sink to the end, and the "other-" catch-alls stay last.
+ */
+export const mergeCatalogModels = (
+	hardcoded: ModelVersionsByProvider,
+	catalog: CatalogModelsByHost,
+): ModelVersionsByProvider => {
+	const merged: ModelVersionsByProvider = { ...hardcoded };
+	const releaseDates = buildReleaseDates(catalog);
+
+	for (const [provider, host] of Object.entries(CATALOG_HOST_BY_PROVIDER)) {
+		const entries = catalog[host];
+		if (!Array.isArray(entries) || entries.length === 0) {
+			continue;
+		}
+
+		const existing = hardcoded[provider] ?? [];
+		const existingNames = new Set(
+			existing.map((model) => normalizeCardName(model.name)),
+		);
+		const additions = entries
+			.filter(
+				(entry) =>
+					entry?.modelId &&
+					!existingNames.has(normalizeCardName(entry.modelId)),
+			)
+			.map((entry) => toModelVersion(entry, provider));
+		if (additions.length === 0) {
+			continue;
+		}
+
+		const curated = existing.filter(
+			(model) => !model.name.startsWith("other-"),
+		);
+		const catchAll = existing.filter((model) =>
+			model.name.startsWith("other-"),
+		);
+		// stable sort: dated cards newest first, undated keep their curated
+		// order after every dated card
+		const dated = [...curated, ...additions].sort((a, b) => {
+			const dateA = lookupReleaseDate(a.name, releaseDates);
+			const dateB = lookupReleaseDate(b.name, releaseDates);
+			if (dateA && dateB) return dateB.localeCompare(dateA);
+			if (dateA) return -1;
+			if (dateB) return 1;
+			return 0;
+		});
+		merged[provider] = [...dated, ...catchAll];
+	}
+
+	return merged;
+};

--- a/packages/client/src/components/import/model/model-import.constants.ts
+++ b/packages/client/src/components/import/model/model-import.constants.ts
@@ -99,14 +99,14 @@ export interface AppendedModelField {
 	insertAfterKey?: string;
 }
 
-interface ModelFormConfig {
+export interface ModelFormConfig {
 	fieldOverrides?: ModelFieldOverride[];
 	appendFields?: AppendedModelField[];
 	advancedFieldOverrides?: ModelFieldOverride[];
 	appendAdvancedFields?: AppendedModelField[];
 }
 
-interface ModelVersionDefinition {
+export interface ModelVersionDefinition {
 	name: string;
 	display: string;
 	icon: string;
@@ -2487,11 +2487,12 @@ const AZURE_ANTHROPIC_INIT_MODEL_ENGINE =
 const GOOGLE_ANTHROPIC_INIT_MODEL_ENGINE =
 	"import genai_client;${VAR_NAME} = genai_client.AnthropicClient(model_name = '${MODEL}', provider = '${PROVIDER}', region='${GCP_REGION}', project='${PROJECT}', service_account_credentials = ${SERVICE_ACCOUNT_CREDENTIALS}, context_window = ${CONTEXT_WINDOW}, max_tokens = ${MAX_TOKENS})";
 
-const AWS_BEDROCK_ANTHROPIC_FORM_CONFIG = buildAnthropicProviderFormConfig({
-	initModelEngine: AWS_BEDROCK_ANTHROPIC_INIT_MODEL_ENGINE,
-	provider: "bedrock",
-	providerFieldType: "text",
-});
+export const AWS_BEDROCK_ANTHROPIC_FORM_CONFIG =
+	buildAnthropicProviderFormConfig({
+		initModelEngine: AWS_BEDROCK_ANTHROPIC_INIT_MODEL_ENGINE,
+		provider: "bedrock",
+		providerFieldType: "text",
+	});
 
 const AZURE_ANTHROPIC_FORM_CONFIG = buildAnthropicProviderFormConfig({
 	initModelEngine: AZURE_ANTHROPIC_INIT_MODEL_ENGINE,
@@ -2503,13 +2504,13 @@ const AZURE_ANTHROPIC_FORM_CONFIG = buildAnthropicProviderFormConfig({
 	useCustomModelInput: true,
 });
 
-const GOOGLE_ANTHROPIC_FORM_CONFIG = buildAnthropicProviderFormConfig({
+export const GOOGLE_ANTHROPIC_FORM_CONFIG = buildAnthropicProviderFormConfig({
 	initModelEngine: GOOGLE_ANTHROPIC_INIT_MODEL_ENGINE,
 	provider: "google",
 	providerFieldType: "text",
 });
 
-const withModelTokenLimits = (
+export const withModelTokenLimits = (
 	baseFormConfig: ModelFormConfig | undefined,
 	maxTokens: number,
 	contextWindow: number,
@@ -2550,50 +2551,6 @@ export const MODEL_VERSIONS: ModelVersionsByProvider = {
 		},
 	],
 	Anthropic: [
-		{
-			name: "claude-haiku-4-5-20251001",
-			display: "Claude Haiku 4.5",
-			icon: "/src/assets/img/CLAUDE_AI.svg",
-			modelBrand: "CLAUDE",
-			embedding: false,
-			link: "https://docs.anthropic.com/en/docs/models-overview",
-			description:
-				"Fast Claude model with near-frontier intelligence for low-latency generation and lightweight assistant workflows.",
-			formConfig: withModelTokenLimits(undefined, 64000, 200000),
-		},
-		{
-			name: "claude-sonnet-4-6",
-			display: "Claude Sonnet 4.6",
-			icon: "/src/assets/img/CLAUDE_AI.svg",
-			modelBrand: "CLAUDE",
-			embedding: false,
-			link: "https://docs.anthropic.com/en/docs/models-overview",
-			description:
-				"Balanced Claude model combining speed and intelligence for general enterprise workloads.",
-			formConfig: withModelTokenLimits(undefined, 64000, 1000000),
-		},
-		{
-			name: "claude-opus-4-6",
-			display: "Claude Opus 4.6",
-			icon: "/src/assets/img/CLAUDE_AI.svg",
-			modelBrand: "CLAUDE",
-			embedding: false,
-			link: "https://docs.anthropic.com/en/docs/models-overview",
-			description:
-				"Most intelligent Claude model for complex reasoning, coding, and advanced agentic workflows.",
-			formConfig: withModelTokenLimits(undefined, 128000, 1000000),
-		},
-		{
-			name: "claude-opus-4-7",
-			display: "Claude Opus 4.7",
-			icon: "/src/assets/img/CLAUDE_AI.svg",
-			modelBrand: "CLAUDE",
-			embedding: false,
-			link: "https://docs.anthropic.com/en/docs/models-overview",
-			description:
-				"Frontier Claude Opus model with advanced software engineering, superior vision, and long-running agentic capabilities.",
-			formConfig: withModelTokenLimits(undefined, 128000, 1000000),
-		},
 		{
 			name: "other-anthropic-model",
 			display: "Other Anthropic Model",
@@ -2707,16 +2664,6 @@ export const MODEL_VERSIONS: ModelVersionsByProvider = {
 				"Amazon Nova multimodal embedding model for text, image, audio, and video representation use cases.",
 		},
 		{
-			name: "amazon.nova-2-lite-v1:0",
-			display: "Amazon Nova 2 Lite",
-			icon: "/src/assets/img/BEDROCK.svg",
-			embedding: false,
-			link: "https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html",
-			description:
-				"Amazon Nova 2 Lite model for efficient multimodal generation and general-purpose assistant workloads.",
-			formConfig: withModelTokenLimits(undefined, 65000, 1000000),
-		},
-		{
 			name: "amazon.nova-2-sonic-v1:0",
 			display: "Amazon Nova 2 Sonic",
 			icon: "/src/assets/img/BEDROCK.svg",
@@ -2738,26 +2685,6 @@ export const MODEL_VERSIONS: ModelVersionsByProvider = {
 				"Amazon Nova Canvas image generation model for text-to-image and visual content creation tasks.",
 		},
 		{
-			name: "amazon.nova-lite-v1:0",
-			display: "Amazon Nova Lite",
-			icon: "/src/assets/img/BEDROCK.svg",
-			embedding: false,
-			link: "https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html",
-			description:
-				"Amazon Nova Lite model for low-latency multimodal generation and cost-sensitive workloads.",
-			formConfig: withModelTokenLimits(undefined, 10000, 300000),
-		},
-		{
-			name: "amazon.nova-micro-v1:0",
-			display: "Amazon Nova Micro",
-			icon: "/src/assets/img/BEDROCK.svg",
-			embedding: false,
-			link: "https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html",
-			description:
-				"Amazon Nova Micro model optimized for fast text generation and lightweight production tasks.",
-			formConfig: withModelTokenLimits(undefined, 10000, 128000),
-		},
-		{
 			name: "amazon.nova-premier-v1:0",
 			display: "Amazon Nova Premier",
 			icon: "/src/assets/img/BEDROCK.svg",
@@ -2766,16 +2693,6 @@ export const MODEL_VERSIONS: ModelVersionsByProvider = {
 			description:
 				"Amazon Nova Premier model for high-capability multimodal reasoning and enterprise workflows.",
 			formConfig: withModelTokenLimits(undefined, 10000, 1000000),
-		},
-		{
-			name: "amazon.nova-pro-v1:0",
-			display: "Amazon Nova Pro",
-			icon: "/src/assets/img/BEDROCK.svg",
-			embedding: false,
-			link: "https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html",
-			description:
-				"Amazon Nova Pro model balancing quality, speed, and multimodal support for production assistants.",
-			formConfig: withModelTokenLimits(undefined, 10000, 300000),
 		},
 		{
 			name: "amazon.nova-reel-v1:0",
@@ -3109,87 +3026,6 @@ export const MODEL_VERSIONS: ModelVersionsByProvider = {
 			),
 		},
 		{
-			name: "gemini-3.1-pro-preview",
-			display: "Gemini 3.1 Pro Preview",
-			icon: "/src/assets/img/GEMINI_COLOR.svg",
-			embedding: false,
-			link: "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-pro",
-			description:
-				"Advanced intelligence model for complex problem-solving and agentic capabilities.",
-			formConfig: withModelTokenLimits(undefined, 65536, 1048576),
-		},
-		{
-			name: "gemini-3-flash-preview",
-			display: "Gemini 3 Flash Preview",
-			icon: "/src/assets/img/GEMINI_COLOR.svg",
-			embedding: false,
-			link: "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-flash",
-			description:
-				"High-performance model with pro-level intelligence at lower latency and cost.",
-			formConfig: withModelTokenLimits(undefined, 65536, 1048576),
-		},
-		{
-			name: "gemini-3.1-flash-lite",
-			display: "Gemini 3.1 Flash Lite",
-			icon: "/src/assets/img/GEMINI_COLOR.svg",
-			embedding: false,
-			link: "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-flash-lite",
-			description:
-				"Optimized preview model for high-volume, cost-sensitive tasks.",
-			formConfig: withModelTokenLimits(undefined, 65536, 1048576),
-		},
-		{
-			name: "gemini-3-pro-image",
-			display: "Gemini 3 Pro Image",
-			icon: "/src/assets/img/GEMINI_COLOR.svg",
-			embedding: false,
-			link: "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image",
-			image: true,
-			description:
-				"High-fidelity image generation model with reasoning capabilities.",
-			formConfig: withModelTokenLimits(undefined, 32768, 65536),
-		},
-		{
-			name: "gemini-3.1-flash-image",
-			display: "Gemini 3.1 Flash Image",
-			icon: "/src/assets/img/GEMINI_COLOR.svg",
-			embedding: false,
-			link: "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-flash-image",
-			image: true,
-			description:
-				"High-efficiency visual creation model for fast image generation workflows.",
-			formConfig: withModelTokenLimits(undefined, 32768, 131072),
-		},
-		{
-			name: "gemini-2.5-pro",
-			display: "Gemini 2.5 Pro",
-			icon: "/src/assets/img/GEMINI_COLOR.svg",
-			embedding: false,
-			link: "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro",
-			description:
-				"High-capability model for complex reasoning and coding with a large context window.",
-			formConfig: withModelTokenLimits(undefined, 65536, 1048576),
-		},
-		{
-			name: "gemini-2.5-flash",
-			display: "Gemini 2.5 Flash",
-			icon: "/src/assets/img/GEMINI_COLOR.svg",
-			embedding: false,
-			link: "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash",
-			description:
-				"Fast and capable model balancing intelligence and speed.",
-			formConfig: withModelTokenLimits(undefined, 65536, 1048576),
-		},
-		{
-			name: "gemini-2.5-flash-lite",
-			display: "Gemini 2.5 Flash Lite",
-			icon: "/src/assets/img/GEMINI_COLOR.svg",
-			embedding: false,
-			link: "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-lite",
-			description: "Optimized Gemini model for high-throughput tasks.",
-			formConfig: withModelTokenLimits(undefined, 65536, 1048576),
-		},
-		{
 			name: "gemini-2.0-flash-001",
 			display: "Gemini 2.0 Flash 001",
 			icon: "/src/assets/img/GEMINI_COLOR.svg",
@@ -3198,17 +3034,6 @@ export const MODEL_VERSIONS: ModelVersionsByProvider = {
 			description:
 				"Multimodal general-purpose model for broad production use.",
 			formConfig: withModelTokenLimits(undefined, 8192, 1048576),
-		},
-		{
-			name: "gemini-2.5-flash-image",
-			display: "Gemini 2.5 Flash Image",
-			icon: "/src/assets/img/GEMINI_COLOR.svg",
-			embedding: false,
-			link: "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-image",
-			image: true,
-			description:
-				"Production-ready image model for fast, high-quality asset generation.",
-			formConfig: withModelTokenLimits(undefined, 32768, 65536),
 		},
 		{
 			name: "gemini-embedding-2",
@@ -3339,86 +3164,6 @@ export const MODEL_VERSIONS: ModelVersionsByProvider = {
 			description:
 				"Cost-efficient GPT Image model for lower-cost image generation and editing use cases.",
 			link: "https://platform.openai.com/docs/models",
-		},
-		{
-			name: "gpt-4.1",
-			display: "GPT-4.1",
-			icon: "/src/assets/img/OPEN_AI.svg",
-			description: "Smartest non-reasoning model.",
-			link: "https://platform.openai.com/docs/models/gpt-4.1",
-		},
-		{
-			name: "gpt-5",
-			display: "GPT-5",
-			icon: "/src/assets/img/OPEN_AI.svg",
-			description:
-				"Previous intelligent reasoning model for coding and agentic tasks with configurable reasoning effort.",
-			link: "https://platform.openai.com/docs/models/gpt-5",
-		},
-		{
-			name: "gpt-5-mini",
-			display: "GPT-5 Mini",
-			icon: "/src/assets/img/OPEN_AI.svg",
-			description:
-				"A faster, cost-efficient GPT-5 variant optimized for well-defined tasks and precise prompts.",
-			link: "https://platform.openai.com/docs/models/gpt-5-mini",
-		},
-		{
-			name: "gpt-5-nano",
-			display: "GPT-5 nano",
-			icon: "/src/assets/img/OPEN_AI.svg",
-			description:
-				"Fastest, most cost-efficient GPT-5 variant ideal for high-volume summarization and classification.",
-			link: "https://platform.openai.com/docs/models/gpt-5-nano",
-		},
-		{
-			name: "gpt-5.1",
-			display: "GPT-5.1",
-			icon: "/src/assets/img/OPEN_AI.svg",
-			description:
-				"The best model for coding and agentic tasks with configurable reasoning effort.",
-			link: "https://platform.openai.com/docs/models/gpt-5.1",
-		},
-		{
-			name: "gpt-5.4",
-			display: "GPT-5.4",
-			icon: "/src/assets/img/OPEN_AI.svg",
-			description:
-				"Best intelligence at scale for agentic, coding, and professional workflows.",
-			link: "https://platform.openai.com/docs/models/gpt-5.4",
-		},
-		{
-			name: "gpt-5.4-mini",
-			display: "GPT-5.4 Mini",
-			icon: "/src/assets/img/OPEN_AI.svg",
-			description:
-				"Strong mini model for coding, computer use, and subagent workflows.",
-			link: "https://platform.openai.com/docs/models/gpt-5.4-mini",
-		},
-		{
-			name: "gpt-5.4-nano",
-			display: "GPT-5.4 Nano",
-			icon: "/src/assets/img/OPEN_AI.svg",
-			description:
-				"Cheapest GPT-5.4-class model for simple high-volume tasks.",
-			link: "https://platform.openai.com/docs/models/gpt-5.4-nano",
-		},
-		{
-			name: "gpt-5.4-pro",
-			display: "GPT-5.4 Pro",
-			icon: "/src/assets/img/OPEN_AI.svg",
-			description:
-				"Version of GPT-5.4 tuned for smarter and more precise responses.",
-			link: "https://platform.openai.com/docs/models/gpt-5.4-pro",
-		},
-		{
-			name: "gpt-5.5",
-			display: "GPT-5.5",
-			icon: "/src/assets/img/OPEN_AI.svg",
-			description:
-				"Next-generation GPT-5 reasoning model with a 1.05M context window and advanced reasoning token support.",
-			link: "https://developers.openai.com/api/docs/models/gpt-5.5",
-			formConfig: withModelTokenLimits(undefined, 128000, 1050000),
 		},
 		{
 			name: "gpt-audio",
@@ -3698,50 +3443,6 @@ export const MODEL_VERSIONS: ModelVersionsByProvider = {
 		},
 	],
 	Perplexity: [
-		{
-			name: "sonar",
-			display: "Sonar",
-			icon: "/src/assets/img/PERPLEXITY.svg",
-			modelBrand: "PERPLEXITY",
-			embedding: false,
-			link: "https://docs.perplexity.ai/models/model-cards",
-			description:
-				"Perplexity's core Sonar model for fast, grounded conversational responses with web-aware context.",
-			formConfig: withModelTokenLimits(undefined, 128000, 128000),
-		},
-		{
-			name: "sonar-pro",
-			display: "Sonar Pro",
-			icon: "/src/assets/img/PERPLEXITY.svg",
-			modelBrand: "PERPLEXITY",
-			embedding: false,
-			link: "https://docs.perplexity.ai/models/model-cards",
-			description:
-				"Higher-capability Sonar variant tuned for stronger instruction-following and more complex chat workloads.",
-			formConfig: withModelTokenLimits(undefined, 128000, 200000),
-		},
-		{
-			name: "sonar-reasoning-pro",
-			display: "Sonar Reasoning Pro",
-			icon: "/src/assets/img/PERPLEXITY.svg",
-			modelBrand: "PERPLEXITY",
-			embedding: false,
-			link: "https://docs.perplexity.ai/models/model-cards",
-			description:
-				"Reasoning-optimized Sonar model for multi-step problem solving and analytical question answering.",
-			formConfig: withModelTokenLimits(undefined, 128000, 128000),
-		},
-		{
-			name: "sonar-deep-research",
-			display: "Sonar Deep Research",
-			icon: "/src/assets/img/PERPLEXITY.svg",
-			modelBrand: "PERPLEXITY",
-			embedding: false,
-			link: "https://docs.perplexity.ai/models/model-cards",
-			description:
-				"Research-focused Sonar model designed for deeper synthesis across multiple sources and longer analyses.",
-			formConfig: withModelTokenLimits(undefined, 128000, 128000),
-		},
 		{
 			name: "other-perplexity-model",
 			display: "Other Perplexity Model",

--- a/packages/client/src/pages/import/model-import-page.tsx
+++ b/packages/client/src/pages/import/model-import-page.tsx
@@ -43,12 +43,17 @@ import type {
 	ImportableModels,
 	ModelFieldOverride,
 	ModelVersionDefinition,
+	ModelVersionsByProvider,
 } from "@/components/import/model/model-import.constants";
 import {
 	IMPORTABLE_MODELS,
 	MODEL_VERSIONS,
 	UNKNOWN_MODEL_BRAND,
 } from "@/components/import/model/model-import.constants";
+import {
+	fetchCatalogModels,
+	mergeCatalogModels,
+} from "@/components/import/model/model-import-catalog";
 import { hasConfigurableReasoning } from "@/components/import/model/model-reasoning-config-field";
 import {
 	ModelEngineIcon,
@@ -723,6 +728,10 @@ export const ModelImportPage: React.FC = () => {
 	const [importableModelsCategory, setimportableModelsCategory] =
 		useState<CategoryTexts | null>(null);
 	const [selectedProvider, setSelectedProvider] = useState("");
+	// hardcoded cards enriched with meta/model.json catalog models once the
+	// ListStaticModelCatalog pixel resolves; stays hardcoded-only on failure
+	const [modelVersions, setModelVersions] =
+		useState<ModelVersionsByProvider>(MODEL_VERSIONS);
 	const [providerFilter, setProviderFilter] =
 		useState<string>(ALL_PROVIDERS_FILTER);
 	const [selectedModel, setSelectedModel] = useState<string | null>(null);
@@ -749,6 +758,7 @@ export const ModelImportPage: React.FC = () => {
 	/**
 	 * Any initialization logic for the model import flow - fetch importable models
 	 */
+	// biome-ignore lint/correctness/useExhaustiveDependencies: run-once init; monolithStore is a stable root store
 	useEffect(() => {
 		const fetch = async () => {
 			setImportableModels(IMPORTABLE_MODELS as ImportableModels);
@@ -765,6 +775,19 @@ export const ModelImportPage: React.FC = () => {
 		};
 
 		fetch();
+
+		// enrich the hardcoded cards with whatever the server's catalog knows;
+		// on any failure the hardcoded cards simply stay as they are
+		let cancelled = false;
+		fetchCatalogModels((pixel) => monolithStore.runQuery(pixel)).then(
+			(catalog) => {
+				if (cancelled || !catalog) return;
+				setModelVersions(mergeCatalogModels(MODEL_VERSIONS, catalog));
+			},
+		);
+		return () => {
+			cancelled = true;
+		};
 	}, []);
 
 	useEffect(() => {
@@ -810,7 +833,7 @@ export const ModelImportPage: React.FC = () => {
 		const normalizedSearch = search.trim().toLowerCase();
 
 		return sortedProviders.map((provider) => {
-			const models = (MODEL_VERSIONS[provider.name] || []).filter(
+			const models = (modelVersions[provider.name] || []).filter(
 				(model) => {
 					if (!normalizedSearch) return true;
 
@@ -831,7 +854,7 @@ export const ModelImportPage: React.FC = () => {
 				models,
 			};
 		});
-	}, [sortedProviders, search]);
+	}, [sortedProviders, search, modelVersions]);
 
 	const visibleProviderSections = useMemo(() => {
 		if (providerFilter === ALL_PROVIDERS_FILTER) {
@@ -846,13 +869,13 @@ export const ModelImportPage: React.FC = () => {
 	const selectedModelMetadata = useMemo(() => {
 		if (!selectedProvider || selectedModel === null) return null;
 
-		const providerModels = MODEL_VERSIONS[selectedProvider] || [];
+		const providerModels = modelVersions[selectedProvider] || [];
 		return (
 			providerModels.find(
 				(m) => m.name === selectedModel || m.display === selectedModel,
 			) || null
 		);
-	}, [selectedProvider, selectedModel]);
+	}, [selectedProvider, selectedModel, modelVersions]);
 
 	// only an "other-" card leaves the Model ID to the user, and only then is there
 	// anything to match against the catalog


### PR DESCRIPTION
## Summary

`MODEL_VERSIONS` in `model-import.constants.ts` hardcoded every Add-Model card, so new model
releases required an FE change. The import page now fetches the server's
`ListStaticModelCatalog()` pixel (backed by `meta/model.json`) and merges catalog models into
the card grid. Updating the catalog file on the server is now the only step needed to surface
new models on the OpenAI, Anthropic, Google Gemini, AWS Bedrock, NVIDIA NIM, and Perplexity
tabs — including Claude on Vertex and Bedrock.

## What changed

### New: `model-import-catalog.ts`
- `fetchCatalogModels(runQuery)` — calls the pixel; returns `null` on **any** failure (older
  server, missing catalog, network error) so the page falls back to the hardcoded cards.
- `mergeCatalogModels(hardcoded, catalog)`:
  - **Dedup, hardcoded wins**: name match is case-insensitive with `@` ≈ `-` and Vertex's
    `@default`/`@latest` qualifiers treated as the bare id, so curated cards keep their
    descriptions/configs and catalog duplicates are dropped.
  - **Newest-first ordering**: the whole grid sorts by release date. Hardcoded cards borrow
    the date of the catalog entry they matched (with Bedrock-style `vendor.`/`-v1:0`/date
    normalization, across all hosts). Undated cards sink below dated ones; `other-*`
    catch-alls stay last.
  - **Adapter**: card name = the host's exact serving model id; icon/brand per provider tab;
    `MAX_TOKENS`/`CONTEXT_WINDOW` defaults from catalog limits; `audio`/`image` flags from
    modalities.
  - **Hosted Claude gets the right init**: an Anthropic-authored model generated onto the
    Google or Bedrock tab receives `GOOGLE_ANTHROPIC_FORM_CONFIG` /
    `AWS_BEDROCK_ANTHROPIC_FORM_CONFIG` (AnthropicClient init script) plus Claude branding —
    without this, a Vertex Claude card would submit the Gemini init and fail.

### `model-import-page.tsx`
- New `modelVersions` state seeded with the hardcoded `MODEL_VERSIONS`; enriched once the
  pixel resolves; all card rendering reads from the state.

### `model-import.constants.ts`
- **Deleted 31 cards the catalog now regenerates exactly** (verified: exact id match under
  the right host, real token limits, no hand-tuned form config): 4 Anthropic Claude, 10
  OpenAI GPT, 9 Gemini (incl. the 3 image models — the `image` flag regenerates from
  modalities), 4 Bedrock Nova, 4 Perplexity Sonar.
- Kept: all embedding cards (`gemini-embedding-*` exact-match the catalog but would
  regenerate as LLM cards because the catalog lists them with text output — deleting them
  would break the import form), Bedrock `anthropic.*` ids, Vertex Claude, image/audio,
  Titan/rerank, NVIDIA, and all `other-*` catch-alls.
- Exported `ModelVersionDefinition`, `ModelFormConfig`, `withModelTokenLimits`,
  `GOOGLE_ANTHROPIC_FORM_CONFIG`, `AWS_BEDROCK_ANTHROPIC_FORM_CONFIG` (fixes three
  pre-existing TS2459 import errors, including one in `model-import-page.test.ts`).

## Merge order / risk

- Requires the Semoss PR (reactor + regenerated `meta/model.json`). Against an older server
  the page falls back to hardcoded cards — functional, but the 31 pruned models would be
  absent until the server side lands, so merge Semoss first.
- The 31 pruned models now exist only via the catalog; if the pixel fails, those tabs show
  the reduced hardcoded set. Acceptable since FE and server deploy together.