### PR TITLE
fix(playground): fix broken JSX and missing vars, etc

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,6 @@
 			".turbo/**",
 			"coverage/**",
 			"**/*.min.js",
-			"**/*.d.ts",
 			"**/.DS_Store",
 			"**/*.local",
 			".history/**"
@@ -138,6 +137,16 @@
 					},
 					"suspicious": {
 						"noExplicitAny": "off"
+					}
+				}
+			}
+		},
+		{
+			"includes": ["**/*.d.ts"],
+			"linter": {
+				"rules": {
+					"correctness": {
+						"noUnusedVariables": "off"
 					}
 				}
 			}

--- a/libs/i18n/src/resources/locales/ar/playground/chat.json
+++ b/libs/i18n/src/resources/locales/ar/playground/chat.json
@@ -17,6 +17,10 @@
 		"poorResponse": "استجابة ضعيفة",
 		"copyResponse": "نسخ الاستجابة",
 		"copyCode": "نسخ الكود",
+		"copy": "نسخ",
+		"saveInRoom": "حفظ في الغرفة",
+		"savingToRoom": "جارٍ الحفظ...",
+		"fullView": "عرض كامل",
 		"feedbackPlaceholder": "أضف تعليقًا (اختياري)",
 		"feedbackCancel": "إلغاء",
 		"feedbackSubmit": "إرسال",
@@ -43,6 +47,7 @@
 		"rewriteSuccess": "تمت إعادة كتابة الرسالة بنجاح",
 		"copySuccess": "تم النسخ إلى الحافظة بنجاح",
 		"noCopyContent": "لا يوجد محتوى للنسخ",
+		"savedInRoom": "تم الحفظ في الغرفة باسم {{filePath}}",
 		"planStepRemoved": "تمت إزالة الخطوة {{stepNumber}} من الخطة بنجاح"
 	},
 	"gracefulErrors": {

--- a/libs/i18n/src/resources/locales/ar/playground/chat.json
+++ b/libs/i18n/src/resources/locales/ar/playground/chat.json
@@ -21,6 +21,8 @@
 		"saveInRoom": "حفظ في الغرفة",
 		"savingToRoom": "جارٍ الحفظ...",
 		"fullView": "عرض كامل",
+		"raw": "خام",
+		"diagram": "الرسم البياني",
 		"feedbackPlaceholder": "أضف تعليقًا (اختياري)",
 		"feedbackCancel": "إلغاء",
 		"feedbackSubmit": "إرسال",

--- a/libs/i18n/src/resources/locales/en/playground/chat.json
+++ b/libs/i18n/src/resources/locales/en/playground/chat.json
@@ -21,6 +21,8 @@
 		"saveInRoom": "Save In Room",
 		"savingToRoom": "Saving...",
 		"fullView": "Full View",
+		"raw": "Raw",
+		"diagram": "Diagram",
 		"feedbackPlaceholder": "Add a comment (optional)",
 		"feedbackCancel": "Cancel",
 		"feedbackSubmit": "Submit",

--- a/libs/i18n/src/resources/locales/en/playground/chat.json
+++ b/libs/i18n/src/resources/locales/en/playground/chat.json
@@ -17,6 +17,10 @@
 		"poorResponse": "Poor response",
 		"copyResponse": "Copy Response",
 		"copyCode": "Copy Code",
+		"copy": "Copy",
+		"saveInRoom": "Save In Room",
+		"savingToRoom": "Saving...",
+		"fullView": "Full View",
 		"feedbackPlaceholder": "Add a comment (optional)",
 		"feedbackCancel": "Cancel",
 		"feedbackSubmit": "Submit",
@@ -43,6 +47,7 @@
 		"rewriteSuccess": "Successfully rewrote message",
 		"copySuccess": "Successfully copied to clipboard",
 		"noCopyContent": "No content to copy",
+		"savedInRoom": "Saved in room as {{filePath}}",
 		"planStepRemoved": "Successfully removed step {{stepNumber}} from plan"
 	},
 	"gracefulErrors": {

--- a/libs/i18n/src/resources/locales/es/playground/chat.json
+++ b/libs/i18n/src/resources/locales/es/playground/chat.json
@@ -21,6 +21,8 @@
 		"saveInRoom": "Guardar en la sala",
 		"savingToRoom": "Guardando...",
 		"fullView": "Vista completa",
+		"raw": "Bruto",
+		"diagram": "Diagrama",
 		"feedbackPlaceholder": "Agregar un comentario (opcional)",
 		"feedbackCancel": "Cancelar",
 		"feedbackSubmit": "Enviar",

--- a/libs/i18n/src/resources/locales/es/playground/chat.json
+++ b/libs/i18n/src/resources/locales/es/playground/chat.json
@@ -17,6 +17,10 @@
 		"poorResponse": "Mala respuesta",
 		"copyResponse": "Copiar respuesta",
 		"copyCode": "Copiar código",
+		"copy": "Copiar",
+		"saveInRoom": "Guardar en la sala",
+		"savingToRoom": "Guardando...",
+		"fullView": "Vista completa",
 		"feedbackPlaceholder": "Agregar un comentario (opcional)",
 		"feedbackCancel": "Cancelar",
 		"feedbackSubmit": "Enviar",
@@ -43,6 +47,7 @@
 		"rewriteSuccess": "Mensaje reescrito con éxito",
 		"copySuccess": "Copiado al portapapeles con éxito",
 		"noCopyContent": "No hay contenido para copiar",
+		"savedInRoom": "Guardado en la sala como {{filePath}}",
 		"planStepRemoved": "Paso {{stepNumber}} eliminado del plan con éxito"
 	},
 	"gracefulErrors": {

--- a/libs/i18n/src/resources/locales/fr/playground/chat.json
+++ b/libs/i18n/src/resources/locales/fr/playground/chat.json
@@ -17,6 +17,10 @@
 		"poorResponse": "Mauvaise réponse",
 		"copyResponse": "Copier la réponse",
 		"copyCode": "Copier le code",
+		"copy": "Copier",
+		"saveInRoom": "Enregistrer dans la salle",
+		"savingToRoom": "Enregistrement...",
+		"fullView": "Vue complète",
 		"feedbackPlaceholder": "Ajouter un commentaire (facultatif)",
 		"feedbackCancel": "Annuler",
 		"feedbackSubmit": "Envoyer",
@@ -43,6 +47,7 @@
 		"rewriteSuccess": "Message réécrit avec succès",
 		"copySuccess": "Copié dans le presse-papiers avec succès",
 		"noCopyContent": "Aucun contenu à copier",
+		"savedInRoom": "Enregistré dans la salle sous {{filePath}}",
 		"planStepRemoved": "Étape {{stepNumber}} supprimée du plan avec succès"
 	},
 	"gracefulErrors": {

--- a/libs/i18n/src/resources/locales/fr/playground/chat.json
+++ b/libs/i18n/src/resources/locales/fr/playground/chat.json
@@ -21,6 +21,8 @@
 		"saveInRoom": "Enregistrer dans la salle",
 		"savingToRoom": "Enregistrement...",
 		"fullView": "Vue complète",
+		"raw": "Brut",
+		"diagram": "Diagramme",
 		"feedbackPlaceholder": "Ajouter un commentaire (facultatif)",
 		"feedbackCancel": "Annuler",
 		"feedbackSubmit": "Envoyer",

--- a/libs/i18n/src/resources/locales/hi/playground/chat.json
+++ b/libs/i18n/src/resources/locales/hi/playground/chat.json
@@ -17,6 +17,10 @@
 		"poorResponse": "खराब जवाब",
 		"copyResponse": "जवाब कॉपी करें",
 		"copyCode": "कोड कॉपी करें",
+		"copy": "कॉपी करें",
+		"saveInRoom": "रूम में सेव करें",
+		"savingToRoom": "सेव हो रहा है...",
+		"fullView": "पूर्ण दृश्य",
 		"feedbackPlaceholder": "टिप्पणी जोड़ें (वैकल्पिक)",
 		"feedbackCancel": "रद्द करें",
 		"feedbackSubmit": "सबमिट करें",
@@ -43,6 +47,7 @@
 		"rewriteSuccess": "संदेश सफलतापूर्वक फिर से लिखा गया",
 		"copySuccess": "क्लिपबोर्ड पर सफलतापूर्वक कॉपी किया गया",
 		"noCopyContent": "कॉपी करने के लिए कोई सामग्री नहीं",
+		"savedInRoom": "{{filePath}} के रूप में रूम में सेव किया गया",
 		"planStepRemoved": "योजना से चरण {{stepNumber}} सफलतापूर्वक हटाया गया"
 	},
 	"gracefulErrors": {

--- a/libs/i18n/src/resources/locales/hi/playground/chat.json
+++ b/libs/i18n/src/resources/locales/hi/playground/chat.json
@@ -21,6 +21,8 @@
 		"saveInRoom": "रूम में सेव करें",
 		"savingToRoom": "सेव हो रहा है...",
 		"fullView": "पूर्ण दृश्य",
+		"raw": "रॉ",
+		"diagram": "आरेख",
 		"feedbackPlaceholder": "टिप्पणी जोड़ें (वैकल्पिक)",
 		"feedbackCancel": "रद्द करें",
 		"feedbackSubmit": "सबमिट करें",

--- a/libs/i18n/src/resources/locales/ja/playground/chat.json
+++ b/libs/i18n/src/resources/locales/ja/playground/chat.json
@@ -17,6 +17,10 @@
 		"poorResponse": "悪い回答",
 		"copyResponse": "回答をコピー",
 		"copyCode": "コードをコピー",
+		"copy": "コピー",
+		"saveInRoom": "ルームに保存",
+		"savingToRoom": "保存中...",
+		"fullView": "全画面表示",
 		"feedbackPlaceholder": "コメントを追加（任意）",
 		"feedbackCancel": "キャンセル",
 		"feedbackSubmit": "送信",
@@ -43,6 +47,7 @@
 		"rewriteSuccess": "メッセージを正常に書き直しました",
 		"copySuccess": "クリップボードに正常にコピーしました",
 		"noCopyContent": "コピーするコンテンツがありません",
+		"savedInRoom": "{{filePath}} としてルームに保存しました",
 		"planStepRemoved": "プランからステップ{{stepNumber}}を正常に削除しました"
 	},
 	"gracefulErrors": {

--- a/libs/i18n/src/resources/locales/ja/playground/chat.json
+++ b/libs/i18n/src/resources/locales/ja/playground/chat.json
@@ -21,6 +21,8 @@
 		"saveInRoom": "ルームに保存",
 		"savingToRoom": "保存中...",
 		"fullView": "全画面表示",
+		"raw": "ソース",
+		"diagram": "図",
 		"feedbackPlaceholder": "コメントを追加（任意）",
 		"feedbackCancel": "キャンセル",
 		"feedbackSubmit": "送信",

--- a/libs/i18n/src/resources/locales/nl/playground/chat.json
+++ b/libs/i18n/src/resources/locales/nl/playground/chat.json
@@ -17,6 +17,10 @@
 		"poorResponse": "Slecht antwoord",
 		"copyResponse": "Antwoord kopiëren",
 		"copyCode": "Code kopiëren",
+		"copy": "Kopiëren",
+		"saveInRoom": "Opslaan in kamer",
+		"savingToRoom": "Bezig met opslaan...",
+		"fullView": "Volledige weergave",
 		"feedbackPlaceholder": "Voeg een opmerking toe (optioneel)",
 		"feedbackCancel": "Annuleren",
 		"feedbackSubmit": "Verzenden",
@@ -43,6 +47,7 @@
 		"rewriteSuccess": "Bericht succesvol herschreven",
 		"copySuccess": "Succesvol gekopieerd naar klembord",
 		"noCopyContent": "Geen inhoud om te kopiëren",
+		"savedInRoom": "Opgeslagen in kamer als {{filePath}}",
 		"planStepRemoved": "Stap {{stepNumber}} succesvol uit plan verwijderd"
 	},
 	"gracefulErrors": {

--- a/libs/i18n/src/resources/locales/nl/playground/chat.json
+++ b/libs/i18n/src/resources/locales/nl/playground/chat.json
@@ -21,6 +21,8 @@
 		"saveInRoom": "Opslaan in kamer",
 		"savingToRoom": "Bezig met opslaan...",
 		"fullView": "Volledige weergave",
+		"raw": "Ruw",
+		"diagram": "Diagram",
 		"feedbackPlaceholder": "Voeg een opmerking toe (optioneel)",
 		"feedbackCancel": "Annuleren",
 		"feedbackSubmit": "Verzenden",

--- a/packages/client/src/global.d.ts
+++ b/packages/client/src/global.d.ts
@@ -7,7 +7,6 @@ interface ImportMetaEnv {
 	// more env variables...
 }
 
-// biome-ignore lint/correctness/noUnusedVariables: Global type augmentation for Vite
 interface ImportMeta {
 	readonly env: ImportMetaEnv;
 }

--- a/packages/playground/src/components/message/response-message-text/code-preview-block.tsx
+++ b/packages/playground/src/components/message/response-message-text/code-preview-block.tsx
@@ -177,7 +177,7 @@ export const CodePreviewBlock = ({
 				false,
 				false,
 			);
-			toast.success(`Saved in room as ${filePath}`);
+			toast.success(t("notifications.savedInRoom", { filePath }));
 		} catch (error) {
 			const message =
 				error instanceof Error && error.message
@@ -280,7 +280,9 @@ export const CodePreviewBlock = ({
 						disabled={!room || !code || isSavingToRoom}
 						onClick={() => void saveInRoom()}
 					>
-						{isSavingToRoom ? "Saving..." : "Save In Room"}
+						{isSavingToRoom
+							? t("response.savingToRoom")
+							: t("response.saveInRoom")}
 					</Button>
 					<Button
 						className="-my-1 h-6 px-2 text-muted-foreground text-xs hover:text-foreground"
@@ -289,7 +291,7 @@ export const CodePreviewBlock = ({
 						disabled={!code}
 						onClick={() => setIsFullViewOpen(true)}
 					>
-						Full View
+						{t("response.fullView")}
 					</Button>
 				</BlockHeader>
 				{!isCollapsed && (
@@ -316,11 +318,11 @@ export const CodePreviewBlock = ({
 										}
 									>
 										<CopyIcon className="size-3.5" />
-										Copy
+										{t("response.copy")}
 									</Button>
 								</TooltipTrigger>
 								<TooltipContent side="bottom">
-									Copy
+									{t("response.copy")}
 								</TooltipContent>
 							</Tooltip>
 						</div>

--- a/packages/playground/src/components/message/response-message-text/code-preview-block.tsx
+++ b/packages/playground/src/components/message/response-message-text/code-preview-block.tsx
@@ -1,7 +1,6 @@
 import {
 	ChevronDownIcon,
 	CopyIcon,
-	ExpandIcon,
 	FileCodeIcon,
 	NotebookPenIcon,
 	PlayIcon,
@@ -72,6 +71,7 @@ export const CodePreviewBlock = ({
 	const [isAddToNotebookOpen, setIsAddToNotebookOpen] = useState(false);
 	const [isSaveCodeDialogOpen, setIsSaveCodeDialogOpen] = useState(false);
 	const [isCollapsed, setIsCollapsed] = useState(false);
+	const [isSavingToRoom, setIsSavingToRoom] = useState(false);
 	// the block is height capped, so it follows its own newest line
 	const codeScroll = useStickToBottom(code);
 	const [isExecuting, setIsExecuting] = useState(false);
@@ -164,6 +164,29 @@ export const CodePreviewBlock = ({
 			});
 		} finally {
 			setIsExecuting(false);
+		}
+	};
+
+	const saveInRoom = async () => {
+		if (!room || !code) return;
+		const filePath = `save-code-response-${Date.now()}.${codeExtension}`;
+		try {
+			setIsSavingToRoom(true);
+			await room.runRoomPixel(
+				`SaveInsightAssets(filePath=[${JSON.stringify(filePath)}], content=["<encode>${code}</encode>"]);`,
+				false,
+				false,
+			);
+			toast.success(`Saved in room as ${filePath}`);
+		} catch (error) {
+			const message =
+				error instanceof Error && error.message
+					? error.message
+					: "Error";
+
+			toast.error(message);
+		} finally {
+			setIsSavingToRoom(false);
 		}
 	};
 
@@ -301,55 +324,17 @@ export const CodePreviewBlock = ({
 								</TooltipContent>
 							</Tooltip>
 						</div>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								className="text-muted-foreground text-xs hover:text-foreground"
-								variant="ghost"
-								size="sm"
-								disabled={!code}
-								onClick={() =>
-									void copyToClipboard(
-										code,
-										() =>
-											toast.success(
-												t("notifications.copySuccess"),
-											),
-										(msg) => toast.error(msg),
-									)
-								}
-							>
-								<CopyIcon className="size-3" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>Copy</TooltipContent>
-					</Tooltip>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								className="text-muted-foreground text-xs hover:text-foreground"
-								variant="ghost"
-								size="sm"
-								disabled={!code}
-								onClick={() => setIsFullViewOpen(true)}
-							>
-								<ExpandIcon className="size-3" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent side="bottom">Full view</TooltipContent>
-					</Tooltip>
-				</BlockHeader>
-				{!isCollapsed && (
-					// capped to the height an html preview uses, so a long block
-					// scrolls inside the message instead of pushing the rest of the
-					// conversation off screen
-					<div
-						ref={codeScroll.ref}
-						onScroll={codeScroll.onScroll}
-						className="overflow-auto p-3"
-						style={{ maxHeight: RESPONSE_BLOCK_MAX_HEIGHT }}
-					>
-						<Code code={code} language={language ?? "txt"} />
+						{/* capped to the height an html preview uses, so a long block
+						scrolls inside the message instead of pushing the rest of the
+						conversation off screen */}
+						<div
+							ref={codeScroll.ref}
+							onScroll={codeScroll.onScroll}
+							className="overflow-auto p-3"
+							style={{ maxHeight: RESPONSE_BLOCK_MAX_HEIGHT }}
+						>
+							<Code code={code} language={language ?? "txt"} />
+						</div>
 					</div>
 				)}
 				{executeResult && (

--- a/packages/playground/src/components/message/response-message-text/mermaid-block.tsx
+++ b/packages/playground/src/components/message/response-message-text/mermaid-block.tsx
@@ -171,7 +171,7 @@ export const MermaidBlock = ({ code, isLoading, room }: MermaidBlockProps) => {
 					))}
 			</div>
 			<Dialog open={isFullViewOpen} onOpenChange={setIsFullViewOpen}>
-				<DialogContent className="h-[100dvh] max-h-[100dvh] w-[100dvw] max-w-[100dvw] grid-rows-[auto_1fr] overflow-hidden rounded-none border-0 p-3 sm:w-[100dvw] sm:max-w-[100dvw]">
+				<DialogContent className="h-dvh max-h-dvh w-dvw max-w-dvw grid-rows-[auto_1fr] overflow-hidden rounded-none border-0 p-3 sm:w-dvw sm:max-w-dvw">
 					<DialogHeader>
 						<DialogTitle>Mermaid</DialogTitle>
 					</DialogHeader>

--- a/packages/playground/src/components/message/response-message-text/mermaid-block.tsx
+++ b/packages/playground/src/components/message/response-message-text/mermaid-block.tsx
@@ -1,5 +1,6 @@
 import { CopyIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "@semoss/i18n";
 import {
 	Button,
 	Code,
@@ -35,6 +36,7 @@ interface MermaidBlockProps {
 }
 
 export const MermaidBlock = ({ code, isLoading, room }: MermaidBlockProps) => {
+	const { t } = useTranslation("chat");
 	const [svg, setSvg] = useState<string | null>(null);
 	const [isCollapsed, setIsCollapsed] = useState(false);
 	const [isFullViewOpen, setIsFullViewOpen] = useState(false);
@@ -82,7 +84,7 @@ export const MermaidBlock = ({ code, isLoading, room }: MermaidBlockProps) => {
 				false,
 				false,
 			);
-			toast.success(`Saved in room as ${filePath}`);
+			toast.success(t("notifications.savedInRoom", { filePath }));
 		} catch (error) {
 			const message =
 				error instanceof Error && error.message
@@ -114,7 +116,7 @@ export const MermaidBlock = ({ code, isLoading, room }: MermaidBlockProps) => {
 						disabled={isLoading || !svg}
 						onClick={() => setIsRaw((prev) => !prev)}
 					>
-						{isRaw ? "Diagram" : "Raw"}
+						{isRaw ? t("response.diagram") : t("response.raw")}
 					</Button>
 					<Button
 						className="-my-1 h-6 px-2 text-muted-foreground text-xs hover:text-foreground"
@@ -123,7 +125,7 @@ export const MermaidBlock = ({ code, isLoading, room }: MermaidBlockProps) => {
 						disabled={!svg}
 						onClick={() => setIsFullViewOpen(true)}
 					>
-						Full View
+						{t("response.fullView")}
 					</Button>
 					<Button
 						className="-my-1 h-6 px-2 text-muted-foreground text-xs hover:text-foreground"
@@ -132,7 +134,9 @@ export const MermaidBlock = ({ code, isLoading, room }: MermaidBlockProps) => {
 						disabled={!room || !code || isSavingToRoom}
 						onClick={() => void saveInRoom()}
 					>
-						{isSavingToRoom ? "Saving..." : "Save In Room"}
+						{isSavingToRoom
+							? t("response.savingToRoom")
+							: t("response.saveInRoom")}
 					</Button>
 					<Tooltip>
 						<TooltipTrigger asChild>
@@ -144,16 +148,21 @@ export const MermaidBlock = ({ code, isLoading, room }: MermaidBlockProps) => {
 								onClick={() =>
 									void copyToClipboard(
 										code,
-										() => toast.success("Copied"),
+										() =>
+											toast.success(
+												t("notifications.copySuccess"),
+											),
 										(msg) => toast.error(msg),
 									)
 								}
 							>
 								<CopyIcon className="size-3.5" />
-								Copy
+								{t("response.copy")}
 							</Button>
 						</TooltipTrigger>
-						<TooltipContent side="bottom">Copy</TooltipContent>
+						<TooltipContent side="bottom">
+							{t("response.copy")}
+						</TooltipContent>
 					</Tooltip>
 				</BlockHeader>
 				{!isCollapsed &&

--- a/packages/playground/src/pages/new-room-page.tsx
+++ b/packages/playground/src/pages/new-room-page.tsx
@@ -320,6 +320,7 @@ export const NewRoomPage = observer(() => {
 	}, [workspaceIdSearchParams]);
 
 	// Handle workspace data loading from RoomWorkspace component selection
+	// biome-ignore lint/correctness/useExhaustiveDependencies: autoGreetedRef guards re-fires
 	useEffect(() => {
 		if (!selectedWorkspaceId) {
 			// clearing the agent clears the guard below, so picking the same
@@ -400,7 +401,6 @@ export const NewRoomPage = observer(() => {
 			autoGreetedRef.current = true;
 			createRoom("Hello", [], { visible: false });
 		}
-		// biome-ignore lint/correctness/useExhaustiveDependencies: autoGreetedRef guards re-fires
 	}, [
 		selectedWorkspaceId,
 		getWorkspace.status,

--- a/packages/playground/vite-env.d.ts
+++ b/packages/playground/vite-env.d.ts
@@ -8,7 +8,6 @@ interface ImportMetaEnv {
 	readonly VITE_DEFAUlT_MODEL_NAME: string;
 }
 
-// biome-ignore lint/correctness/noUnusedVariables: this is actually used
 interface ImportMeta {
 	readonly env: ImportMetaEnv;
 }


### PR DESCRIPTION
## Description
PR #3507 left `code-preview-block.tsx` with orphaned JSX from an incomplete refactor, breaking the playground build, plus a "Save In Room" button wired to undefined state. This fixes the build, wires up save-to-room, and moves the touched UI strings into i18n across all locales.

## Changes Made
- **code-preview-block.tsx**: removed orphaned JSX/duplicate `</BlockHeader>` from #3507, added missing `isSavingToRoom` state + `saveInRoom` handler, i18n'd the button strings.
- **mermaid-block.tsx**: added missing `useTranslation` hook, i18n'd `Raw`/`Diagram`/`Full View`/`Save In Room`/`Copy`, reused existing `copySuccess` key for the copy toast.
- **i18n locales (7 languages)**: added `response.copy/saveInRoom/savingToRoom/fullView/raw/diagram` and `notifications.savedInRoom`.
- **biome.json + 3 files**: cleaned up 4 stray Biome warnings (misplaced suppression comment, `.d.ts` `noUnusedVariables` override for ambient interfaces like `ImportMeta`).

## How to Test
1. Scroll a long code block — Copy button should stick to the top.
2. Click "Save In Room" on a code block — should succeed with a toast.
3. Switch app language — code/mermaid block controls should be translated.
4. `pnpm fix` — zero warnings in `playground`/`client`.

## Notes
Bundled a small, unrelated Biome cleanup found while verifying this fix rather than splitting it out.