### PR TITLE
fix: rebuild the model guardrail settings editor around the engine's reported methods and arguments

### DIFF
--- a/libs/ui/src/next/form.tsx
+++ b/libs/ui/src/next/form.tsx
@@ -491,7 +491,7 @@ function FormFileDropzone({
 /* -------------------------------------------------------------------------- */
 
 type FormActionsProps = {
-	/** Mirrors form.formState.isSubmitting — disables both buttons and shows the Spinner. */
+	/** Mirrors form.formState.isSubmitting - disables both buttons and shows the Spinner. */
 	isSubmitting: boolean;
 	/** Called when the user clicks Cancel. */
 	onCancel: () => void;
@@ -567,6 +567,7 @@ export {
 	FormProvider,
 	type SubmitHandler,
 	type UseFormReturn,
+	useFieldArray,
 	useForm,
 	useFormContext,
 } from "react-hook-form";

--- a/packages/client/src/components/engine/engine-guardrail-settings.constants.test.ts
+++ b/packages/client/src/components/engine/engine-guardrail-settings.constants.test.ts
@@ -1,0 +1,525 @@
+import { describe, expect, test } from "vitest";
+import {
+	collectGuardrailConfigIssues,
+	createGuardrailPipeline,
+	extractGuardrailEngineDetails,
+	extractGuardrailFileStatus,
+	extractInterceptableMethods,
+	extractResultArgumentName,
+	guardrailArgumentOptions,
+	guardrailConfigFromResponse,
+	guardrailConfigToJson,
+	type InterceptableMethod,
+	validateGuardrailConfig,
+} from "./engine-guardrail-settings.constants";
+
+const INPUT_REACTOR = "prerna.reactor.interceptor.GenericGuardrailInputReactor";
+
+const LIST_BATCHES: InterceptableMethod = {
+	name: "listBatches",
+	deprecated: false,
+	returnType: "BatchListResponse",
+	returnsModelResponse: false,
+	arguments: [],
+};
+
+/** A blocking response check reading one argument. */
+const outputCheck = (args: string) => ({
+	id: "check-1",
+	guardrailEngineId: "guardrail-1",
+	failureAction: "block" as const,
+	closeRoomOnBlock: false,
+	blockErrorMessage: "",
+	inputMapping: [{ id: "a", key: "prompt", args }],
+	directParameters: [],
+});
+
+const ASK_ROOM: InterceptableMethod = {
+	name: "askRoom",
+	deprecated: false,
+	returnType: "AskModelEngineResponse",
+	returnsModelResponse: true,
+	arguments: [
+		{
+			name: "arg0",
+			position: 0,
+			nameIsFromSource: false,
+			type: "InputMessage",
+			guardable: true,
+		},
+		{
+			name: "arg1",
+			position: 1,
+			nameIsFromSource: false,
+			type: "Room",
+			guardable: false,
+		},
+	],
+};
+
+describe("guardrail settings configuration", () => {
+	test("loads and serializes a response as one exclusive action", () => {
+		const form = guardrailConfigFromResponse({
+			pipelines: {
+				askRoom: {
+					input: [
+						{
+							reactorClass: INPUT_REACTOR,
+							params: {
+								guardrailEngineId: "guardrail-1",
+								blockOnGuardrailFailure: false,
+								maskOnGuardrailFailure: false,
+								respondWithGuardrailMessage: true,
+								closeRoomOnBlock: false,
+								inputMapping: { prompt: "arg0" },
+							},
+						},
+					],
+				},
+			},
+		});
+
+		const entry = form.pipelines[0]?.input[0];
+		expect(entry).toMatchObject({
+			failureAction: "respond",
+			closeRoomOnBlock: false,
+			blockErrorMessage: "",
+		});
+
+		const serializedEntry = JSON.parse(guardrailConfigToJson(form))
+			.pipelines.askRoom.input[0];
+		expect(serializedEntry.reactorClass).toBe(INPUT_REACTOR);
+		expect(serializedEntry.params).toMatchObject({
+			blockOnGuardrailFailure: false,
+			maskOnGuardrailFailure: false,
+			respondWithGuardrailMessage: true,
+			closeRoomOnBlock: false,
+		});
+		expect(serializedEntry.params).not.toHaveProperty("blockErrorMessage");
+	});
+
+	test("writes explicit false defaults and omits an empty block message", () => {
+		const form = { pipelines: [createGuardrailPipeline("askRoom")] };
+		const entry = form.pipelines[0]?.input[0];
+		if (entry) {
+			entry.guardrailEngineId = "guardrail-1";
+		}
+
+		const serialized = JSON.parse(guardrailConfigToJson(form));
+		const params = serialized.pipelines.askRoom.input[0].params;
+		expect(params.blockOnGuardrailFailure).toBe(true);
+		expect(params.maskOnGuardrailFailure).toBe(false);
+		expect(params.respondWithGuardrailMessage).toBe(false);
+		expect(params.closeRoomOnBlock).toBe(false);
+		expect(params).not.toHaveProperty("blockErrorMessage");
+	});
+
+	test("serializes masking as the only active failure action", () => {
+		const form = { pipelines: [createGuardrailPipeline("askRoom")] };
+		const entry = form.pipelines[0]?.input[0];
+		if (entry) {
+			entry.guardrailEngineId = "guardrail-1";
+			entry.failureAction = "mask";
+		}
+
+		expect(validateGuardrailConfig(form)).toBe(true);
+		const params = JSON.parse(guardrailConfigToJson(form)).pipelines.askRoom
+			.input[0].params;
+		expect(params).toMatchObject({
+			blockOnGuardrailFailure: false,
+			maskOnGuardrailFailure: true,
+			respondWithGuardrailMessage: false,
+		});
+		expect(params).not.toHaveProperty("maskTargetParam");
+	});
+
+	test("accepts masking under any guardrail parameter name", () => {
+		const pipeline = createGuardrailPipeline("askRoom");
+		const entry = pipeline.input[0];
+		if (entry) {
+			entry.guardrailEngineId = "guardrail-1";
+			entry.failureAction = "mask";
+			// a storage or vector call names its content something else
+			entry.inputMapping = [{ id: "a", key: "content", args: "arg1" }];
+		}
+
+		expect(validateGuardrailConfig({ pipelines: [pipeline] })).toBe(true);
+	});
+
+	test("rejects masking when no input can receive the masked value", () => {
+		const combined = createGuardrailPipeline("askRoom");
+		const combinedEntry = combined.input[0];
+		if (combinedEntry) {
+			combinedEntry.guardrailEngineId = "guardrail-1";
+			combinedEntry.failureAction = "mask";
+			combinedEntry.inputMapping = [
+				{ id: "a", key: "content", args: "arg0, arg1" },
+			];
+		}
+		expect(validateGuardrailConfig({ pipelines: [combined] })).toContain(
+			"Masking needs one input that reads a single argument",
+		);
+
+		const overridden = createGuardrailPipeline("askRoom");
+		const overriddenEntry = overridden.input[0];
+		if (overriddenEntry) {
+			overriddenEntry.guardrailEngineId = "guardrail-1";
+			overriddenEntry.failureAction = "mask";
+			overriddenEntry.inputMapping = [
+				{ id: "a", key: "content", args: "arg0" },
+			];
+			// a fixed value shadows the mapping, so the argument is never read
+			overriddenEntry.directParameters = [
+				{ id: "b", key: "content", type: "string", value: "fixed" },
+			];
+		}
+		expect(validateGuardrailConfig({ pipelines: [overridden] })).toContain(
+			"is not overridden by a fixed value",
+		);
+	});
+
+	test("accepts masking when only one of several inputs is writable", () => {
+		const pipeline = createGuardrailPipeline("askRoom");
+		const entry = pipeline.input[0];
+		if (entry) {
+			entry.guardrailEngineId = "guardrail-1";
+			entry.failureAction = "mask";
+			entry.inputMapping = [
+				{ id: "a", key: "content", args: "arg0, arg1" },
+				{ id: "b", key: "title", args: "arg2" },
+			];
+		}
+
+		expect(validateGuardrailConfig({ pipelines: [pipeline] })).toBe(true);
+	});
+
+	test("loads and serializes array and JSON direct parameters", () => {
+		const form = guardrailConfigFromResponse({
+			pipelines: {
+				askRoom: {
+					input: [
+						{
+							reactorClass: INPUT_REACTOR,
+							params: {
+								guardrailEngineId: "guardrail-1",
+								inputMapping: { prompt: "arg0" },
+								directParameters: {
+									labels: ["person", "email address"],
+									thresholds: [0.5, 0.8],
+									flags: [true, false],
+									options: { mode: "strict" },
+								},
+							},
+						},
+					],
+				},
+			},
+		});
+
+		const directParameters = form.pipelines[0]?.input[0]?.directParameters;
+		expect(
+			directParameters?.map(({ key, type }) => ({ key, type })),
+		).toEqual([
+			{ key: "labels", type: "string-array" },
+			{ key: "thresholds", type: "number-array" },
+			{ key: "flags", type: "boolean-array" },
+			{ key: "options", type: "json" },
+		]);
+
+		const serialized = JSON.parse(guardrailConfigToJson(form)).pipelines
+			.askRoom.input[0].params.directParameters;
+		expect(serialized).toEqual({
+			labels: ["person", "email address"],
+			thresholds: [0.5, 0.8],
+			flags: [true, false],
+			options: { mode: "strict" },
+		});
+	});
+
+	test("rejects array direct parameters with the wrong item type", () => {
+		const form = { pipelines: [createGuardrailPipeline("askRoom")] };
+		const entry = form.pipelines[0]?.input[0];
+		if (entry) {
+			entry.guardrailEngineId = "guardrail-1";
+			entry.directParameters = [
+				{
+					id: "labels",
+					key: "labels",
+					type: "string-array",
+					value: '["person", 1]',
+				},
+			];
+		}
+
+		expect(validateGuardrailConfig(form)).toBe(
+			'Direct parameter "labels" must contain only string values in pipeline "askRoom".',
+		);
+	});
+
+	test("reports every problem with the rule and check it belongs to", () => {
+		const first = createGuardrailPipeline("askRoom");
+		const second = createGuardrailPipeline("askRoom");
+		const issues = collectGuardrailConfigIssues(
+			{ pipelines: [first, second] },
+			{ methods: [ASK_ROOM], resultArgumentName: "result" },
+		);
+		const errors = issues.filter((issue) => issue.severity === "error");
+
+		// both checks lack an engine, and the second rule repeats the method
+		expect(errors).toHaveLength(3);
+		expect(
+			errors.filter((issue) =>
+				/needs a guardrail engine/.test(issue.message),
+			),
+		).toHaveLength(2);
+		expect(errors[0]).toMatchObject({
+			pipelineId: first.id,
+			phase: "input",
+			entryId: first.input[0]?.id,
+		});
+		expect(
+			errors.some(
+				(issue) =>
+					issue.pipelineId === second.id &&
+					issue.message.includes("must be unique"),
+			),
+		).toBe(true);
+	});
+
+	test("warns about argument names the runtime cannot resolve", () => {
+		const pipeline = createGuardrailPipeline("askRoom");
+		const entry = pipeline.input[0];
+		if (entry) {
+			entry.guardrailEngineId = "guardrail-1";
+			entry.inputMapping[0] = {
+				id: "mapping-1",
+				key: "prompt",
+				args: "arg9",
+			};
+		}
+
+		const warnings = collectGuardrailConfigIssues(
+			{ pipelines: [pipeline] },
+			{ methods: [ASK_ROOM] },
+		).filter((issue) => issue.severity === "warning");
+
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]?.message).toBe(
+			'"arg9" is not an argument of askRoom, so the guardrail receives nothing for "prompt".',
+		);
+		// a warning still leaves the configuration saveable
+		expect(validateGuardrailConfig({ pipelines: [pipeline] })).toBe(true);
+	});
+
+	test("warns that a dot path is allowed but a plumbing argument is not text", () => {
+		const pipeline = createGuardrailPipeline("askRoom");
+		const entry = pipeline.input[0];
+		if (entry) {
+			entry.guardrailEngineId = "guardrail-1";
+			entry.inputMapping = [
+				{ id: "a", key: "prompt", args: "arg0.message" },
+				{ id: "b", key: "room", args: "arg1" },
+			];
+		}
+
+		const warnings = collectGuardrailConfigIssues(
+			{ pipelines: [pipeline] },
+			{ methods: [ASK_ROOM] },
+		).filter((issue) => issue.severity === "warning");
+
+		expect(warnings.map((issue) => issue.message)).toEqual([
+			'"arg1" is the Room argument of askRoom, which is not text a guardrail can screen.',
+		]);
+	});
+
+	test("accepts a response check reading result from a model response", () => {
+		const pipeline = createGuardrailPipeline("askRoom");
+		pipeline.input = [];
+		pipeline.output = [outputCheck("result")];
+
+		// the output reactor unwraps the response, so result is screenable
+		expect(
+			collectGuardrailConfigIssues(
+				{ pipelines: [pipeline] },
+				{ methods: [ASK_ROOM], resultArgumentName: "result" },
+			),
+		).toEqual([]);
+	});
+
+	test("warns when the intercepted call returns no model response", () => {
+		const pipeline = createGuardrailPipeline("listBatches");
+		pipeline.input = [];
+		pipeline.output = [outputCheck("result")];
+
+		const warnings = collectGuardrailConfigIssues(
+			{ pipelines: [pipeline] },
+			{
+				methods: [ASK_ROOM, LIST_BATCHES],
+				resultArgumentName: "result",
+			},
+		).filter((issue) => issue.severity === "warning");
+
+		expect(warnings.map((issue) => issue.message)).toEqual([
+			'listBatches returns BatchListResponse rather than a model response, so "prompt" receives that object rather than screenable content.',
+		]);
+	});
+
+	test("warns when an input check reads a result that does not exist yet", () => {
+		const pipeline = createGuardrailPipeline("askRoom");
+		const entry = pipeline.input[0];
+		if (entry) {
+			entry.guardrailEngineId = "guardrail-1";
+			entry.inputMapping[0] = { id: "a", key: "prompt", args: "result" };
+		}
+
+		const warnings = collectGuardrailConfigIssues(
+			{ pipelines: [pipeline] },
+			{ methods: [ASK_ROOM], resultArgumentName: "result" },
+		).filter((issue) => issue.severity === "warning");
+
+		expect(warnings[0]?.message).toBe(
+			'"result" only exists after the model runs, so an input guardrail receives nothing for "prompt".',
+		);
+	});
+});
+
+describe("guardrail settings response extraction", () => {
+	test("reads the interceptable methods and the result argument", () => {
+		const response = {
+			interceptableMethods: [
+				{
+					name: "askRoom",
+					deprecated: false,
+					returnType: "AskModelEngineResponse",
+					returnsModelResponse: true,
+					arguments: [
+						{
+							name: "arg0",
+							position: 0,
+							nameIsFromSource: false,
+							type: "InputMessage",
+							guardable: true,
+						},
+						{ notAnArgument: true },
+					],
+				},
+				{ missingName: true },
+			],
+			resultArgumentName: "result",
+		};
+
+		const methods = extractInterceptableMethods(response);
+		expect(methods).toHaveLength(1);
+		expect(methods[0]?.arguments.map((argument) => argument.name)).toEqual([
+			"arg0",
+		]);
+		expect(extractResultArgumentName(response)).toBe("result");
+	});
+
+	test("falls back when the backend reports no methods", () => {
+		expect(extractInterceptableMethods({})).toEqual([]);
+		expect(extractInterceptableMethods(null)).toEqual([]);
+		expect(extractResultArgumentName({})).toBe("result");
+	});
+
+	test("reads whether the engine loads a pipeline file", () => {
+		expect(
+			extractGuardrailFileStatus({
+				configured: false,
+				pipelineFileName: null,
+				fileExists: false,
+			}).state,
+		).toBe("not-enabled");
+		expect(
+			extractGuardrailFileStatus({
+				configured: true,
+				pipelineFileName: "pipeline.json",
+				fileExists: false,
+			}),
+		).toMatchObject({
+			state: "file-missing",
+			pipelineFileName: "pipeline.json",
+		});
+		expect(
+			extractGuardrailFileStatus({
+				configured: true,
+				pipelineFileName: "pipeline.json",
+				fileExists: true,
+				parseError: "Expected a ','",
+				rawContent: "{",
+			}),
+		).toMatchObject({
+			state: "loaded",
+			parseError: "Expected a ','",
+			rawContent: "{",
+		});
+	});
+
+	test("treats an engine with no reported details as usable", () => {
+		const details = extractGuardrailEngineDetails({
+			guardrailEngines: {
+				"guardrail-1": { name: "Policy guardrail" },
+				"guardrail-2": {
+					name: null,
+					exists: false,
+					userCanView: false,
+				},
+			},
+		});
+
+		expect(details["guardrail-1"]).toMatchObject({
+			name: "Policy guardrail",
+			exists: true,
+			userCanView: true,
+		});
+		expect(details["guardrail-2"]).toMatchObject({
+			name: null,
+			exists: false,
+			userCanView: false,
+		});
+	});
+});
+
+describe("guardrail argument options", () => {
+	test("offers a known method's arguments, adding result for the output phase", () => {
+		expect(
+			guardrailArgumentOptions({
+				method: "askRoom",
+				phase: "input",
+				methods: [ASK_ROOM],
+			}).map((option) => option.name),
+		).toEqual(["arg0", "arg1"]);
+
+		expect(
+			guardrailArgumentOptions({
+				method: "askRoom",
+				phase: "output",
+				methods: [ASK_ROOM],
+			}).map((option) => option.name),
+		).toEqual(["result", "arg0", "arg1"]);
+	});
+
+	test("cannot name arguments for a wildcard or unreported method", () => {
+		expect(
+			guardrailArgumentOptions({
+				method: "*",
+				phase: "input",
+				methods: [ASK_ROOM],
+			}),
+		).toEqual([]);
+		expect(
+			guardrailArgumentOptions({
+				method: "somethingElse",
+				phase: "input",
+				methods: [ASK_ROOM],
+			}),
+		).toEqual([]);
+		expect(
+			guardrailArgumentOptions({
+				method: "*",
+				phase: "output",
+				methods: [ASK_ROOM],
+			}).map((option) => option.name),
+		).toEqual(["result"]);
+	});
+});

--- a/packages/client/src/components/engine/engine-guardrail-settings.constants.ts
+++ b/packages/client/src/components/engine/engine-guardrail-settings.constants.ts
@@ -4,43 +4,88 @@
  * guardrail proxy via GetModelGuardrailConfig / UpdateModelGuardrailConfig.
  */
 
+import { z } from "@semoss/ui/next";
+
 const GUARDRAIL_INPUT_REACTOR =
 	"prerna.reactor.interceptor.GenericGuardrailInputReactor";
-const GUARDRAIL_INPUT_OUTPUT_REACTOR =
-	"prerna.reactor.interceptor.GenericGuardrailInputOutputReactor";
+const GUARDRAIL_OUTPUT_REACTOR =
+	"prerna.reactor.interceptor.GenericGuardrailOutputReactor";
 
-export const DEFAULT_MASK_TARGET_PARAM = "prompt";
+/** Parameter a new check starts wired to, since the guardrails in the catalog
+ * declare it. Nothing depends on the name; the picker lists whatever the
+ * selected guardrail engine declares. */
+const DEFAULT_GUARDRAIL_PARAM = "prompt";
+
+/** Method value that applies a pipeline to every intercepted call. */
+export const GUARDRAIL_ALL_METHODS = "*";
+
+/** Argument name the interceptor uses for the intercepted method's return value. */
+export const GUARDRAIL_RESULT_ARGUMENT = "result";
 
 export type GuardrailPhase = "input" | "output";
+export const GUARDRAIL_FAILURE_ACTIONS = ["block", "mask", "respond"] as const;
+export const GUARDRAIL_DIRECT_PARAMETER_TYPES = [
+	"string",
+	"number",
+	"boolean",
+	"string-array",
+	"number-array",
+	"boolean-array",
+	"json",
+] as const;
 
-/** Reactor classes legal per phase - the output slot is instantiated as an
- * output reactor by the backend, so the input-only class is not allowed
- * there. */
-export const GUARDRAIL_REACTOR_OPTIONS: Record<
-	GuardrailPhase,
-	Array<{ value: string; label: string }>
-> = {
-	input: [
-		{ value: GUARDRAIL_INPUT_REACTOR, label: "Check input only" },
-		{
-			value: GUARDRAIL_INPUT_OUTPUT_REACTOR,
-			label: "Check input and output",
-		},
-	],
-	output: [
-		{
-			value: GUARDRAIL_INPUT_OUTPUT_REACTOR,
-			label: "Check input and output",
-		},
-	],
-};
-
-interface GuardrailEngineDetails {
+/** Backend resolved details for a guardrail engine referenced by the config. */
+export interface GuardrailEngineDetails {
+	/** Display name, or null when the engine could not be resolved. */
 	name: string | null;
+
+	/** Whether the engine is still in the catalog. */
 	exists: boolean;
+
+	/** Catalog type, expected to be GUARDRAIL. */
 	type: string | null;
+
+	/** Catalog subtype, such as the guardrail implementation. */
 	subtype: string | null;
+
+	/** Whether the current user can view the engine. */
 	userCanView: boolean;
+}
+
+/** One argument of a method a guardrail pipeline can intercept. */
+export interface InterceptableMethodArgument {
+	/** Name the runtime resolves at request time, such as arg0. */
+	name: string;
+
+	/** Zero based position in the method signature. */
+	position: number;
+
+	/** Whether the name comes from the source signature rather than the position. */
+	nameIsFromSource: boolean;
+
+	/** Readable Java type, such as List<String>. */
+	type: string;
+
+	/** Whether a guardrail can screen this argument's value. */
+	guardable: boolean;
+}
+
+/** A model engine method a guardrail pipeline can intercept. */
+export interface InterceptableMethod {
+	/** Java method name, used as the pipeline key. */
+	name: string;
+
+	/** Whether the method is deprecated on the engine interface. */
+	deprecated: boolean;
+
+	/** Readable return type. */
+	returnType: string;
+
+	/** Whether the return value is a model response object. */
+	returnsModelResponse: boolean;
+
+	/** Arguments in signature order. */
+	arguments: InterceptableMethodArgument[];
 }
 
 /** Response shape of GetModelGuardrailConfig. */
@@ -54,45 +99,101 @@ export interface GetModelGuardrailConfigResponse {
 	pipelines: Record<string, unknown>;
 	guardrailEngines: Record<string, GuardrailEngineDetails>;
 	allowedReactorClasses: { input: string[]; output: string[] };
+	interceptableMethods: InterceptableMethod[];
+	resultArgumentName: string;
 }
 
-export interface GuardrailMappingEntryFormValue {
-	id: string;
-	/** Guardrail parameter name (e.g. prompt) */
-	key: string;
-	/** Intercepted argument name(s), comma separated in the editor */
-	args: string;
+/** Whether the engine loads a guardrail pipeline file, and which one. */
+export type GuardrailFileState = "loaded" | "file-missing" | "not-enabled";
+
+/** Everything the editor needs to explain the stored configuration's state. */
+export interface GuardrailFileStatus {
+	state: GuardrailFileState;
+
+	/** Name of the pipeline file the engine points at, when configured. */
+	pipelineFileName: string | null;
+
+	/** Parse failure reported for the stored file, when it could not be read. */
+	parseError: string | null;
+
+	/** Contents of the stored file, present only when it failed to parse. */
+	rawContent: string | null;
 }
 
-export interface GuardrailDirectParamFormValue {
-	id: string;
-	key: string;
-	type: "string" | "number" | "boolean";
-	value: string;
-}
+const guardrailMappingEntrySchema = z.object({
+	id: z.string(),
+	key: z.string().trim().min(1, "Enter a guardrail parameter."),
+	args: z.string().trim().min(1, "Enter at least one method argument."),
+});
 
-export interface GuardrailReactorFormValue {
-	id: string;
-	reactorClass: string;
-	guardrailEngineId: string;
-	blockOnGuardrailFailure: boolean;
-	maskOnGuardrailFailure: boolean;
-	maskTargetParam: string;
-	inputMapping: GuardrailMappingEntryFormValue[];
-	directParameters: GuardrailDirectParamFormValue[];
-}
+const guardrailDirectParamSchema = z.object({
+	id: z.string(),
+	key: z.string().trim().min(1, "Enter a parameter name."),
+	type: z.enum(GUARDRAIL_DIRECT_PARAMETER_TYPES),
+	value: z.string(),
+});
 
-export interface GuardrailPipelineFormValue {
-	id: string;
-	/** Engine method to intercept, or "*" for every method */
-	method: string;
-	input: GuardrailReactorFormValue[];
-	output: GuardrailReactorFormValue[];
-}
+const guardrailFailureActionSchema = z.enum(GUARDRAIL_FAILURE_ACTIONS);
 
-export interface GuardrailConfigFormValue {
-	pipelines: GuardrailPipelineFormValue[];
-}
+const guardrailReactorSchema = z
+	.object({
+		id: z.string(),
+		guardrailEngineId: z.string().min(1, "Select a guardrail engine."),
+		failureAction: guardrailFailureActionSchema,
+		closeRoomOnBlock: z.boolean(),
+		blockErrorMessage: z.string(),
+		inputMapping: z
+			.array(guardrailMappingEntrySchema)
+			.min(1, "Add at least one parameter mapping."),
+		directParameters: z.array(guardrailDirectParamSchema),
+	})
+	.superRefine((value, context) => {
+		if (
+			value.failureAction === "block" &&
+			value.blockErrorMessage.length > 0 &&
+			!value.blockErrorMessage.trim()
+		) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "The custom block message cannot be blank.",
+				path: ["blockErrorMessage"],
+			});
+		}
+	});
+
+const guardrailPipelineSchema = z.object({
+	id: z.string(),
+	method: z.string().trim().min(1, "Enter a method name, or use *."),
+	input: z.array(guardrailReactorSchema),
+	output: z.array(guardrailReactorSchema),
+});
+
+export const guardrailConfigSchema = z
+	.object({ pipelines: z.array(guardrailPipelineSchema) })
+	.superRefine((value, context) => {
+		const validation = validateGuardrailConfig(value);
+		if (validation !== true) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: validation,
+			});
+		}
+	});
+
+export type GuardrailMappingEntryFormValue = z.infer<
+	typeof guardrailMappingEntrySchema
+>;
+export type GuardrailDirectParamFormValue = z.infer<
+	typeof guardrailDirectParamSchema
+>;
+export type GuardrailFailureAction = z.infer<
+	typeof guardrailFailureActionSchema
+>;
+export type GuardrailReactorFormValue = z.infer<typeof guardrailReactorSchema>;
+export type GuardrailPipelineFormValue = z.infer<
+	typeof guardrailPipelineSchema
+>;
+export type GuardrailConfigFormValue = z.infer<typeof guardrailConfigSchema>;
 
 let guardrailFieldIdSeed = 0;
 const nextGuardrailFieldId = () => {
@@ -121,22 +222,17 @@ export const createGuardrailReactor = (
 	phase: GuardrailPhase,
 ): GuardrailReactorFormValue => ({
 	id: nextGuardrailFieldId(),
-	reactorClass:
-		phase === "output"
-			? GUARDRAIL_INPUT_OUTPUT_REACTOR
-			: GUARDRAIL_INPUT_REACTOR,
 	guardrailEngineId: "",
-	blockOnGuardrailFailure: true,
-	maskOnGuardrailFailure: false,
-	maskTargetParam: DEFAULT_MASK_TARGET_PARAM,
+	failureAction: "block",
+	closeRoomOnBlock: false,
+	blockErrorMessage: "",
 	// without a mapping the guardrail receives no content to check, so new
-	// entries start wired to the first argument (input) or the response
-	// (output) - "arg0" is the intercepted method's first argument and
-	// "result" is the method's return value
+	// entries start wired to the first argument (request) or the return value
+	// (response) - "arg0" is the intercepted method's first argument
 	inputMapping: [
 		createGuardrailMappingEntry(
-			DEFAULT_MASK_TARGET_PARAM,
-			phase === "output" ? "result" : "arg0",
+			DEFAULT_GUARDRAIL_PARAM,
+			phase === "output" ? GUARDRAIL_RESULT_ARGUMENT : "arg0",
 		),
 	],
 	directParameters: [],
@@ -161,6 +257,54 @@ const splitArgs = (args: string): string[] =>
 		.map((arg) => arg.trim())
 		.filter(Boolean);
 
+const inferDirectParameterType = (
+	value: unknown,
+): GuardrailDirectParamFormValue["type"] => {
+	if (Array.isArray(value)) {
+		if (
+			value.length > 0 &&
+			value.every((item) => typeof item === "string")
+		) {
+			return "string-array";
+		}
+		if (
+			value.length > 0 &&
+			value.every(
+				(item) => typeof item === "number" && Number.isFinite(item),
+			)
+		) {
+			return "number-array";
+		}
+		if (
+			value.length > 0 &&
+			value.every((item) => typeof item === "boolean")
+		) {
+			return "boolean-array";
+		}
+		return "json";
+	}
+	if (value !== null && typeof value === "object") {
+		return "json";
+	}
+	if (typeof value === "boolean") {
+		return "boolean";
+	}
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return "number";
+	}
+	return "string";
+};
+
+const directParameterValueForForm = (
+	value: unknown,
+	type: GuardrailDirectParamFormValue["type"],
+): string => {
+	if (type.endsWith("-array") || type === "json") {
+		return JSON.stringify(value, null, 2);
+	}
+	return value === null || value === undefined ? "" : String(value);
+};
+
 const normalizeReactorEntry = (
 	entry: unknown,
 	phase: GuardrailPhase,
@@ -170,15 +314,6 @@ const normalizeReactorEntry = (
 		return base;
 	}
 	const e = entry as Record<string, unknown>;
-	const allowedClasses = GUARDRAIL_REACTOR_OPTIONS[phase].map(
-		(option) => option.value,
-	);
-	if (
-		typeof e.reactorClass === "string" &&
-		allowedClasses.includes(e.reactorClass)
-	) {
-		base.reactorClass = e.reactorClass;
-	}
 	const params =
 		e.params && typeof e.params === "object"
 			? (e.params as Record<string, unknown>)
@@ -186,17 +321,22 @@ const normalizeReactorEntry = (
 	if (typeof params.guardrailEngineId === "string") {
 		base.guardrailEngineId = params.guardrailEngineId;
 	}
-	if (typeof params.blockOnGuardrailFailure === "boolean") {
-		base.blockOnGuardrailFailure = params.blockOnGuardrailFailure;
-	}
-	if (typeof params.maskOnGuardrailFailure === "boolean") {
-		base.maskOnGuardrailFailure = params.maskOnGuardrailFailure;
+	if (phase === "input" && params.respondWithGuardrailMessage === true) {
+		base.failureAction = "respond";
+	} else if (phase === "input" && params.maskOnGuardrailFailure === true) {
+		base.failureAction = "mask";
 	}
 	if (
-		typeof params.maskTargetParam === "string" &&
-		params.maskTargetParam.trim()
+		base.failureAction === "block" &&
+		typeof params.closeRoomOnBlock === "boolean"
 	) {
-		base.maskTargetParam = params.maskTargetParam.trim();
+		base.closeRoomOnBlock = params.closeRoomOnBlock;
+	}
+	if (
+		base.failureAction === "block" &&
+		typeof params.blockErrorMessage === "string"
+	) {
+		base.blockErrorMessage = params.blockErrorMessage;
 	}
 	if (params.inputMapping && typeof params.inputMapping === "object") {
 		base.inputMapping = Object.entries(
@@ -223,19 +363,8 @@ const normalizeReactorEntry = (
 		).map(([key, paramValue]) => {
 			const param = createGuardrailDirectParam();
 			param.key = key;
-			if (typeof paramValue === "boolean") {
-				param.type = "boolean";
-				param.value = String(paramValue);
-			} else if (
-				typeof paramValue === "number" &&
-				Number.isFinite(paramValue)
-			) {
-				param.type = "number";
-				param.value = String(paramValue);
-			} else {
-				param.type = "string";
-				param.value = typeof paramValue === "string" ? paramValue : "";
-			}
+			param.type = inferDirectParameterType(paramValue);
+			param.value = directParameterValueForForm(paramValue, param.type);
 			return param;
 		});
 	}
@@ -289,153 +418,506 @@ export const guardrailConfigFromResponse = (
 	return { pipelines };
 };
 
-/** Pull the id-to-name fallbacks for guardrail engines referenced by the
- * config but missing from the user's MyEngines list. */
-export const extractGuardrailEngineNames = (
+/** Pull the backend resolved details for every guardrail engine the config
+ * references, including engines missing from the user's MyEngines list. */
+export const extractGuardrailEngineDetails = (
 	raw: unknown,
-): Record<string, string> => {
-	const names: Record<string, string> = {};
+): Record<string, GuardrailEngineDetails> => {
+	const resolved: Record<string, GuardrailEngineDetails> = {};
 	if (!raw || typeof raw !== "object") {
-		return names;
+		return resolved;
 	}
 	const engines = (raw as Record<string, unknown>).guardrailEngines;
 	if (!engines || typeof engines !== "object") {
-		return names;
+		return resolved;
 	}
 	for (const [engineId, details] of Object.entries(
 		engines as Record<string, unknown>,
 	)) {
-		if (details && typeof details === "object") {
-			const name = (details as Record<string, unknown>).name;
-			if (typeof name === "string" && name) {
-				names[engineId] = name;
-			}
+		if (!details || typeof details !== "object") {
+			continue;
+		}
+		const d = details as Record<string, unknown>;
+		resolved[engineId] = {
+			name: typeof d.name === "string" && d.name ? d.name : null,
+			// an older backend omits these, so treat a present engine as usable
+			exists: d.exists !== false,
+			type: typeof d.type === "string" ? d.type : null,
+			subtype: typeof d.subtype === "string" ? d.subtype : null,
+			userCanView: d.userCanView !== false,
+		};
+	}
+	return resolved;
+};
+
+/** The methods a pipeline can intercept, as reported by the backend. Empty
+ * when the backend does not supply them, which drops the editor back to
+ * free-text method and argument entry. */
+export const extractInterceptableMethods = (
+	raw: unknown,
+): InterceptableMethod[] => {
+	if (!raw || typeof raw !== "object") {
+		return [];
+	}
+	const methods = (raw as Record<string, unknown>).interceptableMethods;
+	if (!Array.isArray(methods)) {
+		return [];
+	}
+	return methods.flatMap((entry) => {
+		if (!entry || typeof entry !== "object") {
+			return [];
+		}
+		const e = entry as Record<string, unknown>;
+		if (typeof e.name !== "string" || !e.name) {
+			return [];
+		}
+		const rawArguments = Array.isArray(e.arguments) ? e.arguments : [];
+		return [
+			{
+				name: e.name,
+				deprecated: e.deprecated === true,
+				returnType:
+					typeof e.returnType === "string" ? e.returnType : "",
+				returnsModelResponse: e.returnsModelResponse === true,
+				arguments: rawArguments.flatMap((argument, index) => {
+					if (!argument || typeof argument !== "object") {
+						return [];
+					}
+					const a = argument as Record<string, unknown>;
+					if (typeof a.name !== "string" || !a.name) {
+						return [];
+					}
+					return [
+						{
+							name: a.name,
+							position:
+								typeof a.position === "number"
+									? a.position
+									: index,
+							nameIsFromSource: a.nameIsFromSource === true,
+							type: typeof a.type === "string" ? a.type : "",
+							guardable: a.guardable === true,
+						},
+					];
+				}),
+			},
+		];
+	});
+};
+
+/** The argument name carrying the model's return value, which output
+ * guardrails map from. */
+export const extractResultArgumentName = (raw: unknown): string => {
+	if (raw && typeof raw === "object") {
+		const name = (raw as Record<string, unknown>).resultArgumentName;
+		if (typeof name === "string" && name) {
+			return name;
 		}
 	}
-	return names;
+	return GUARDRAIL_RESULT_ARGUMENT;
 };
 
-export interface GuardrailMaskConflict {
-	pipelineId: string;
-	phase: GuardrailPhase;
-	entryId: string;
-}
+/** Whether the engine actually loads a pipeline file. A config that looks
+ * complete in the editor still screens nothing when the engine has no
+ * PIPELINE key, so the editor reports this state directly. */
+export const extractGuardrailFileStatus = (
+	raw: unknown,
+): GuardrailFileStatus => {
+	const status: GuardrailFileStatus = {
+		state: "not-enabled",
+		pipelineFileName: null,
+		parseError: null,
+		rawContent: null,
+	};
+	if (!raw || typeof raw !== "object") {
+		return status;
+	}
+	const response = raw as Record<string, unknown>;
+	status.pipelineFileName =
+		typeof response.pipelineFileName === "string" &&
+		response.pipelineFileName
+			? response.pipelineFileName
+			: null;
+	status.parseError =
+		typeof response.parseError === "string" && response.parseError
+			? response.parseError
+			: null;
+	status.rawContent =
+		typeof response.rawContent === "string" ? response.rawContent : null;
+	if (response.configured !== true) {
+		return status;
+	}
+	status.state = response.fileExists === true ? "loaded" : "file-missing";
+	return status;
+};
 
+/** The arguments a mapping row can select for a phase. Empty when the method
+ * is a wildcard or is not one the backend reported, since the argument list
+ * cannot be known in that case. */
+export const guardrailArgumentOptions = ({
+	method,
+	phase,
+	methods,
+	resultArgumentName = GUARDRAIL_RESULT_ARGUMENT,
+}: {
+	method: string;
+	phase: GuardrailPhase;
+	methods: InterceptableMethod[];
+	resultArgumentName?: string;
+}): InterceptableMethodArgument[] => {
+	const trimmed = method.trim();
+	const matched =
+		trimmed && trimmed !== GUARDRAIL_ALL_METHODS
+			? methods.find((candidate) => candidate.name === trimmed)
+			: undefined;
+	// a response guardrail reads the payload of a model response, so the value is
+	// screenable unless the call returns something that is not one
+	const resultArgument: InterceptableMethodArgument = {
+		name: resultArgumentName,
+		position: -1,
+		nameIsFromSource: true,
+		type: matched ? matched.returnType : "model response",
+		guardable: matched ? matched.returnsModelResponse : true,
+	};
+	if (!matched) {
+		return phase === "output" ? [resultArgument] : [];
+	}
+	return phase === "output"
+		? [resultArgument, ...matched.arguments]
+		: matched.arguments;
+};
+
+/** Whether a check has no input a masked value could be written back to. */
 const entryHasMaskConflict = (entry: GuardrailReactorFormValue): boolean => {
-	if (!entry.maskOnGuardrailFailure) {
+	if (entry.failureAction !== "mask") {
 		return false;
 	}
-	const maskTarget =
-		entry.maskTargetParam.trim() || DEFAULT_MASK_TARGET_PARAM;
-	const mapping = entry.inputMapping.find(
-		(row) => row.key.trim() === maskTarget,
+	const fixedValueKeys = new Set(
+		entry.directParameters.map((row) => row.key.trim()),
 	);
-	// the backend falls back to blocking unless the mask target maps to
-	// exactly one argument, so anything else is a conflict
-	return !mapping || splitArgs(mapping.args).length !== 1;
+	// Masking writes the guardrail's single returned value back to the argument
+	// that supplied it, so one input has to read exactly one argument that no
+	// fixed value overrides. A combined input cannot receive one value, and an
+	// overridden input is never read from the call.
+	return !entry.inputMapping.some(
+		(row) =>
+			splitArgs(row.args).length === 1 &&
+			!fixedValueKeys.has(row.key.trim()),
+	);
 };
 
-/** Every entry whose mask setting the runtime would silently downgrade to
- * block. Shared by the inline warnings and the save-time validation. */
-export const findMaskMultiValueConflicts = (
+const validateDirectParameterValue = (
+	row: GuardrailDirectParamFormValue,
+): string | null => {
+	const key = row.key.trim() || "unnamed";
+	if (row.type === "number") {
+		if (!row.value.trim() || !Number.isFinite(Number(row.value))) {
+			return `Direct parameter "${key}" needs a numeric value.`;
+		}
+		return null;
+	}
+	if (!row.type.endsWith("-array") && row.type !== "json") {
+		return null;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(row.value);
+	} catch {
+		return `Direct parameter "${key}" needs valid JSON.`;
+	}
+	if (row.type === "json") {
+		return null;
+	}
+	if (!Array.isArray(parsed)) {
+		return `Direct parameter "${key}" needs a JSON array.`;
+	}
+
+	const itemType = row.type.replace("-array", "");
+	const itemsAreValid = parsed.every(
+		(item) =>
+			typeof item === itemType &&
+			(itemType !== "number" || Number.isFinite(item)),
+	);
+	return itemsAreValid
+		? null
+		: `Direct parameter "${key}" must contain only ${itemType} values.`;
+};
+
+export type GuardrailIssueSeverity = "error" | "warning";
+
+/** A problem found in the editor's value. Errors block saving; warnings flag
+ * configuration that saves cleanly but is unlikely to screen anything. */
+export interface GuardrailConfigIssue {
+	/** Message shown to the user. */
+	message: string;
+
+	/** Whether the issue blocks saving. */
+	severity: GuardrailIssueSeverity;
+
+	/** Pipeline the issue belongs to, when it can be pinpointed. */
+	pipelineId?: string;
+
+	/** Phase the issue belongs to, when it can be pinpointed. */
+	phase?: GuardrailPhase;
+
+	/** Guardrail entry the issue belongs to, when it can be pinpointed. */
+	entryId?: string;
+}
+
+/** Backend knowledge that lets validation flag method and argument names the
+ * runtime will not resolve. Absent when the backend did not report them. */
+export interface GuardrailValidationContext {
+	/** Methods the engine can intercept. */
+	methods?: InterceptableMethod[];
+
+	/** Argument name carrying the model's return value. */
+	resultArgumentName?: string;
+}
+
+/** The root segment of a mapped argument, so dot paths such as arg0.message
+ * are checked against the argument they start from. */
+const argumentRoot = (argument: string): string =>
+	argument.trim().split(".")[0] ?? "";
+
+/**
+ * Every problem in the editor's value, in the order the user reads them.
+ * Collecting all of them lets the editor list them at once instead of
+ * surfacing one per save attempt.
+ */
+export const collectGuardrailConfigIssues = (
 	value: GuardrailConfigFormValue,
-): GuardrailMaskConflict[] => {
-	const conflicts: GuardrailMaskConflict[] = [];
+	context: GuardrailValidationContext = {},
+): GuardrailConfigIssue[] => {
+	const issues: GuardrailConfigIssue[] = [];
+	const methods = context.methods ?? [];
+	const resultArgumentName =
+		context.resultArgumentName ?? GUARDRAIL_RESULT_ARGUMENT;
+	const seenMethods = new Set<string>();
+
 	for (const pipeline of value.pipelines) {
+		const method = pipeline.method.trim();
+		const pipelineTarget = { pipelineId: pipeline.id };
+		if (!method) {
+			issues.push({
+				message:
+					"Every pipeline needs a method name (use * for all methods).",
+				severity: "error",
+				...pipelineTarget,
+			});
+		} else if (seenMethods.has(method)) {
+			issues.push({
+				message: `Pipeline method names must be unique - "${method}" is used more than once.`,
+				severity: "error",
+				...pipelineTarget,
+			});
+		} else {
+			seenMethods.add(method);
+		}
+
+		const matchedMethod =
+			method && method !== GUARDRAIL_ALL_METHODS
+				? methods.find((candidate) => candidate.name === method)
+				: undefined;
+		if (method && method !== GUARDRAIL_ALL_METHODS && methods.length > 0) {
+			if (!matchedMethod) {
+				issues.push({
+					message: `"${method}" is not a method this engine reports as interceptable, so this pipeline may never run.`,
+					severity: "warning",
+					...pipelineTarget,
+				});
+			} else if (matchedMethod.deprecated) {
+				issues.push({
+					message: `"${method}" is deprecated on the engine interface and may carry no traffic.`,
+					severity: "warning",
+					...pipelineTarget,
+				});
+			}
+		}
+
+		if (pipeline.input.length === 0 && pipeline.output.length === 0) {
+			issues.push({
+				message: `Pipeline "${method}" needs at least one guardrail.`,
+				severity: "error",
+				...pipelineTarget,
+			});
+		}
+
 		for (const phase of ["input", "output"] as const) {
 			for (const entry of pipeline[phase]) {
-				if (entryHasMaskConflict(entry)) {
-					conflicts.push({
-						pipelineId: pipeline.id,
-						phase,
-						entryId: entry.id,
+				const target = {
+					pipelineId: pipeline.id,
+					phase,
+					entryId: entry.id,
+				};
+				if (!entry.guardrailEngineId) {
+					issues.push({
+						message: `Every guardrail in pipeline "${method}" needs a guardrail engine.`,
+						severity: "error",
+						...target,
 					});
+				}
+				if (phase === "output" && entry.failureAction !== "block") {
+					issues.push({
+						message: `Output guardrails in pipeline "${method}" must block on failure.`,
+						severity: "error",
+						...target,
+					});
+				}
+				if (
+					entry.failureAction === "block" &&
+					entry.blockErrorMessage.length > 0 &&
+					!entry.blockErrorMessage.trim()
+				) {
+					issues.push({
+						message: `The custom block message in pipeline "${method}" cannot be blank.`,
+						severity: "error",
+						...target,
+					});
+				}
+				if (entry.inputMapping.length === 0) {
+					issues.push({
+						message: `Every guardrail in pipeline "${method}" needs a parameter mapping (under Advanced) - the guardrail receives no content to check without one.`,
+						severity: "error",
+						...target,
+					});
+				}
+				if (entryHasMaskConflict(entry)) {
+					issues.push({
+						message: `Masking needs one input that reads a single argument and is not overridden by a fixed value, because the masked value is written back to that argument.`,
+						severity: "error",
+						...target,
+					});
+				}
+
+				const seenMappingKeys = new Set<string>();
+				for (const row of entry.inputMapping) {
+					const key = row.key.trim();
+					const args = splitArgs(row.args);
+					if (!key || args.length === 0) {
+						issues.push({
+							message: `Every parameter mapping in pipeline "${method}" needs a parameter name and at least one argument.`,
+							severity: "error",
+							...target,
+						});
+					} else if (seenMappingKeys.has(key)) {
+						issues.push({
+							message: `Parameter mappings in pipeline "${method}" must have unique parameter names.`,
+							severity: "error",
+							...target,
+						});
+					} else {
+						seenMappingKeys.add(key);
+					}
+
+					for (const argument of args) {
+						const root = argumentRoot(argument);
+						if (root === resultArgumentName) {
+							if (phase === "input") {
+								issues.push({
+									message: `"${resultArgumentName}" only exists after the model runs, so an input guardrail receives nothing for "${key}".`,
+									severity: "warning",
+									...target,
+								});
+							} else if (
+								matchedMethod &&
+								!matchedMethod.returnsModelResponse
+							) {
+								// a response guardrail is handed the payload of a
+								// model response; any other return value reaches it
+								// as the object itself
+								issues.push({
+									message: `${method} returns ${matchedMethod.returnType} rather than a model response, so "${key}" receives that object rather than screenable content.`,
+									severity: "warning",
+									...target,
+								});
+							}
+							continue;
+						}
+						if (!matchedMethod) {
+							continue;
+						}
+						const matchedArgument = matchedMethod.arguments.find(
+							(candidate) => candidate.name === root,
+						);
+						if (!matchedArgument) {
+							issues.push({
+								message: `"${root}" is not an argument of ${method}, so the guardrail receives nothing for "${key}".`,
+								severity: "warning",
+								...target,
+							});
+						} else if (
+							!matchedArgument.guardable &&
+							root === argument.trim()
+						) {
+							issues.push({
+								message: `"${root}" is the ${matchedArgument.type} argument of ${method}, which is not text a guardrail can screen.`,
+								severity: "warning",
+								...target,
+							});
+						}
+					}
+				}
+
+				const seenParamKeys = new Set<string>();
+				for (const row of entry.directParameters) {
+					const key = row.key.trim();
+					if (!key) {
+						issues.push({
+							message: `Every direct parameter in pipeline "${method}" needs a name.`,
+							severity: "error",
+							...target,
+						});
+						continue;
+					}
+					if (seenParamKeys.has(key)) {
+						issues.push({
+							message: `Direct parameters in pipeline "${method}" must have unique names.`,
+							severity: "error",
+							...target,
+						});
+						continue;
+					}
+					seenParamKeys.add(key);
+					const valueError = validateDirectParameterValue(row);
+					if (valueError) {
+						issues.push({
+							message: `${valueError.slice(0, -1)} in pipeline "${method}".`,
+							severity: "error",
+							...target,
+						});
+					}
 				}
 			}
 		}
 	}
-	return conflicts;
+	return issues;
 };
 
 /** true when the config is submittable, otherwise the message to surface. */
 export const validateGuardrailConfig = (
 	value: GuardrailConfigFormValue,
 ): true | string => {
-	const seenMethods = new Set<string>();
-	for (const pipeline of value.pipelines) {
-		const method = pipeline.method.trim();
-		if (!method) {
-			return "Every pipeline needs a method name (use * for all methods).";
-		}
-		if (seenMethods.has(method)) {
-			return `Pipeline method names must be unique - "${method}" is used more than once.`;
-		}
-		seenMethods.add(method);
-		if (pipeline.input.length === 0 && pipeline.output.length === 0) {
-			return `Pipeline "${method}" needs at least one guardrail.`;
-		}
-		for (const phase of ["input", "output"] as const) {
-			const allowedClasses = GUARDRAIL_REACTOR_OPTIONS[phase].map(
-				(option) => option.value,
-			);
-			for (const entry of pipeline[phase]) {
-				if (!entry.guardrailEngineId) {
-					return `Every guardrail in pipeline "${method}" needs a guardrail engine.`;
-				}
-				if (!allowedClasses.includes(entry.reactorClass)) {
-					return `Output guardrails in pipeline "${method}" must check input and output.`;
-				}
-				if (entry.inputMapping.length === 0) {
-					return `Every guardrail in pipeline "${method}" needs a parameter mapping (under Advanced) - the guardrail receives no content to check without one.`;
-				}
-				const seenMappingKeys = new Set<string>();
-				for (const row of entry.inputMapping) {
-					const key = row.key.trim();
-					if (!key || splitArgs(row.args).length === 0) {
-						return `Every parameter mapping in pipeline "${method}" needs a parameter name and at least one argument.`;
-					}
-					if (seenMappingKeys.has(key)) {
-						return `Parameter mappings in pipeline "${method}" must have unique parameter names.`;
-					}
-					seenMappingKeys.add(key);
-				}
-				const seenParamKeys = new Set<string>();
-				for (const row of entry.directParameters) {
-					const key = row.key.trim();
-					if (!key) {
-						return `Every direct parameter in pipeline "${method}" needs a name.`;
-					}
-					if (seenParamKeys.has(key)) {
-						return `Direct parameters in pipeline "${method}" must have unique names.`;
-					}
-					seenParamKeys.add(key);
-					if (
-						row.type === "number" &&
-						!Number.isFinite(Number.parseFloat(row.value))
-					) {
-						return `Direct parameter "${key}" in pipeline "${method}" needs a numeric value.`;
-					}
-				}
-			}
-		}
-	}
-	if (findMaskMultiValueConflicts(value).length > 0) {
-		return "Masking requires the mask target parameter to map to exactly one argument - otherwise the guardrail blocks instead of masking.";
-	}
-	return true;
+	const blocking = collectGuardrailConfigIssues(value).filter(
+		(issue) => issue.severity === "error",
+	);
+	return blocking.length === 0 ? true : blocking[0].message;
 };
 
 const serializeReactorEntry = (
 	entry: GuardrailReactorFormValue,
+	phase: GuardrailPhase,
 ): Record<string, unknown> => {
+	const failureAction = phase === "output" ? "block" : entry.failureAction;
 	const params: Record<string, unknown> = {
 		guardrailEngineId: entry.guardrailEngineId,
-		blockOnGuardrailFailure: entry.blockOnGuardrailFailure,
-		maskOnGuardrailFailure: entry.maskOnGuardrailFailure,
+		blockOnGuardrailFailure: failureAction === "block",
+		maskOnGuardrailFailure: failureAction === "mask",
+		respondWithGuardrailMessage: failureAction === "respond",
+		closeRoomOnBlock: failureAction === "block" && entry.closeRoomOnBlock,
 	};
-	if (entry.maskOnGuardrailFailure) {
-		params.maskTargetParam =
-			entry.maskTargetParam.trim() || DEFAULT_MASK_TARGET_PARAM;
+	if (failureAction === "block" && entry.blockErrorMessage.trim()) {
+		params.blockErrorMessage = entry.blockErrorMessage.trim();
 	}
 	if (entry.inputMapping.length > 0) {
 		const inputMapping: Record<string, unknown> = {};
@@ -449,16 +931,28 @@ const serializeReactorEntry = (
 		const directParameters: Record<string, unknown> = {};
 		for (const row of entry.directParameters) {
 			if (row.type === "number") {
-				directParameters[row.key.trim()] = Number.parseFloat(row.value);
+				directParameters[row.key.trim()] = Number(row.value);
 			} else if (row.type === "boolean") {
 				directParameters[row.key.trim()] = row.value === "true";
+			} else if (row.type.endsWith("-array") || row.type === "json") {
+				try {
+					directParameters[row.key.trim()] = JSON.parse(row.value);
+				} catch {
+					directParameters[row.key.trim()] = row.value;
+				}
 			} else {
 				directParameters[row.key.trim()] = row.value;
 			}
 		}
 		params.directParameters = directParameters;
 	}
-	return { reactorClass: entry.reactorClass, params };
+	return {
+		reactorClass:
+			phase === "input"
+				? GUARDRAIL_INPUT_REACTOR
+				: GUARDRAIL_OUTPUT_REACTOR,
+		params,
+	};
 };
 
 /** Serialize the editor value to the pipeline.json contract expected by
@@ -470,10 +964,14 @@ export const guardrailConfigToJson = (
 	for (const pipeline of value.pipelines) {
 		const serialized: Record<string, unknown> = {};
 		if (pipeline.input.length > 0) {
-			serialized.input = pipeline.input.map(serializeReactorEntry);
+			serialized.input = pipeline.input.map((entry) =>
+				serializeReactorEntry(entry, "input"),
+			);
 		}
 		if (pipeline.output.length > 0) {
-			serialized.output = pipeline.output.map(serializeReactorEntry);
+			serialized.output = pipeline.output.map((entry) =>
+				serializeReactorEntry(entry, "output"),
+			);
 		}
 		pipelines[pipeline.method.trim()] = serialized;
 	}

--- a/packages/client/src/components/engine/engine-guardrail-settings.test.tsx
+++ b/packages/client/src/components/engine/engine-guardrail-settings.test.tsx
@@ -1,0 +1,733 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { expect, test, vi } from "vitest";
+import { EngineGuardrailSettings } from "./engine-guardrail-settings";
+
+class ResizeObserverMock {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+
+vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+HTMLElement.prototype.scrollIntoView = vi.fn();
+
+const INPUT_REACTOR = "prerna.reactor.interceptor.GenericGuardrailInputReactor";
+
+const INTERCEPTABLE_METHODS = vi.hoisted(() => [
+	{
+		name: "askRoom",
+		deprecated: false,
+		returnType: "AskModelEngineResponse",
+		returnsModelResponse: true,
+		arguments: [
+			{
+				name: "arg0",
+				position: 0,
+				nameIsFromSource: false,
+				type: "InputMessage",
+				guardable: true,
+			},
+			{
+				name: "arg1",
+				position: 1,
+				nameIsFromSource: false,
+				type: "Room",
+				guardable: false,
+			},
+		],
+	},
+	{
+		name: "ask",
+		deprecated: true,
+		returnType: "AskModelEngineResponse",
+		returnsModelResponse: true,
+		arguments: [
+			{
+				name: "arg0",
+				position: 0,
+				nameIsFromSource: false,
+				type: "String",
+				guardable: true,
+			},
+		],
+	},
+]);
+
+/** Builds a GetModelGuardrailConfig response with the given overrides. */
+const buildConfig = (overrides: Record<string, unknown> = {}) => ({
+	engineId: "model-1",
+	configured: true,
+	pipelineFileName: "pipeline.json",
+	fileExists: true,
+	parseError: null,
+	rawContent: null,
+	pipelines: {
+		askRoom: {
+			input: [
+				{
+					reactorClass: INPUT_REACTOR,
+					params: {
+						guardrailEngineId: "guardrail-1",
+						blockOnGuardrailFailure: false,
+						maskOnGuardrailFailure: false,
+						respondWithGuardrailMessage: true,
+						closeRoomOnBlock: false,
+						inputMapping: { prompt: "arg0" },
+					},
+				},
+				{
+					reactorClass: INPUT_REACTOR,
+					params: {
+						guardrailEngineId: "guardrail-2",
+						blockOnGuardrailFailure: true,
+						inputMapping: { prompt: "arg0" },
+					},
+				},
+			],
+		},
+	},
+	guardrailEngines: {
+		"guardrail-1": {
+			name: "Policy guardrail",
+			exists: true,
+			type: "GUARDRAIL",
+			subtype: "policy",
+			userCanView: true,
+		},
+		"guardrail-2": {
+			name: "PII guardrail",
+			exists: true,
+			type: "GUARDRAIL",
+			subtype: "gliner",
+			userCanView: true,
+		},
+	},
+	allowedReactorClasses: { input: [], output: [] },
+	interceptableMethods: INTERCEPTABLE_METHODS,
+	resultArgumentName: "result",
+	...overrides,
+});
+
+const CONFIG = vi.hoisted(() => ({ current: null as unknown }));
+
+vi.mock("@semoss/sdk/react", () => ({
+	usePixel: (pixel: string) => {
+		if (pixel.startsWith("GetModelGuardrailConfig")) {
+			return {
+				status: "SUCCESS",
+				data: CONFIG.current,
+				error: undefined,
+				refresh: () => {},
+			};
+		}
+		if (pixel.startsWith("GetEngineUsage")) {
+			return {
+				status: "SUCCESS",
+				data: [
+					{
+						type: "guardrail",
+						parameters: [
+							{
+								name: "prompt",
+								type: "String",
+								description: "The text to evaluate.",
+								required: true,
+							},
+							{
+								name: "labels",
+								type: "List<String>",
+								description: "Entity labels to detect.",
+								required: true,
+							},
+							{
+								name: "threshold",
+								type: "Double",
+								description: "Detection threshold.",
+								required: false,
+							},
+						],
+					},
+				],
+				error: undefined,
+				refresh: () => {},
+			};
+		}
+		return {
+			status: "SUCCESS",
+			data: [],
+			error: undefined,
+			refresh: () => {},
+		};
+	},
+	// the shared engine select pages through the guardrail catalog itself
+	useIteratorPixel: () => ({
+		data: [
+			{
+				engine_id: "guardrail-1",
+				engine_name: "Policy guardrail",
+				engine_type: "GUARDRAIL",
+				engine_subtype: "policy",
+			},
+			{
+				engine_id: "guardrail-2",
+				engine_name: "PII guardrail",
+				engine_type: "GUARDRAIL",
+				engine_subtype: "gliner",
+			},
+		],
+		isLoading: false,
+		hasMore: false,
+		next: () => {},
+	}),
+}));
+
+vi.mock("@/hooks", () => ({
+	useRootStore: () => ({
+		configStore: { runPixel: async () => ({ errors: [] }) },
+	}),
+}));
+
+/** Renders the editor against a response built from the given overrides. */
+const renderSettings = (overrides: Record<string, unknown> = {}) => {
+	CONFIG.current = buildConfig(overrides);
+	return render(
+		<EngineGuardrailSettings engineId="model-1" permission="OWNER" />,
+	);
+};
+
+test("separates request and response checks into tabs", async () => {
+	renderSettings();
+
+	const requestTab = await screen.findByRole("tab", { name: /Request/ });
+	const responseTab = screen.getByRole("tab", { name: /Response/ });
+	expect(requestTab).toHaveAttribute("data-state", "active");
+	expect(requestTab).toHaveTextContent("2");
+	expect(responseTab).toHaveTextContent("0");
+
+	// the add control follows the list, so a new check lands at the bottom
+	const requestPanel = screen.getByTestId(
+		"engine-guardrail-settings--pipeline-0",
+	);
+	const addRequest = within(requestPanel).getByTestId(
+		"engine-guardrail-settings--pipeline-0-input-add",
+	);
+	const lastCheck = within(requestPanel).getByTestId(
+		"engine-guardrail-settings--pipeline-0-input-entry-1",
+	);
+	expect(
+		lastCheck.compareDocumentPosition(addRequest) &
+			Node.DOCUMENT_POSITION_FOLLOWING,
+	).toBeTruthy();
+
+	fireEvent.mouseDown(responseTab);
+	expect(
+		screen.getByText(
+			"Nothing screens the response before it reaches the caller.",
+		),
+	).toBeInTheDocument();
+});
+
+test("selects the rule to edit from a top level selector", async () => {
+	renderSettings({
+		pipelines: {
+			askRoom: {
+				input: [
+					{
+						reactorClass: INPUT_REACTOR,
+						params: {
+							guardrailEngineId: "guardrail-1",
+							blockOnGuardrailFailure: true,
+							inputMapping: { prompt: "arg0" },
+						},
+					},
+				],
+			},
+			"*": {
+				input: [
+					{
+						reactorClass: INPUT_REACTOR,
+						params: {
+							guardrailEngineId: "guardrail-2",
+							blockOnGuardrailFailure: true,
+							inputMapping: { prompt: "arg0" },
+						},
+					},
+				],
+			},
+		},
+	});
+
+	const ruleSelect = await screen.findByTestId(
+		"engine-guardrail-settings--rule-select",
+	);
+	expect(ruleSelect).toHaveTextContent("askRoom");
+	// the rail is gone, so the full width belongs to the selected rule
+	expect(
+		screen.queryByRole("navigation", { name: "Guardrail rules" }),
+	).not.toBeInTheDocument();
+
+	fireEvent.click(ruleSelect);
+	fireEvent.click(await screen.findByRole("option", { name: /^\* / }));
+	expect(
+		screen.getByTestId("engine-guardrail-settings--pipeline-1-method"),
+	).toHaveTextContent("*");
+});
+
+test("keeps the selected phase when switching rules", async () => {
+	renderSettings({
+		pipelines: {
+			askRoom: {
+				output: [
+					{
+						reactorClass:
+							"prerna.reactor.interceptor.GenericGuardrailOutputReactor",
+						params: {
+							guardrailEngineId: "guardrail-1",
+							blockOnGuardrailFailure: true,
+							inputMapping: { prompt: "result" },
+						},
+					},
+				],
+			},
+			"*": {
+				input: [
+					{
+						reactorClass: INPUT_REACTOR,
+						params: {
+							guardrailEngineId: "guardrail-2",
+							blockOnGuardrailFailure: true,
+							inputMapping: { prompt: "arg0" },
+						},
+					},
+				],
+			},
+		},
+	});
+
+	// askRoom has only response checks, so the editor opens on Response
+	expect(
+		await screen.findByRole("tab", { name: /Response/ }),
+	).toHaveAttribute("data-state", "active");
+
+	fireEvent.click(
+		screen.getByTestId("engine-guardrail-settings--rule-select"),
+	);
+	fireEvent.click(await screen.findByRole("option", { name: /^\* / }));
+
+	// the phase survives the switch rather than snapping back to Request
+	expect(screen.getByRole("tab", { name: /Response/ })).toHaveAttribute(
+		"data-state",
+		"active",
+	);
+});
+
+test("confirms before removing a rule", async () => {
+	renderSettings();
+
+	fireEvent.click(
+		await screen.findByTestId(
+			"engine-guardrail-settings--remove-pipeline-btn",
+		),
+	);
+	expect(await screen.findByText("Remove this rule?")).toBeInTheDocument();
+	expect(
+		screen.getByText(/2 checks stop screening askRoom/),
+	).toBeInTheDocument();
+
+	fireEvent.click(
+		screen.getByTestId(
+			"engine-guardrail-settings--remove-pipeline-confirm",
+		),
+	);
+	expect(
+		screen.getByTestId("engine-guardrail-settings--empty-state"),
+	).toBeInTheDocument();
+});
+
+test("switches to the rule that was just added", async () => {
+	renderSettings();
+
+	const ruleSelect = await screen.findByTestId(
+		"engine-guardrail-settings--rule-select",
+	);
+	expect(ruleSelect).toHaveTextContent("askRoom");
+
+	fireEvent.click(
+		screen.getByTestId("engine-guardrail-settings--add-pipeline-btn"),
+	);
+
+	// the new rule becomes the one being edited, on a call nothing else covers
+	expect(ruleSelect).toHaveTextContent("*");
+	expect(
+		screen.getByTestId("engine-guardrail-settings--pipeline-1-method"),
+	).toHaveTextContent("*");
+	expect(
+		screen.queryByTestId("engine-guardrail-settings--pipeline-0-method"),
+	).not.toBeInTheDocument();
+	// it still needs an engine picked, but it does not arrive as a duplicate
+	expect(
+		screen.getByTestId("engine-guardrail-settings--errors"),
+	).not.toHaveTextContent("used more than once");
+});
+
+test("cannot claim a call another rule already covers", async () => {
+	renderSettings({
+		pipelines: {
+			askRoom: {
+				input: [
+					{
+						reactorClass: INPUT_REACTOR,
+						params: {
+							guardrailEngineId: "guardrail-1",
+							blockOnGuardrailFailure: true,
+							inputMapping: { prompt: "arg0" },
+						},
+					},
+				],
+			},
+			"*": {
+				input: [
+					{
+						reactorClass: INPUT_REACTOR,
+						params: {
+							guardrailEngineId: "guardrail-2",
+							blockOnGuardrailFailure: true,
+							inputMapping: { prompt: "arg0" },
+						},
+					},
+				],
+			},
+		},
+	});
+
+	// editing askRoom, so Every call belongs to the other rule
+	fireEvent.click(
+		await screen.findByTestId(
+			"engine-guardrail-settings--pipeline-0-method",
+		),
+	);
+	const everyCall = await screen.findByRole("option", {
+		name: /already covered/,
+	});
+	expect(everyCall).toHaveAttribute("data-disabled");
+	expect(everyCall).toHaveTextContent("*");
+	// its own call stays selectable
+	expect(
+		screen.getByRole("option", { name: /^askRoom/ }),
+	).not.toHaveAttribute("data-disabled");
+});
+
+test("offers the engine's reported methods instead of free text", async () => {
+	renderSettings();
+
+	const methodPicker = await screen.findByTestId(
+		"engine-guardrail-settings--pipeline-0-method",
+	);
+	expect(methodPicker).toHaveTextContent("askRoom");
+
+	fireEvent.click(methodPicker);
+	expect(
+		await screen.findByRole("option", { name: /every call with no rule/ }),
+	).toBeInTheDocument();
+	const deprecated = screen.getByRole("option", { name: /^ask deprecated/ });
+	expect(deprecated).toHaveTextContent("deprecated");
+	expect(
+		screen.getByRole("option", { name: /Another method/ }),
+	).toBeInTheDocument();
+	fireEvent.keyDown(methodPicker, { key: "Escape" });
+});
+
+test("offers the selected method's arguments for a mapping row", async () => {
+	renderSettings();
+
+	const argumentPicker = await screen.findByTestId(
+		"engine-guardrail-settings--pipeline-0-input-entry-0-mapping-0-args",
+	);
+	expect(argumentPicker).toHaveTextContent("arg0");
+
+	fireEvent.click(argumentPicker);
+	const plumbing = await screen.findByRole("option", { name: /arg1/ });
+	expect(plumbing).toHaveTextContent("not screenable text");
+	expect(screen.getByRole("option", { name: /arg0/ })).toHaveTextContent(
+		"InputMessage",
+	);
+	fireEvent.keyDown(argumentPicker, { key: "Escape" });
+});
+
+test("exposes every failure option and reveals the block settings", async () => {
+	renderSettings();
+
+	expect(
+		await screen.findByRole("tab", { name: /Request/ }),
+	).toBeInTheDocument();
+	expect(screen.getAllByLabelText(/^Block/)).toHaveLength(2);
+	expect(screen.getAllByLabelText(/^Mask and continue/)).toHaveLength(2);
+	expect(screen.getAllByLabelText(/^Return guardrail message/)).toHaveLength(
+		2,
+	);
+	expect(
+		screen.getAllByLabelText(/^Return guardrail message/)[0],
+	).toBeChecked();
+
+	const responseEntry = screen.getByTestId(
+		"engine-guardrail-settings--pipeline-0-input-entry-0",
+	);
+	expect(
+		within(responseEntry).queryByText("Close room after block"),
+	).not.toBeInTheDocument();
+
+	fireEvent.click(within(responseEntry).getByLabelText(/^Block/));
+	expect(
+		within(responseEntry).getByText("Close room after block"),
+	).toBeInTheDocument();
+	expect(
+		within(responseEntry).getByLabelText("Custom block message"),
+	).toBeInTheDocument();
+});
+
+test("shows the parameter wiring without an extra disclosure step", async () => {
+	renderSettings();
+
+	const responseEntry = await screen.findByTestId(
+		"engine-guardrail-settings--pipeline-0-input-entry-0",
+	);
+	expect(
+		within(responseEntry).queryByText("Advanced parameter wiring"),
+	).not.toBeInTheDocument();
+	expect(within(responseEntry).getByText("Inputs")).toBeInTheDocument();
+	expect(within(responseEntry).getByText("Fixed values")).toBeInTheDocument();
+
+	const deleteMapping = within(responseEntry).getByRole("button", {
+		name: "Delete mapping 1",
+	});
+	expect(deleteMapping).toBeDisabled();
+
+	const addFixedValue = within(responseEntry).getByRole("combobox", {
+		name: "Add direct parameter",
+	});
+	fireEvent.click(addFixedValue);
+	const mappedPrompt = await screen.findByRole("option", { name: /prompt/ });
+	expect(mappedPrompt).toHaveAttribute("data-disabled");
+	expect(mappedPrompt).toHaveTextContent("Mapped");
+	fireEvent.click(await screen.findByRole("option", { name: /labels/ }));
+	expect(responseEntry).toHaveTextContent("Entity labels to detect.");
+	expect(responseEntry).toHaveTextContent("String array");
+});
+
+test("reorders checks within a phase", async () => {
+	renderSettings();
+
+	fireEvent.click(
+		await screen.findByTestId(
+			"engine-guardrail-settings--pipeline-0-input-entry-0-move-down",
+		),
+	);
+	expect(
+		screen.getByTestId(
+			"engine-guardrail-settings--pipeline-0-input-entry-0",
+		),
+	).toHaveTextContent("PII guardrail");
+});
+
+test("reports that the engine loads no pipeline file", async () => {
+	renderSettings({
+		configured: false,
+		pipelineFileName: null,
+		fileExists: false,
+		pipelines: {},
+	});
+
+	expect(
+		await screen.findByTestId("engine-guardrail-settings--not-enabled"),
+	).toHaveTextContent("Guardrails are not enabled yet");
+});
+
+test("keeps the unreadable stored file available after a parse failure", async () => {
+	renderSettings({
+		parseError: "Expected a ',' or '}'",
+		rawContent: '{"pipelines": {',
+		pipelines: {},
+	});
+
+	const alert = await screen.findByTestId(
+		"engine-guardrail-settings--parse-error",
+	);
+	expect(alert).toHaveTextContent("Expected a ',' or '}'");
+	// the empty editor is explained by the parse failure, not a missing rule set
+	expect(
+		screen.queryByTestId("engine-guardrail-settings--no-rules"),
+	).not.toBeInTheDocument();
+	fireEvent.click(
+		screen.getByTestId("engine-guardrail-settings--raw-content-toggle"),
+	);
+	expect(
+		screen.getByTestId("engine-guardrail-settings--raw-content"),
+	).toHaveTextContent('{"pipelines": {');
+});
+
+test("flags a guardrail engine that no longer exists", async () => {
+	renderSettings({
+		guardrailEngines: {
+			"guardrail-1": {
+				name: "Policy guardrail",
+				exists: false,
+				type: null,
+				subtype: null,
+				userCanView: false,
+			},
+			"guardrail-2": {
+				name: "PII guardrail",
+				exists: true,
+				type: "GUARDRAIL",
+				subtype: "detoxify",
+				userCanView: true,
+			},
+		},
+	});
+
+	expect(
+		await screen.findByTestId(
+			"engine-guardrail-settings--pipeline-0-input-entry-0-engine-missing",
+		),
+	).toHaveTextContent("This guardrail engine no longer exists");
+});
+
+test("lists every problem at once and navigates to the check that owns it", async () => {
+	renderSettings({
+		pipelines: {
+			askRoom: {
+				input: [
+					{
+						reactorClass: INPUT_REACTOR,
+						params: {
+							guardrailEngineId: "",
+							blockOnGuardrailFailure: true,
+							inputMapping: { prompt: "arg9" },
+						},
+					},
+				],
+			},
+			"*": {
+				input: [
+					{
+						reactorClass: INPUT_REACTOR,
+						params: {
+							guardrailEngineId: "",
+							blockOnGuardrailFailure: true,
+							inputMapping: { prompt: "arg0" },
+						},
+					},
+				],
+			},
+		},
+	});
+
+	const errors = await screen.findByTestId(
+		"engine-guardrail-settings--errors",
+	);
+	expect(errors).toHaveTextContent("2 problems block saving");
+	expect(
+		within(errors).getAllByText(/needs a guardrail engine/),
+	).toHaveLength(2);
+
+	const warnings = screen.getByTestId("engine-guardrail-settings--warnings");
+	expect(warnings).toHaveTextContent('"arg9" is not an argument of askRoom');
+
+	// selecting a problem opens the rule it belongs to
+	fireEvent.click(
+		within(warnings).getByRole("button", {
+			name: /"arg9" is not an argument of askRoom/,
+		}),
+	);
+	expect(
+		screen.getByTestId("engine-guardrail-settings--pipeline-0-method"),
+	).toHaveTextContent("askRoom");
+});
+
+test("accepts a response check reading result and serializes the output reactor", async () => {
+	renderSettings({
+		pipelines: {
+			askRoom: {
+				output: [
+					{
+						reactorClass:
+							"prerna.reactor.interceptor.GenericGuardrailOutputReactor",
+						params: {
+							guardrailEngineId: "guardrail-1",
+							blockOnGuardrailFailure: true,
+							inputMapping: { prompt: "result" },
+						},
+					},
+				],
+			},
+		},
+	});
+
+	expect(
+		await screen.findByRole("tab", { name: /Request/ }),
+	).toBeInTheDocument();
+	// askRoom returns a model response, so reading result needs no warning
+	expect(
+		screen.queryByTestId("engine-guardrail-settings--warnings"),
+	).not.toBeInTheDocument();
+
+	fireEvent.mouseDown(screen.getByRole("tab", { name: "JSON" }));
+	expect(
+		screen.getByTestId("engine-guardrail-settings--config-json"),
+	).toHaveTextContent("GenericGuardrailOutputReactor");
+});
+
+test("warns when the intercepted call returns no model response", async () => {
+	renderSettings({
+		pipelines: {
+			listBatches: {
+				output: [
+					{
+						reactorClass:
+							"prerna.reactor.interceptor.GenericGuardrailOutputReactor",
+						params: {
+							guardrailEngineId: "guardrail-1",
+							blockOnGuardrailFailure: true,
+							inputMapping: { prompt: "result" },
+						},
+					},
+				],
+			},
+		},
+		interceptableMethods: [
+			...INTERCEPTABLE_METHODS,
+			{
+				name: "listBatches",
+				deprecated: false,
+				returnType: "BatchListResponse",
+				returnsModelResponse: false,
+				arguments: [],
+			},
+		],
+	});
+
+	expect(
+		await screen.findByTestId("engine-guardrail-settings--warnings"),
+	).toHaveTextContent(
+		"listBatches returns BatchListResponse rather than a model response",
+	);
+});
+
+test("lets a viewer inspect the wiring without editing it", async () => {
+	CONFIG.current = buildConfig();
+	render(
+		<EngineGuardrailSettings engineId="model-1" permission="READ_ONLY" />,
+	);
+
+	const responseEntry = await screen.findByTestId(
+		"engine-guardrail-settings--pipeline-0-input-entry-0",
+	);
+	expect(within(responseEntry).getByText("Inputs")).toBeInTheDocument();
+	expect(
+		screen.queryByTestId("engine-guardrail-settings--save-btn"),
+	).not.toBeInTheDocument();
+	expect(
+		screen.queryByTestId("engine-guardrail-settings--add-pipeline-btn"),
+	).not.toBeInTheDocument();
+});

--- a/packages/client/src/components/engine/engine-guardrail-settings.tsx
+++ b/packages/client/src/components/engine/engine-guardrail-settings.tsx
@@ -1,34 +1,58 @@
-import { ChevronsUpDown, Plus } from "lucide-react";
-import { useEffect, useId, useRef, useState } from "react";
+import { AlertTriangle, Copy, Plus, Save, Trash2, Undo2 } from "lucide-react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { Role } from "@semoss/sdk";
 import { usePixel } from "@semoss/sdk/react";
 import {
+	Badge,
 	Button,
 	Card,
-	CardAction,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Field,
+	FieldLabel,
+	Form,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
 	Spinner,
+	Tabs,
+	TabsList,
+	TabsTrigger,
 	toast,
+	useForm,
+	zodResolver,
 } from "@semoss/ui/next";
 import { useRootStore } from "@/hooks";
 import {
+	collectGuardrailConfigIssues,
 	createGuardrailPipeline,
-	extractGuardrailEngineNames,
-	findMaskMultiValueConflicts,
+	extractGuardrailEngineDetails,
+	extractGuardrailFileStatus,
+	extractInterceptableMethods,
+	extractResultArgumentName,
 	type GetModelGuardrailConfigResponse,
+	GUARDRAIL_ALL_METHODS,
 	type GuardrailConfigFormValue,
+	type GuardrailConfigIssue,
+	type GuardrailPhase,
 	guardrailConfigFromResponse,
+	guardrailConfigSchema,
 	guardrailConfigToJson,
 	validateGuardrailConfig,
 } from "./engine-guardrail-settings.constants";
-import { GuardrailPipelineField } from "./guardrail-pipeline-field";
-import type { GuardrailEngineOption } from "./guardrail-reactor-entry-field";
+import { GuardrailConfigStatus } from "./guardrail-config-status";
+import { GuardrailIssueList } from "./guardrail-issue-list";
+import {
+	GuardrailPipelineField,
+	type GuardrailRevealTarget,
+} from "./guardrail-pipeline-field";
 
 export interface EngineGuardrailSettingsProps {
 	/** Id of the model engine */
@@ -41,11 +65,11 @@ export interface EngineGuardrailSettingsProps {
 	onUpdated?: () => void;
 }
 
+type GuardrailEditorMode = "form" | "json";
+
 /**
- * Settings card for a model engine's guardrails: loads the pipeline
- * configuration via GetModelGuardrailConfig, edits it with a structured
- * per-method pipeline editor, and saves through UpdateModelGuardrailConfig,
- * which validates and applies the change to the running engine immediately.
+ * Model guardrail editor. One rule is edited at a time, chosen from a selector
+ * above the editor so the full width goes to the rule's checks.
  */
 export const EngineGuardrailSettings = ({
 	engineId,
@@ -54,75 +78,208 @@ export const EngineGuardrailSettings = ({
 }: EngineGuardrailSettingsProps) => {
 	const { configStore } = useRootStore();
 	const fieldId = useId();
+	const ruleSelectId = useId();
 	const isEditable = permission === "OWNER" || permission === "EDIT";
 
 	const getConfig = usePixel<GetModelGuardrailConfigResponse>(
 		engineId ? `GetModelGuardrailConfig(engine=["${engineId}"]);` : "",
 	);
-	const guardrailEngines = usePixel<GuardrailEngineOption[]>(
-		`MyEngines(engineTypes=["GUARDRAIL"]);`,
+
+	const form = useForm<GuardrailConfigFormValue>({
+		resolver: zodResolver(guardrailConfigSchema),
+		defaultValues: { pipelines: [] },
+	});
+	const [mode, setMode] = useState<GuardrailEditorMode>("form");
+	const [selectedPipelineId, setSelectedPipelineId] = useState<string | null>(
+		null,
 	);
-
-	const [isSaving, setIsSaving] = useState(false);
-	const [form, setForm] = useState<GuardrailConfigFormValue | null>(null);
-	const [initialForm, setInitialForm] =
-		useState<GuardrailConfigFormValue | null>(null);
-
-	const isDirty = JSON.stringify(form) !== JSON.stringify(initialForm);
-
-	// Read through a ref so the resync effect below can check for unsaved work
-	// without re-running on every keystroke.
-	const isDirtyRef = useRef(isDirty);
-	isDirtyRef.current = isDirty;
+	const [revealTarget, setRevealTarget] =
+		useState<GuardrailRevealTarget | null>(null);
+	// held here so selecting another rule keeps the reader on the same side of
+	// the call instead of snapping back to the request checks
+	const [activePhase, setActivePhase] = useState<GuardrailPhase>("input");
+	const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
+	const hasChosenPhaseRef = useRef(false);
+	// names for engines picked during this session, so a check keeps showing the
+	// engine's name before the configuration is reloaded
+	const [pickedEngineNames, setPickedEngineNames] = useState<
+		Record<string, string>
+	>({});
+	const pipelines = form.watch("pipelines");
+	const isDirty = form.formState.isDirty;
+	const isSubmitting = form.formState.isSubmitting;
+	const hasUnsavedChangesRef = useRef(false);
+	hasUnsavedChangesRef.current = isDirty || isSubmitting;
 
 	useEffect(() => {
-		if (getConfig.status !== "SUCCESS") {
-			return;
-		}
-
-		// A refetch must not overwrite in-progress edits.
-		if (isDirtyRef.current) {
+		if (getConfig.status !== "SUCCESS" || hasUnsavedChangesRef.current) {
 			return;
 		}
 
 		const nextForm = guardrailConfigFromResponse(getConfig.data);
-		setForm(nextForm);
-		setInitialForm(nextForm);
-	}, [getConfig.status, getConfig.data]);
+		form.reset(nextForm);
+		setSelectedPipelineId((current) =>
+			nextForm.pipelines.some((pipeline) => pipeline.id === current)
+				? current
+				: nextForm.pipelines[0]?.id || null,
+		);
 
-	const engineOptions = guardrailEngines.data ?? [];
-	const enginesLoading = guardrailEngines.status === "LOADING";
-	const engineNameFallbacks = extractGuardrailEngineNames(getConfig.data);
-	const parseError = getConfig.data?.parseError ?? null;
-	const maskConflicts = form ? findMaskMultiValueConflicts(form) : [];
+		// Open on the phase the first rule actually screens. Only on the first
+		// load, so a refetch after saving does not move the tab the reader
+		// chose, and so switching rules leaves it alone.
+		if (!hasChosenPhaseRef.current) {
+			hasChosenPhaseRef.current = true;
+			const first = nextForm.pipelines[0];
+			if (first && first.input.length === 0 && first.output.length > 0) {
+				setActivePhase("output");
+			}
+		}
+	}, [getConfig.status, getConfig.data, form]);
 
-	// pretty-printed pipeline.json for the read-only viewer; tracks the form
-	// so it matches the stored file when pristine and the pending save when
-	// dirty
-	const configJsonPreview = form
-		? JSON.stringify(JSON.parse(guardrailConfigToJson(form)), null, 2)
-		: "";
+	// unsaved rules are held only in this form, so leaving the page drops them
+	useEffect(() => {
+		if (!isDirty) {
+			return;
+		}
+		const warnBeforeUnload = (event: BeforeUnloadEvent) => {
+			event.preventDefault();
+		};
+		window.addEventListener("beforeunload", warnBeforeUnload);
+		return () =>
+			window.removeEventListener("beforeunload", warnBeforeUnload);
+	}, [isDirty]);
 
-	const updateForm = (next: GuardrailConfigFormValue) => setForm(next);
+	const selectedPipeline =
+		pipelines.find((pipeline) => pipeline.id === selectedPipelineId) ||
+		pipelines[0] ||
+		null;
+	const selectedIndex = selectedPipeline
+		? pipelines.findIndex((pipeline) => pipeline.id === selectedPipeline.id)
+		: -1;
+	const engineDetails = extractGuardrailEngineDetails(getConfig.data);
+	const interceptableMethods = extractInterceptableMethods(getConfig.data);
+	const resultArgumentName = extractResultArgumentName(getConfig.data);
+	const fileStatus = extractGuardrailFileStatus(getConfig.data);
+	const issues = collectGuardrailConfigIssues(
+		{ pipelines },
+		{ methods: interceptableMethods, resultArgumentName },
+	);
+	const errorPipelineIds = new Set(
+		issues
+			.filter((issue) => issue.severity === "error" && issue.pipelineId)
+			.map((issue) => issue.pipelineId as string),
+	);
+	const savedPipelines = form.formState.defaultValues?.pipelines ?? [];
+	const dirtyPipelineIds = new Set(
+		pipelines
+			.filter((pipeline) => {
+				const saved = savedPipelines.find(
+					(candidate) => candidate.id === pipeline.id,
+				);
+				return (
+					!saved || JSON.stringify(saved) !== JSON.stringify(pipeline)
+				);
+			})
+			.map((pipeline) => pipeline.id),
+	);
+	const totalChecks = pipelines.reduce(
+		(total, pipeline) =>
+			total + pipeline.input.length + pipeline.output.length,
+		0,
+	);
+	const configJson = useMemo(
+		() =>
+			mode === "json"
+				? JSON.stringify(
+						JSON.parse(guardrailConfigToJson({ pipelines })),
+						null,
+						2,
+					)
+				: "",
+		[mode, pipelines],
+	);
 
-	const handleDiscard = () => {
-		setForm(initialForm);
+	const updatePipelines = (next: GuardrailConfigFormValue["pipelines"]) => {
+		form.setValue("pipelines", next, {
+			shouldDirty: true,
+			shouldTouch: true,
+		});
 	};
 
-	const handleSave = async () => {
-		if (!form) {
-			return;
-		}
-		const validation = validateGuardrailConfig(form);
-		if (validation !== true) {
-			toast.error(validation);
-			return;
-		}
+	const addPipeline = () => {
+		// start the rule on a call no other rule covers, so it does not open
+		// already reporting a duplicate
+		const claimed = new Set(
+			pipelines.map((pipeline) => pipeline.method.trim()),
+		);
+		const method = !claimed.has(GUARDRAIL_ALL_METHODS)
+			? GUARDRAIL_ALL_METHODS
+			: (interceptableMethods.find(
+					(candidate) => !claimed.has(candidate.name),
+				)?.name ?? "");
+		const pipeline = createGuardrailPipeline(method);
+		updatePipelines([...pipelines, pipeline]);
+		setSelectedPipelineId(pipeline.id);
+		setMode("form");
+	};
 
-		setIsSaving(true);
+	const removePipeline = (pipelineId: string) => {
+		const index = pipelines.findIndex(
+			(pipeline) => pipeline.id === pipelineId,
+		);
+		const next = pipelines.filter((pipeline) => pipeline.id !== pipelineId);
+		updatePipelines(next);
+		if (selectedPipelineId === pipelineId) {
+			setSelectedPipelineId(
+				next[Math.min(Math.max(index, 0), next.length - 1)]?.id || null,
+			);
+		}
+	};
+
+	const pipelineToRemove = pipelines.find(
+		(pipeline) => pipeline.id === confirmRemoveId,
+	);
+	const removalCheckCount = pipelineToRemove
+		? pipelineToRemove.input.length + pipelineToRemove.output.length
+		: 0;
+	const removalMethod = pipelineToRemove?.method.trim();
+	const removalSummary =
+		removalCheckCount === 0
+			? "The rule has no checks and will be removed from the configuration."
+			: `Its ${removalCheckCount} ${removalCheckCount === 1 ? "check stops" : "checks stop"} screening ${removalMethod === GUARDRAIL_ALL_METHODS ? "every call" : removalMethod || "this call"}. The change applies once the configuration is saved.`;
+
+	const revealIssue = (issue: GuardrailConfigIssue) => {
+		if (!issue.pipelineId) {
+			return;
+		}
+		setMode("form");
+		setSelectedPipelineId(issue.pipelineId);
+		setRevealTarget(issue.entryId ? { entryId: issue.entryId } : null);
+	};
+
+	const handleDiscard = () => {
+		const defaults = form.formState.defaultValues?.pipelines ?? [];
+		form.reset();
+		setSelectedPipelineId((current) =>
+			defaults.some((pipeline) => pipeline.id === current)
+				? current
+				: defaults[0]?.id || null,
+		);
+	};
+
+	const copyConfigJson = async () => {
+		try {
+			await navigator.clipboard.writeText(configJson);
+			toast.success("Copied the guardrail configuration");
+		} catch {
+			toast.error("Unable to copy the guardrail configuration");
+		}
+	};
+
+	const handleSubmit = async (values: GuardrailConfigFormValue) => {
 		try {
 			const response = await configStore.runPixel(
-				`UpdateModelGuardrailConfig(engine=["${engineId}"], map=[${guardrailConfigToJson(form)}]);`,
+				`UpdateModelGuardrailConfig(engine=["${engineId}"], map=[${guardrailConfigToJson(values)}]);`,
 			);
 			const result = response.pixelReturn?.[0];
 			if (
@@ -138,7 +295,7 @@ export const EngineGuardrailSettings = ({
 				);
 			}
 
-			setInitialForm(form);
+			form.reset(values);
 			toast.success("Guardrail configuration updated");
 			getConfig.refresh();
 			onUpdated?.();
@@ -148,26 +305,16 @@ export const EngineGuardrailSettings = ({
 					? error.message
 					: "Unable to update the guardrail configuration.",
 			);
-		} finally {
-			setIsSaving(false);
 		}
 	};
 
-	const addPipeline = () => {
-		if (!form) {
-			return;
-		}
-		// default new pipelines to the next method not already taken; the
-		// first one covers every method
-		const method = form.pipelines.some(
-			(pipeline) => pipeline.method.trim() === "*",
-		)
-			? ""
-			: "*";
-		updateForm({
-			...form,
-			pipelines: [...form.pipelines, createGuardrailPipeline(method)],
-		});
+	const handleInvalid = () => {
+		const validation = validateGuardrailConfig(form.getValues());
+		toast.error(
+			validation === true
+				? "Review the guardrail configuration before saving."
+				: validation,
+		);
 	};
 
 	if (getConfig.status === "ERROR") {
@@ -179,7 +326,7 @@ export const EngineGuardrailSettings = ({
 		);
 	}
 
-	if (getConfig.status !== "SUCCESS" || form === null) {
+	if (getConfig.status !== "SUCCESS") {
 		return (
 			<div className="flex min-h-64 items-center justify-center">
 				<Spinner />
@@ -188,170 +335,333 @@ export const EngineGuardrailSettings = ({
 	}
 
 	return (
-		<Card>
-			<CardHeader className="border-b">
-				<CardTitle>Guardrails</CardTitle>
-				<CardDescription>
-					Guardrail engines that screen this model's requests and
-					responses. Changes apply to the running engine immediately.
-				</CardDescription>
-				{isEditable && isDirty && (
-					<CardAction className="flex gap-2 self-center">
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={handleDiscard}
-							disabled={isSaving}
-							data-testid="engine-guardrail-settings--cancel-btn"
-						>
-							Discard
-						</Button>
-						<Button
-							size="sm"
-							onClick={handleSave}
-							disabled={isSaving}
-							data-testid="engine-guardrail-settings--save-btn"
-						>
-							{isSaving ? <Spinner className="size-4" /> : "Save"}
-						</Button>
-					</CardAction>
-				)}
-			</CardHeader>
-			<CardContent className="space-y-4">
-				{parseError && (
-					<div
-						className="rounded-md border border-destructive p-3 text-sm"
-						data-testid="engine-guardrail-settings--parse-error"
-					>
-						<p className="font-medium text-destructive">
-							The stored guardrail configuration could not be
-							parsed: {parseError}
-						</p>
-						<p className="mt-1 text-muted-foreground text-xs">
-							Saving will replace the stored file with the
-							configuration built here.
-						</p>
-					</div>
-				)}
+		<div className="space-y-4">
+			<GuardrailConfigStatus
+				status={fileStatus}
+				ruleCount={pipelines.length}
+				isEditable={isEditable}
+			/>
 
-				{maskConflicts.length > 0 && (
-					<p
-						className="text-destructive text-sm"
-						data-testid="engine-guardrail-settings--mask-conflict-warning"
-					>
-						A guardrail masks a parameter that is not mapped to
-						exactly one argument - the runtime would block instead
-						of masking. Fix the parameter mapping before saving.
-					</p>
-				)}
+			<GuardrailIssueList issues={issues} onSelect={revealIssue} />
 
-				{form.pipelines.length === 0 ? (
-					<div
-						className="flex flex-col items-center gap-3 rounded-md border border-dashed p-8 text-center"
-						data-testid="engine-guardrail-settings--empty-state"
-					>
-						<p className="font-medium text-sm">
-							No guardrails are attached to this model yet.
-						</p>
-						<p className="text-muted-foreground text-xs">
-							Attach guardrail engines to screen requests and
-							responses for this model.
-						</p>
-						{isEditable && (
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onClick={addPipeline}
-								data-testid="engine-guardrail-settings--add-pipeline-btn"
-							>
-								<Plus className="h-4 w-4" />
-								Add Pipeline
-							</Button>
-						)}
-					</div>
-				) : (
-					<>
-						{form.pipelines.map((pipeline, index) => (
-							<GuardrailPipelineField
-								key={pipeline.id}
-								value={pipeline}
-								onChange={(next) =>
-									updateForm({
-										...form,
-										pipelines: form.pipelines.map(
-											(other) =>
-												other.id === pipeline.id
-													? next
-													: other,
-										),
-									})
+			<Card className="gap-0 py-0">
+				<Form
+					form={form}
+					onSubmit={handleSubmit}
+					onError={handleInvalid}
+					className="flex flex-col"
+				>
+					<div className="flex flex-col gap-3 border-b p-4 sm:flex-row sm:items-center sm:justify-between">
+						<div className="min-w-0 space-y-1">
+							<div className="flex flex-wrap items-center gap-2">
+								<h2 className="font-semibold text-base">
+									Guardrails
+								</h2>
+								<Badge variant="outline">
+									{pipelines.length}{" "}
+									{pipelines.length === 1 ? "rule" : "rules"}
+								</Badge>
+								<Badge variant="outline">
+									{totalChecks}{" "}
+									{totalChecks === 1 ? "check" : "checks"}
+								</Badge>
+								{isDirty && (
+									<Badge variant="secondary">
+										Unsaved changes
+									</Badge>
+								)}
+							</div>
+							<p className="text-muted-foreground text-sm">
+								Screen model requests and responses. Saved
+								changes apply to the running engine immediately.
+							</p>
+						</div>
+
+						<div className="flex flex-wrap items-center gap-2">
+							<Tabs
+								value={mode}
+								onValueChange={(value) =>
+									setMode(value as GuardrailEditorMode)
 								}
-								onRemove={() =>
-									updateForm({
-										...form,
-										pipelines: form.pipelines.filter(
-											(other) => other.id !== pipeline.id,
-										),
-									})
-								}
-								engineOptions={engineOptions}
-								enginesLoading={enginesLoading}
-								engineNameFallbacks={engineNameFallbacks}
-								disabled={!isEditable || isSaving}
-								idPrefix={`${fieldId}-pipeline-${index}`}
-								testIdPrefix={`engine-guardrail-settings--pipeline-${index}`}
-							/>
-						))}
-						{isEditable && (
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								className="w-fit"
-								onClick={addPipeline}
-								disabled={isSaving}
-								data-testid="engine-guardrail-settings--add-pipeline-btn"
 							>
-								<Plus className="h-4 w-4" />
-								Add Pipeline
-							</Button>
-						)}
-					</>
-				)}
+								<TabsList>
+									<TabsTrigger value="form">Form</TabsTrigger>
+									<TabsTrigger value="json">JSON</TabsTrigger>
+								</TabsList>
+							</Tabs>
+							{isEditable && (
+								<>
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onClick={handleDiscard}
+										disabled={!isDirty || isSubmitting}
+										data-testid="engine-guardrail-settings--cancel-btn"
+									>
+										<Undo2 className="size-4" aria-hidden />
+										Discard
+									</Button>
+									<Button
+										type="submit"
+										size="sm"
+										disabled={!isDirty || isSubmitting}
+										data-testid="engine-guardrail-settings--save-btn"
+									>
+										{isSubmitting ? (
+											<Spinner className="size-4" />
+										) : (
+											<Save
+												className="size-4"
+												aria-hidden
+											/>
+										)}
+										Save
+									</Button>
+								</>
+							)}
+						</div>
+					</div>
 
-				<Collapsible>
-					<CollapsibleTrigger asChild>
+					{mode === "json" ? (
+						<div className="space-y-2 p-4">
+							<div className="flex flex-wrap items-center justify-between gap-2">
+								<p className="text-muted-foreground text-xs">
+									{isDirty
+										? "Read-only preview of the pipeline.json that will be saved, including unsaved changes."
+										: "Read-only preview of the pipeline.json that will be saved."}
+								</p>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={copyConfigJson}
+									data-testid="engine-guardrail-settings--copy-json"
+								>
+									<Copy className="size-4" aria-hidden />
+									Copy
+								</Button>
+							</div>
+							<pre
+								className="max-h-[60vh] select-text overflow-auto rounded-md bg-muted p-4 font-mono text-xs"
+								data-testid="engine-guardrail-settings--config-json"
+							>
+								{configJson}
+							</pre>
+						</div>
+					) : (
+						<div className="space-y-4 p-4">
+							<div className="flex flex-wrap items-end gap-2">
+								<Field className="min-w-56 flex-1">
+									<FieldLabel htmlFor={ruleSelectId}>
+										Rule
+									</FieldLabel>
+									<Select
+										value={selectedPipeline?.id ?? ""}
+										onValueChange={(id) => {
+											// Radix mirrors this select into a hidden native
+											// select for the surrounding form, which reports an
+											// empty value while the option list is unmounted. No
+											// rule has an empty id, so that is never a choice.
+											if (!id) {
+												return;
+											}
+											setSelectedPipelineId(id);
+											setRevealTarget(null);
+										}}
+										disabled={pipelines.length === 0}
+									>
+										<SelectTrigger
+											id={ruleSelectId}
+											className="w-full"
+											data-testid="engine-guardrail-settings--rule-select"
+										>
+											<SelectValue placeholder="No rules configured" />
+										</SelectTrigger>
+										<SelectContent>
+											{pipelines.map((pipeline) => {
+												const method =
+													pipeline.method.trim();
+												return (
+													<SelectItem
+														key={pipeline.id}
+														value={pipeline.id}
+													>
+														<span className="flex w-full min-w-0 items-center gap-2">
+															{errorPipelineIds.has(
+																pipeline.id,
+															) && (
+																<AlertTriangle className="size-3.5 shrink-0 text-destructive" />
+															)}
+															<span className="truncate font-mono">
+																{method ||
+																	"no call selected"}
+															</span>
+															<span className="ms-auto shrink-0 text-muted-foreground text-xs">
+																{
+																	pipeline
+																		.input
+																		.length
+																}{" "}
+																request,{" "}
+																{
+																	pipeline
+																		.output
+																		.length
+																}{" "}
+																response
+																{dirtyPipelineIds.has(
+																	pipeline.id,
+																)
+																	? " - edited"
+																	: ""}
+															</span>
+														</span>
+													</SelectItem>
+												);
+											})}
+										</SelectContent>
+									</Select>
+								</Field>
+								{isEditable && (
+									<>
+										<Button
+											type="button"
+											variant="outline"
+											size="sm"
+											onClick={addPipeline}
+											data-testid="engine-guardrail-settings--add-pipeline-btn"
+										>
+											<Plus
+												className="size-4"
+												aria-hidden
+											/>
+											Add Rule
+										</Button>
+										{selectedPipeline && (
+											<Button
+												type="button"
+												variant="outline"
+												size="sm"
+												onClick={() =>
+													setConfirmRemoveId(
+														selectedPipeline.id,
+													)
+												}
+												disabled={isSubmitting}
+												data-testid="engine-guardrail-settings--remove-pipeline-btn"
+											>
+												<Trash2
+													className="size-4"
+													aria-hidden
+												/>
+												Remove Rule
+											</Button>
+										)}
+									</>
+								)}
+							</div>
+
+							{selectedPipeline && selectedIndex >= 0 ? (
+								<GuardrailPipelineField
+									key={selectedPipeline.id}
+									value={selectedPipeline}
+									activePhase={activePhase}
+									onPhaseChange={setActivePhase}
+									engineDetails={engineDetails}
+									engineNames={pickedEngineNames}
+									onEngineResolved={(id, name) =>
+										setPickedEngineNames((current) =>
+											current[id] === name
+												? current
+												: { ...current, [id]: name },
+										)
+									}
+									methods={interceptableMethods}
+									takenMethods={pipelines
+										.filter(
+											(pipeline) =>
+												pipeline.id !==
+												selectedPipeline.id,
+										)
+										.map((pipeline) => pipeline.method)}
+									resultArgumentName={resultArgumentName}
+									issues={issues.filter(
+										(issue) =>
+											issue.pipelineId ===
+											selectedPipeline.id,
+									)}
+									revealTarget={revealTarget}
+									disabled={!isEditable || isSubmitting}
+									idPrefix={`${fieldId}-pipeline-${selectedIndex}`}
+									testIdPrefix={`engine-guardrail-settings--pipeline-${selectedIndex}`}
+									namePrefix={`pipelines.${selectedIndex}`}
+								/>
+							) : (
+								<div
+									className="flex min-h-48 flex-col items-center justify-center gap-3 rounded-md border border-dashed p-6 text-center"
+									data-testid="engine-guardrail-settings--empty-state"
+								>
+									<p className="font-medium text-sm">
+										No guardrail rules yet
+									</p>
+									<p className="text-muted-foreground text-xs">
+										Add a rule to screen requests,
+										responses, or both.
+									</p>
+									{isEditable && (
+										<Button
+											type="button"
+											variant="outline"
+											size="sm"
+											onClick={addPipeline}
+										>
+											<Plus
+												className="size-4"
+												aria-hidden
+											/>
+											Add Rule
+										</Button>
+									)}
+								</div>
+							)}
+						</div>
+					)}
+				</Form>
+			</Card>
+
+			<Dialog
+				open={!!confirmRemoveId}
+				onOpenChange={(open) => !open && setConfirmRemoveId(null)}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Remove this rule?</DialogTitle>
+						<DialogDescription>{removalSummary}</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<DialogClose asChild>
+							<Button type="button" variant="outline">
+								Cancel
+							</Button>
+						</DialogClose>
 						<Button
 							type="button"
-							variant="ghost"
-							size="sm"
-							className="w-fit px-2"
-							data-testid="engine-guardrail-settings--view-json-btn"
+							variant="destructive"
+							onClick={() => {
+								if (confirmRemoveId) {
+									removePipeline(confirmRemoveId);
+								}
+								setConfirmRemoveId(null);
+							}}
+							data-testid="engine-guardrail-settings--remove-pipeline-confirm"
 						>
-							<ChevronsUpDown className="h-4 w-4" />
-							View configuration JSON
+							<Trash2 className="size-4" aria-hidden />
+							Remove Rule
 						</Button>
-					</CollapsibleTrigger>
-					<CollapsibleContent className="space-y-1 pt-2">
-						{isDirty && (
-							<p className="text-muted-foreground text-xs">
-								This preview includes unsaved changes.
-							</p>
-						)}
-						<pre
-							className="max-h-96 select-text overflow-auto rounded-md bg-muted p-3 font-mono text-xs"
-							data-testid="engine-guardrail-settings--config-json"
-						>
-							{configJsonPreview}
-						</pre>
-						<p className="text-muted-foreground text-xs">
-							The pipeline.json stored with the engine. Read-only
-							- edit through the form above.
-						</p>
-					</CollapsibleContent>
-				</Collapsible>
-			</CardContent>
-		</Card>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
 	);
 };

--- a/packages/client/src/components/engine/guardrail-argument-field.tsx
+++ b/packages/client/src/components/engine/guardrail-argument-field.tsx
@@ -1,0 +1,173 @@
+import { useId, useState } from "react";
+import {
+	Field,
+	FieldDescription,
+	FieldError,
+	FieldLabel,
+	FormField,
+	FormInput,
+	Input,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	useFormContext,
+} from "@semoss/ui/next";
+import type { InterceptableMethodArgument } from "./engine-guardrail-settings.constants";
+
+export interface GuardrailArgumentFieldProps {
+	/** React Hook Form path for this mapping row's argument list. */
+	name: string;
+
+	/** Arguments the rule's method exposes in this phase. Empty falls back to
+	 * free text, since the argument names cannot be known for a wildcard rule. */
+	options: InterceptableMethodArgument[];
+
+	/** Whether the field accepts edits. */
+	disabled?: boolean;
+
+	/** Prefix for this field's test ids. */
+	testIdPrefix: string;
+}
+
+/** Sentinel for the option that reveals the free-text argument input. */
+const CUSTOM_ARGUMENT_OPTION = "__custom-argument__";
+
+const FREE_TEXT_DESCRIPTION =
+	"Use the argument name the runtime resolves, such as arg0, or result for the model's return value. A dot path such as arg0.message reads inside a map argument, and several comma separated names are joined before the guardrail runs.";
+
+const PICKER_DESCRIPTION =
+	"Several comma separated names are joined before the guardrail runs, and a dot path such as arg0.message reads inside a map argument.";
+
+/**
+ * Selects which intercepted argument feeds one guardrail parameter. Offering
+ * the engine's own argument names keeps the mapping resolvable, since a name
+ * the runtime cannot find leaves the guardrail with nothing to screen.
+ */
+export const GuardrailArgumentField = ({
+	name,
+	options,
+	disabled,
+	testIdPrefix,
+}: GuardrailArgumentFieldProps) => {
+	// untyped so the caller can pass an arbitrary mapping row path
+	const { control } = useFormContext();
+	const selectId = useId();
+	const customId = useId();
+	const [showCustom, setShowCustom] = useState(false);
+
+	if (options.length === 0) {
+		return (
+			<FormInput
+				name={name}
+				label="Reads from"
+				placeholder="Argument name, such as arg0"
+				description={FREE_TEXT_DESCRIPTION}
+				disabled={disabled}
+				data-testid={`${testIdPrefix}-args`}
+			/>
+		);
+	}
+
+	return (
+		<FormField
+			control={control}
+			name={name}
+			render={({ field, fieldState }) => {
+				const current = String(field.value ?? "");
+				const trimmed = current.trim();
+				const matched = options.find(
+					(option) => option.name === trimmed,
+				);
+				const isCustom = showCustom || (!!trimmed && !matched);
+
+				return (
+					<Field data-invalid={!!fieldState.error}>
+						<FieldLabel htmlFor={selectId}>Reads from</FieldLabel>
+						<Select
+							value={isCustom ? CUSTOM_ARGUMENT_OPTION : trimmed}
+							onValueChange={(next) => {
+								// the hidden native select Radix adds for the
+								// surrounding form reports an empty value while
+								// the option list is unmounted, and no option
+								// here is empty
+								if (!next) {
+									return;
+								}
+								if (next === CUSTOM_ARGUMENT_OPTION) {
+									setShowCustom(true);
+									return;
+								}
+								setShowCustom(false);
+								field.onChange(next);
+							}}
+							disabled={disabled}
+						>
+							<SelectTrigger
+								id={selectId}
+								className="w-full"
+								aria-invalid={!!fieldState.error}
+								data-testid={`${testIdPrefix}-args`}
+							>
+								<SelectValue placeholder="Select the argument to read" />
+							</SelectTrigger>
+							<SelectContent>
+								{options.map((option) => (
+									<SelectItem
+										key={option.name}
+										value={option.name}
+									>
+										<span className="flex w-full min-w-0 items-center justify-between gap-4">
+											<span className="truncate font-mono">
+												{option.name}
+											</span>
+											<span className="shrink-0 text-muted-foreground text-xs">
+												{option.type}
+												{option.guardable
+													? ""
+													: " - not screenable text"}
+											</span>
+										</span>
+									</SelectItem>
+								))}
+								<SelectItem value={CUSTOM_ARGUMENT_OPTION}>
+									Another argument or a dot path...
+								</SelectItem>
+							</SelectContent>
+						</Select>
+
+						{isCustom && (
+							<>
+								<FieldLabel htmlFor={customId}>
+									Argument name
+								</FieldLabel>
+								<Input
+									id={customId}
+									value={current}
+									onChange={(event) =>
+										field.onChange(event.target.value)
+									}
+									onBlur={field.onBlur}
+									placeholder="Argument name(s), such as arg0 or arg0.message"
+									disabled={disabled}
+									aria-invalid={!!fieldState.error}
+									data-testid={`${testIdPrefix}-args-custom`}
+								/>
+							</>
+						)}
+
+						<FieldDescription>
+							{isCustom
+								? FREE_TEXT_DESCRIPTION
+								: PICKER_DESCRIPTION}
+						</FieldDescription>
+						{fieldState.error?.message && (
+							<FieldError>{fieldState.error.message}</FieldError>
+						)}
+					</Field>
+				);
+			}}
+		/>
+	);
+};

--- a/packages/client/src/components/engine/guardrail-config-status.tsx
+++ b/packages/client/src/components/engine/guardrail-config-status.tsx
@@ -1,0 +1,179 @@
+import { AlertTriangle, ChevronsUpDown, Copy, ShieldOff } from "lucide-react";
+import {
+	Button,
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+	cn,
+	toast,
+} from "@semoss/ui/next";
+import type { GuardrailFileStatus } from "./engine-guardrail-settings.constants";
+
+export interface GuardrailConfigStatusProps {
+	/** State of the stored pipeline file, as reported by the backend. */
+	status: GuardrailFileStatus;
+
+	/** Number of rules currently held in the editor. */
+	ruleCount: number;
+
+	/** Whether the current user can save the configuration. */
+	isEditable: boolean;
+}
+
+interface GuardrailNoticeProps extends React.PropsWithChildren {
+	icon: React.ComponentType<{ className?: string }>;
+	destructive?: boolean;
+	testId: string;
+}
+
+/** One compact status line. Built from plain layout so the notice stays a
+ * single row of text next to its icon. */
+const GuardrailNotice = ({
+	icon: Icon,
+	destructive,
+	testId,
+	children,
+}: GuardrailNoticeProps) => (
+	<div
+		className={cn(
+			"flex items-start gap-2 rounded-md border px-3 py-2 text-sm",
+			destructive
+				? "border-destructive/40 bg-destructive/5 text-destructive"
+				: "border-border bg-muted/40 text-foreground",
+		)}
+		data-testid={testId}
+	>
+		<Icon className="mt-0.5 size-4 shrink-0" aria-hidden />
+		<div className="min-w-0 flex-1">{children}</div>
+	</div>
+);
+
+const copyToClipboard = async (content: string) => {
+	try {
+		await navigator.clipboard.writeText(content);
+		toast.success("Copied the stored configuration");
+	} catch {
+		toast.error("Unable to copy the stored configuration");
+	}
+};
+
+/**
+ * Reports whether the engine actually loads a guardrail file. A rule set that
+ * looks complete in the editor still screens nothing while the engine has no
+ * pipeline file, so that state is called out rather than left to be inferred.
+ */
+export const GuardrailConfigStatus = ({
+	status,
+	ruleCount,
+	isEditable,
+}: GuardrailConfigStatusProps) => {
+	const savingHint = isEditable
+		? "Saving writes the file and points the engine at it."
+		: "An engine editor has to save the configuration to enable it.";
+
+	return (
+		<div className="space-y-2">
+			{status.state === "not-enabled" && (
+				<GuardrailNotice
+					icon={ShieldOff}
+					testId="engine-guardrail-settings--not-enabled"
+				>
+					<span className="font-medium">
+						Guardrails are not enabled yet.
+					</span>{" "}
+					This engine has no pipeline file, so every request and
+					response reaches the model unchecked. {savingHint}
+				</GuardrailNotice>
+			)}
+
+			{status.state === "file-missing" && (
+				<GuardrailNotice
+					icon={AlertTriangle}
+					testId="engine-guardrail-settings--file-missing"
+				>
+					<span className="font-medium">
+						The configured pipeline file does not exist.
+					</span>{" "}
+					The engine points at{" "}
+					<span className="font-mono">{status.pipelineFileName}</span>
+					, which has not been created, so nothing is screened yet.{" "}
+					{savingHint}
+				</GuardrailNotice>
+			)}
+
+			{status.state === "loaded" &&
+				ruleCount === 0 &&
+				!status.parseError && (
+					<GuardrailNotice
+						icon={ShieldOff}
+						testId="engine-guardrail-settings--no-rules"
+					>
+						<span className="font-medium">
+							No rules are configured.
+						</span>{" "}
+						Guardrails are enabled for this engine but no rule is
+						defined, so every call passes unchecked.
+					</GuardrailNotice>
+				)}
+
+			{status.parseError && (
+				<GuardrailNotice
+					icon={AlertTriangle}
+					destructive
+					testId="engine-guardrail-settings--parse-error"
+				>
+					<p>
+						<span className="font-medium">
+							The stored configuration could not be read:
+						</span>{" "}
+						{status.parseError}
+					</p>
+					<p className="mt-1">
+						The editor starts empty because of this. Saving replaces
+						the stored file with whatever is configured here, so
+						copy anything worth keeping first.
+					</p>
+					{status.rawContent !== null && (
+						<Collapsible className="mt-2">
+							<div className="flex flex-wrap items-center gap-2">
+								<CollapsibleTrigger asChild>
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										data-testid="engine-guardrail-settings--raw-content-toggle"
+									>
+										<ChevronsUpDown
+											className="size-4"
+											aria-hidden
+										/>
+										View the stored file
+									</Button>
+								</CollapsibleTrigger>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() =>
+										copyToClipboard(status.rawContent ?? "")
+									}
+								>
+									<Copy className="size-4" aria-hidden />
+									Copy
+								</Button>
+							</div>
+							<CollapsibleContent>
+								<pre
+									className="mt-2 max-h-64 select-text overflow-auto rounded-md bg-muted p-3 font-mono text-foreground text-xs"
+									data-testid="engine-guardrail-settings--raw-content"
+								>
+									{status.rawContent}
+								</pre>
+							</CollapsibleContent>
+						</Collapsible>
+					)}
+				</GuardrailNotice>
+			)}
+		</div>
+	);
+};

--- a/packages/client/src/components/engine/guardrail-direct-parameters-field.test.ts
+++ b/packages/client/src/components/engine/guardrail-direct-parameters-field.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest";
+import { guardrailParameterTypeForForm } from "./guardrail-engine-parameters";
+
+describe("guardrail direct parameter types", () => {
+	test.each([
+		["String", "string"],
+		["Double", "number"],
+		["Integer", "number"],
+		["Boolean", "boolean"],
+		["List<String>", "string-array"],
+		["List<Double>", "number-array"],
+		["Boolean[]", "boolean-array"],
+		["List<Object>", "json"],
+		["List<Map<String, Object>>", "json"],
+		["Map<String, Object>", "json"],
+	])("maps %s to %s", (engineType, formType) => {
+		expect(guardrailParameterTypeForForm(engineType)).toBe(formType);
+	});
+});

--- a/packages/client/src/components/engine/guardrail-direct-parameters-field.tsx
+++ b/packages/client/src/components/engine/guardrail-direct-parameters-field.tsx
@@ -1,9 +1,14 @@
-import { Plus, X } from "lucide-react";
+import { Plus, Trash2 } from "lucide-react";
+import { useId } from "react";
 import {
+	Badge,
 	Button,
+	Field,
 	FieldDescription,
 	FieldLabel,
-	Input,
+	FormField,
+	FormInput,
+	FormTextarea,
 	Select,
 	SelectContent,
 	SelectItem,
@@ -15,137 +20,351 @@ import {
 	createGuardrailDirectParam,
 	type GuardrailDirectParamFormValue,
 } from "./engine-guardrail-settings.constants";
+import {
+	type GuardrailParameterOption,
+	type GuardrailParametersStatus,
+	guardrailParameterTypeForForm,
+} from "./guardrail-engine-parameters";
+
+const DIRECT_PARAMETER_TYPE_LABELS: Record<
+	GuardrailDirectParamFormValue["type"],
+	string
+> = {
+	string: "String",
+	number: "Number",
+	boolean: "Boolean",
+	"string-array": "String array",
+	"number-array": "Number array",
+	"boolean-array": "Boolean array",
+	json: "JSON",
+};
+
+const defaultValueForType = (
+	type: GuardrailDirectParamFormValue["type"],
+): string => {
+	if (type === "boolean") {
+		return "false";
+	}
+	if (type.endsWith("-array")) {
+		return "[]";
+	}
+	if (type === "json") {
+		return "{}";
+	}
+	return "";
+};
+
+const structuredValueHelp = (
+	type: GuardrailDirectParamFormValue["type"],
+): { placeholder: string; description: string } => {
+	if (type === "string-array") {
+		return {
+			placeholder: '["person", "email address"]',
+			description: "Enter a JSON array containing only strings.",
+		};
+	}
+	if (type === "number-array") {
+		return {
+			placeholder: "[0.5, 0.8]",
+			description: "Enter a JSON array containing only numbers.",
+		};
+	}
+	if (type === "boolean-array") {
+		return {
+			placeholder: "[true, false]",
+			description: "Enter a JSON array containing only booleans.",
+		};
+	}
+	return {
+		placeholder: '{"key": "value"}',
+		description: "Enter any valid JSON value, array, or object.",
+	};
+};
 
 export interface GuardrailDirectParametersFieldProps {
+	/** Fixed values currently held for this check. */
 	value: GuardrailDirectParamFormValue[];
+
+	/** Replaces the fixed values. */
 	onChange: (next: GuardrailDirectParamFormValue[]) => void;
+
+	/** Parameters the selected guardrail engine declares. */
+	parameterOptions: GuardrailParameterOption[];
+
+	/** Load state of the guardrail engine's parameters. */
+	parametersStatus: GuardrailParametersStatus;
+
+	/** Parameter names already supplied by the check's inputs. */
+	mappedParameterNames: string[];
+
+	/** Whether the fields accept edits. */
 	disabled?: boolean;
+
+	/** Prefix for this field's element ids. */
 	idPrefix: string;
+
+	/** React Hook Form path for this fixed value array. */
+	namePrefix: string;
 }
 
 /**
- * Editor for a guardrail entry's directParameters: literal values (e.g. a
- * threshold) passed straight to the guardrail engine on every call.
+ * Editor for a check's directParameters: literal values such as a threshold
+ * that are passed to the guardrail engine on every call.
  */
 export const GuardrailDirectParametersField = ({
 	value,
 	onChange,
+	parameterOptions,
+	parametersStatus,
+	mappedParameterNames,
 	disabled,
 	idPrefix,
+	namePrefix,
 }: GuardrailDirectParametersFieldProps) => {
-	const updateRow = (
-		rowId: string,
-		partial: Partial<GuardrailDirectParamFormValue>,
-	) =>
-		onChange(
-			value.map((row) =>
-				row.id === rowId ? { ...row, ...partial } : row,
-			),
+	const addParameterId = useId();
+	const mappedParameters = new Set(
+		mappedParameterNames.map((name) => name.trim()),
+	);
+	const directParameters = new Set(value.map((row) => row.key.trim()));
+	const availableParameters = parameterOptions.filter(
+		(parameter) =>
+			!mappedParameters.has(parameter.name) &&
+			!directParameters.has(parameter.name),
+	);
+	const addPlaceholder =
+		parametersStatus === "no-engine"
+			? "Select a guardrail engine first"
+			: parametersStatus === "loading"
+				? "Loading engine parameters..."
+				: parametersStatus === "error"
+					? "Unable to load engine parameters"
+					: parameterOptions.length === 0
+						? "This guardrail defines no parameters"
+						: availableParameters.length === 0
+							? `All ${parameterOptions.length} engine parameters are configured`
+							: "Choose a parameter to add";
+
+	const addParameter = (parameterName: string) => {
+		const option = parameterOptions.find(
+			(parameter) => parameter.name === parameterName,
 		);
+		if (!option) {
+			return;
+		}
+		const parameter = createGuardrailDirectParam();
+		parameter.key = option.name;
+		parameter.type = guardrailParameterTypeForForm(option.type);
+		parameter.value = defaultValueForType(parameter.type);
+		onChange([...value, parameter]);
+	};
 
 	return (
-		<div className="space-y-2">
-			<FieldLabel htmlFor={`${idPrefix}-param-0-key`}>
-				Direct Parameters
-			</FieldLabel>
-			{value.map((row, index) => (
-				<div key={row.id} className="flex items-center gap-2">
-					<Input
-						id={`${idPrefix}-param-${index}-key`}
-						placeholder="Parameter name (e.g. threshold)"
-						value={row.key}
-						onChange={(event) =>
-							updateRow(row.id, { key: event.target.value })
-						}
-						disabled={disabled}
-					/>
-					<Select
-						value={row.type}
-						onValueChange={(type) =>
-							updateRow(row.id, {
-								type: type as GuardrailDirectParamFormValue["type"],
-								// a stale value makes no sense across types
-								value: type === "boolean" ? "false" : "",
-							})
-						}
-						disabled={disabled}
+		<div className="space-y-3">
+			<div className="flex flex-wrap items-center justify-between gap-2">
+				<FieldLabel>Fixed values</FieldLabel>
+				<Badge variant="secondary">
+					{value.length}{" "}
+					{value.length === 1 ? "fixed value" : "fixed values"}
+				</Badge>
+			</div>
+			<FieldDescription>
+				Values sent to the guardrail unchanged on every call, such as a
+				threshold. Parameters already supplied by Inputs are marked
+				Mapped; fixed values added here are marked Added.
+			</FieldDescription>
+			<Field>
+				<FieldLabel htmlFor={addParameterId}>
+					Add fixed value
+				</FieldLabel>
+				<Select
+					value=""
+					onValueChange={addParameter}
+					disabled={
+						disabled ||
+						parametersStatus !== "loaded" ||
+						parameterOptions.length === 0
+					}
+				>
+					<SelectTrigger
+						id={addParameterId}
+						className="w-full"
+						aria-label="Add direct parameter"
 					>
-						<SelectTrigger
-							id={`${idPrefix}-param-${index}-type`}
-							className="w-32 shrink-0"
+						<Plus className="size-4" aria-hidden />
+						<SelectValue placeholder={addPlaceholder} />
+					</SelectTrigger>
+					<SelectContent
+						align="start"
+						className="w-[var(--radix-select-trigger-width)]"
+					>
+						{parameterOptions.map((parameter) => {
+							const status = mappedParameters.has(parameter.name)
+								? "Mapped"
+								: directParameters.has(parameter.name)
+									? "Added"
+									: "Available";
+
+							return (
+								<SelectItem
+									key={parameter.name}
+									value={parameter.name}
+									disabled={status !== "Available"}
+									className="[&>span:last-child]:w-full"
+								>
+									<span className="flex w-full min-w-0 items-center justify-between gap-4">
+										<span className="min-w-0">
+											<span className="block truncate font-mono">
+												{parameter.name}
+											</span>
+											{parameter.description && (
+												<span className="block truncate text-muted-foreground text-xs">
+													{parameter.description}
+												</span>
+											)}
+										</span>
+										<span className="flex shrink-0 items-center gap-2">
+											<span className="text-muted-foreground text-xs">
+												{parameter.type}
+												{parameter.required
+													? " - required"
+													: ""}
+											</span>
+											<Badge
+												variant={
+													status === "Available"
+														? "outline"
+														: "secondary"
+												}
+											>
+												{status}
+											</Badge>
+										</span>
+									</span>
+								</SelectItem>
+							);
+						})}
+					</SelectContent>
+				</Select>
+			</Field>
+
+			{value.length === 0 && availableParameters.length > 0 && (
+				<div className="rounded-md border border-dashed p-4 text-center text-muted-foreground text-sm">
+					No fixed values added.
+				</div>
+			)}
+			{value.length === 0 &&
+				parameterOptions.length > 0 &&
+				availableParameters.length === 0 && (
+					<div className="rounded-md border border-dashed p-4 text-center text-muted-foreground text-sm">
+						Every engine parameter is already supplied by Inputs.
+					</div>
+				)}
+			{value.map((row, index) => (
+				<div
+					key={row.id}
+					className="overflow-hidden rounded-md border bg-card"
+				>
+					<div className="flex items-start justify-between gap-3 border-b bg-muted/30 px-3 py-2">
+						<div className="min-w-0 space-y-1">
+							<div className="flex flex-wrap items-center gap-2">
+								<span className="font-mono font-semibold text-sm">
+									{row.key || `Parameter ${index + 1}`}
+								</span>
+								<Badge variant="outline">
+									{DIRECT_PARAMETER_TYPE_LABELS[row.type]}
+								</Badge>
+							</div>
+							{parameterOptions.find(
+								(parameter) => parameter.name === row.key,
+							)?.description && (
+								<p className="text-muted-foreground text-xs">
+									{
+										parameterOptions.find(
+											(parameter) =>
+												parameter.name === row.key,
+										)?.description
+									}
+								</p>
+							)}
+						</div>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							aria-label={`Delete direct parameter ${row.key || index + 1}`}
+							onClick={() =>
+								onChange(
+									value.filter(
+										(other) => other.id !== row.id,
+									),
+								)
+							}
+							disabled={disabled}
+							className="text-destructive hover:text-destructive"
 						>
-							<SelectValue />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem value="string">String</SelectItem>
-							<SelectItem value="number">Number</SelectItem>
-							<SelectItem value="boolean">Boolean</SelectItem>
-						</SelectContent>
-					</Select>
-					{row.type === "boolean" ? (
-						<div className="flex flex-1 justify-start">
-							<Switch
-								id={`${idPrefix}-param-${index}-value`}
-								checked={row.value === "true"}
-								onCheckedChange={(checked) =>
-									updateRow(row.id, {
-										value: String(checked),
-									})
+							<Trash2 className="size-4" aria-hidden />
+							Delete
+						</Button>
+					</div>
+					<div className="p-3">
+						{row.type === "boolean" ? (
+							<FormField
+								name={`${namePrefix}.${index}.value`}
+								render={({ field, fieldState }) => (
+									<Field
+										orientation="horizontal"
+										data-invalid={!!fieldState.error}
+									>
+										<Switch
+											id={`${idPrefix}-param-${index}-value`}
+											checked={field.value === "true"}
+											onCheckedChange={(checked) =>
+												field.onChange(String(checked))
+											}
+											disabled={disabled}
+										/>
+										<FieldLabel
+											htmlFor={`${idPrefix}-param-${index}-value`}
+										>
+											Value
+										</FieldLabel>
+									</Field>
+								)}
+							/>
+						) : row.type.endsWith("-array") ||
+							row.type === "json" ? (
+							<FormTextarea
+								name={`${namePrefix}.${index}.value`}
+								label="Value"
+								placeholder={
+									structuredValueHelp(row.type).placeholder
+								}
+								description={
+									structuredValueHelp(row.type).description
+								}
+								rows={4}
+								disabled={disabled}
+							/>
+						) : (
+							<FormInput
+								name={`${namePrefix}.${index}.value`}
+								label="Value"
+								inputMode={
+									row.type === "number"
+										? "decimal"
+										: undefined
+								}
+								placeholder={
+									row.type === "number"
+										? "Value (e.g. 0.8)"
+										: "Value"
 								}
 								disabled={disabled}
 							/>
-						</div>
-					) : (
-						<Input
-							id={`${idPrefix}-param-${index}-value`}
-							inputMode={
-								row.type === "number" ? "decimal" : undefined
-							}
-							placeholder={
-								row.type === "number"
-									? "Value (e.g. 0.8)"
-									: "Value"
-							}
-							value={row.value}
-							onChange={(event) =>
-								updateRow(row.id, { value: event.target.value })
-							}
-							disabled={disabled}
-						/>
-					)}
-					<Button
-						type="button"
-						variant="ghost"
-						size="icon"
-						aria-label="Remove direct parameter"
-						onClick={() =>
-							onChange(
-								value.filter((other) => other.id !== row.id),
-							)
-						}
-						disabled={disabled}
-					>
-						<X className="h-4 w-4" />
-					</Button>
+						)}
+					</div>
 				</div>
 			))}
-			<Button
-				type="button"
-				variant="outline"
-				size="sm"
-				className="w-fit"
-				onClick={() =>
-					onChange([...value, createGuardrailDirectParam()])
-				}
-				disabled={disabled}
-			>
-				<Plus className="h-4 w-4" />
-				Add Parameter
-			</Button>
-			<FieldDescription>
-				Literal values passed to the guardrail engine on every call,
-				such as a detection threshold.
-			</FieldDescription>
 		</div>
 	);
 };

--- a/packages/client/src/components/engine/guardrail-engine-field.tsx
+++ b/packages/client/src/components/engine/guardrail-engine-field.tsx
@@ -1,0 +1,79 @@
+import { useId } from "react";
+import { EngineSelect } from "@semoss/shared";
+import {
+	Field,
+	FieldError,
+	FieldLabel,
+	FormField,
+	useFormContext,
+} from "@semoss/ui/next";
+
+export interface GuardrailEngineFieldProps {
+	/** React Hook Form path for this check's guardrail engine id. */
+	name: string;
+
+	/** Display name of the selected engine, resolved by the caller. */
+	engineName: string;
+
+	/** Records the display name of a newly picked engine so it can be shown
+	 * without refetching the configuration. */
+	onEngineResolved: (engineId: string, engineName: string) => void;
+
+	/** Whether the field accepts edits. */
+	disabled?: boolean;
+
+	/** Prefix for this field's test ids. */
+	testIdPrefix: string;
+}
+
+/**
+ * Picks the guardrail engine a check runs. Uses the shared engine select so
+ * the options carry the same icon, name, and id as every other engine picker,
+ * and so a long guardrail catalog stays searchable.
+ */
+export const GuardrailEngineField = ({
+	name,
+	engineName,
+	onEngineResolved,
+	disabled,
+	testIdPrefix,
+}: GuardrailEngineFieldProps) => {
+	// untyped so the caller can pass an arbitrary check path
+	const { control } = useFormContext();
+	const fieldId = useId();
+
+	return (
+		<FormField
+			control={control}
+			name={name}
+			render={({ field, fieldState }) => (
+				<Field
+					data-invalid={!!fieldState.error}
+					data-testid={`${testIdPrefix}-engine`}
+				>
+					<FieldLabel htmlFor={fieldId}>Check with</FieldLabel>
+					<EngineSelect
+						className="h-9 w-full max-w-none justify-start border border-input px-3 shadow-xs"
+						name={engineName}
+						value={String(field.value ?? "")}
+						engineTypes={["GUARDRAIL"]}
+						showEngineId
+						disabled={disabled}
+						onChange={(engine) => {
+							field.onChange(engine.engine_id);
+							onEngineResolved(
+								engine.engine_id,
+								engine.engine_display_name ||
+									engine.engine_name,
+							);
+						}}
+						popoverContentProps={{ align: "start" }}
+					/>
+					{fieldState.error?.message && (
+						<FieldError>{fieldState.error.message}</FieldError>
+					)}
+				</Field>
+			)}
+		/>
+	);
+};

--- a/packages/client/src/components/engine/guardrail-engine-parameters.ts
+++ b/packages/client/src/components/engine/guardrail-engine-parameters.ts
@@ -1,0 +1,158 @@
+/**
+ * The parameters a guardrail engine declares, read from GetEngineUsage. Both
+ * the parameter mapping and the fixed value editors offer these names, so a
+ * guardrail is wired with parameters it actually reads.
+ */
+
+import { usePixel } from "@semoss/sdk/react";
+import type { GuardrailDirectParamFormValue } from "./engine-guardrail-settings.constants";
+
+/** One parameter a guardrail engine accepts. */
+export interface GuardrailParameterOption {
+	/** Parameter name the guardrail reads. */
+	name: string;
+
+	/** Java type the engine declares, such as List<String>. */
+	type: string;
+
+	/** Engine supplied explanation of the parameter. */
+	description: string;
+
+	/** Whether the guardrail requires the parameter. */
+	required: boolean;
+}
+
+/** Load state of a guardrail engine's declared parameters. */
+export type GuardrailParametersStatus =
+	| "no-engine"
+	| "loading"
+	| "error"
+	| "loaded";
+
+/** The parameters and load state for one guardrail engine. */
+export interface GuardrailEngineParameters {
+	options: GuardrailParameterOption[];
+	status: GuardrailParametersStatus;
+}
+
+interface GuardrailUsageSection {
+	parameters?: unknown;
+}
+
+/** Pull the parameter list out of a GetEngineUsage response, ignoring
+ * sections that do not describe parameters. */
+export const getGuardrailParameters = (
+	data: unknown,
+): GuardrailParameterOption[] => {
+	if (!data || typeof data !== "object") {
+		return [];
+	}
+
+	const sections = Array.isArray(data) ? data : Object.values(data);
+	for (const section of sections) {
+		if (!section || typeof section !== "object") {
+			continue;
+		}
+		const parameters = (section as GuardrailUsageSection).parameters;
+		if (!Array.isArray(parameters)) {
+			continue;
+		}
+
+		return parameters.flatMap((parameter) => {
+			if (!parameter || typeof parameter !== "object") {
+				return [];
+			}
+			const candidate = parameter as Partial<GuardrailParameterOption>;
+			if (typeof candidate.name !== "string" || !candidate.name.trim()) {
+				return [];
+			}
+			return [
+				{
+					name: candidate.name,
+					type:
+						typeof candidate.type === "string"
+							? candidate.type
+							: "String",
+					description:
+						typeof candidate.description === "string"
+							? candidate.description
+							: "",
+					required: candidate.required === true,
+				},
+			];
+		});
+	}
+	return [];
+};
+
+/** Map a guardrail engine's declared Java type onto the editor's value type. */
+export const guardrailParameterTypeForForm = (
+	type: string,
+): GuardrailDirectParamFormValue["type"] => {
+	const normalized = type.toLowerCase().replaceAll(" ", "");
+	const isArray =
+		normalized.includes("list") ||
+		normalized.includes("array") ||
+		normalized.endsWith("[]");
+	if (isArray) {
+		const isArrayOf = (itemType: string) =>
+			normalized.includes(`<${itemType}>`) ||
+			normalized.endsWith(`${itemType}[]`);
+		if (isArrayOf("boolean")) {
+			return "boolean-array";
+		}
+		if (
+			["double", "float", "integer", "long", "number", "short"].some(
+				(numberType) => isArrayOf(numberType),
+			)
+		) {
+			return "number-array";
+		}
+		if (isArrayOf("string")) {
+			return "string-array";
+		}
+		return "json";
+	}
+	if (normalized.includes("boolean")) {
+		return "boolean";
+	}
+	if (
+		["double", "float", "integer", "long", "number", "short"].some(
+			(numberType) => normalized === numberType,
+		)
+	) {
+		return "number";
+	}
+	if (normalized.includes("map") || normalized.includes("object")) {
+		return "json";
+	}
+	return "string";
+};
+
+/**
+ * Loads the parameters a guardrail engine declares. Fetching once per
+ * guardrail check keeps the mapping and fixed value editors working from the
+ * same list.
+ *
+ * @param guardrailEngineId engine to describe, or an empty string for none
+ */
+export const useGuardrailEngineParameters = (
+	guardrailEngineId: string,
+): GuardrailEngineParameters => {
+	const usage = usePixel<unknown>(
+		guardrailEngineId
+			? `GetEngineUsage(engine=[${JSON.stringify(guardrailEngineId)}]);`
+			: "",
+	);
+
+	if (!guardrailEngineId) {
+		return { options: [], status: "no-engine" };
+	}
+	if (usage.status === "LOADING" || usage.status === "INITIAL") {
+		return { options: [], status: "loading" };
+	}
+	if (usage.status === "ERROR") {
+		return { options: [], status: "error" };
+	}
+	return { options: getGuardrailParameters(usage.data), status: "loaded" };
+};

--- a/packages/client/src/components/engine/guardrail-input-mapping-field.tsx
+++ b/packages/client/src/components/engine/guardrail-input-mapping-field.tsx
@@ -1,78 +1,92 @@
-import { Plus, X } from "lucide-react";
-import { Button, FieldDescription, FieldLabel, Input } from "@semoss/ui/next";
+import { Plus, Trash2 } from "lucide-react";
+import { useId, useState } from "react";
+import {
+	Button,
+	Field,
+	FieldDescription,
+	FieldError,
+	FieldLabel,
+	FormField,
+	FormInput,
+	Input,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	useFormContext,
+} from "@semoss/ui/next";
 import {
 	createGuardrailMappingEntry,
 	type GuardrailMappingEntryFormValue,
+	type InterceptableMethodArgument,
 } from "./engine-guardrail-settings.constants";
+import { GuardrailArgumentField } from "./guardrail-argument-field";
+import type {
+	GuardrailParameterOption,
+	GuardrailParametersStatus,
+} from "./guardrail-engine-parameters";
 
 export interface GuardrailInputMappingFieldProps {
+	/** Mapping rows currently held for this check. */
 	value: GuardrailMappingEntryFormValue[];
+
+	/** Replaces the mapping rows. */
 	onChange: (next: GuardrailMappingEntryFormValue[]) => void;
+
+	/** Parameters the selected guardrail engine declares. */
+	parameterOptions: GuardrailParameterOption[];
+
+	/** Load state of the guardrail engine's parameters. */
+	parametersStatus: GuardrailParametersStatus;
+
+	/** Arguments the rule's method exposes in this phase. */
+	argumentOptions: InterceptableMethodArgument[];
+
+	/** Whether the fields accept edits. */
 	disabled?: boolean;
-	idPrefix: string;
-	/** Set when masking is on - the row mapping this parameter must resolve
-	 * to a single argument or the runtime blocks instead of masking. */
-	maskTargetParam?: string | null;
+
+	/** Prefix for this field's test ids. */
+	testIdPrefix: string;
+
+	/** React Hook Form path for this mapping array. */
+	namePrefix: string;
 }
 
+/** Sentinel for the option that reveals the free-text parameter input. */
+const CUSTOM_PARAMETER_OPTION = "__custom-parameter__";
+
 /**
- * Editor for a guardrail entry's inputMapping: rows of guardrail parameter
- * name to the intercepted method argument name(s) that feed it. Multiple
- * comma-separated arguments are concatenated by the runtime.
+ * Editor for a check's inputMapping: each row names a guardrail parameter and
+ * the intercepted argument that feeds it. Multiple comma-separated arguments
+ * are concatenated by the runtime.
  */
 export const GuardrailInputMappingField = ({
 	value,
 	onChange,
+	parameterOptions,
+	parametersStatus,
+	argumentOptions,
 	disabled,
-	idPrefix,
-	maskTargetParam,
+	testIdPrefix,
+	namePrefix,
 }: GuardrailInputMappingFieldProps) => {
-	const updateRow = (
-		rowId: string,
-		partial: Partial<GuardrailMappingEntryFormValue>,
-	) =>
-		onChange(
-			value.map((row) =>
-				row.id === rowId ? { ...row, ...partial } : row,
-			),
-		);
-
-	const rowHasMaskConflict = (row: GuardrailMappingEntryFormValue) =>
-		!!maskTargetParam &&
-		row.key.trim() === maskTargetParam &&
-		row.args.split(",").filter((arg) => arg.trim()).length > 1;
-
 	return (
 		<div className="space-y-2">
-			<FieldLabel htmlFor={`${idPrefix}-mapping-0-key`}>
-				Parameter Mapping
-			</FieldLabel>
+			<FieldLabel>Inputs</FieldLabel>
+			<FieldDescription>
+				Each row hands one guardrail parameter the value of an
+				intercepted argument. A check with no inputs receives nothing to
+				screen, so at least one row is required.
+			</FieldDescription>
 			{value.map((row, index) => (
-				<div key={row.id} className="space-y-1">
-					<div className="flex items-center gap-2">
-						<Input
-							id={`${idPrefix}-mapping-${index}-key`}
-							placeholder="Guardrail parameter (e.g. prompt)"
-							value={row.key}
-							onChange={(event) =>
-								updateRow(row.id, { key: event.target.value })
-							}
-							disabled={disabled}
-						/>
-						<Input
-							id={`${idPrefix}-mapping-${index}-args`}
-							placeholder="Argument name(s), comma separated (e.g. arg0)"
-							value={row.args}
-							onChange={(event) =>
-								updateRow(row.id, { args: event.target.value })
-							}
-							disabled={disabled}
-						/>
+				<div key={row.id} className="space-y-3 rounded-md border p-3">
+					<div className="flex items-center justify-between gap-2">
+						<p className="font-medium text-sm">Input {index + 1}</p>
 						<Button
 							type="button"
 							variant="ghost"
-							size="icon"
-							aria-label="Remove parameter mapping"
+							size="sm"
 							onClick={() =>
 								onChange(
 									value.filter(
@@ -80,21 +94,36 @@ export const GuardrailInputMappingField = ({
 									),
 								)
 							}
-							disabled={disabled}
+							disabled={disabled || value.length === 1}
+							aria-label={`Delete mapping ${index + 1}`}
+							title={
+								value.length === 1
+									? "At least one mapping is required"
+									: `Delete mapping ${index + 1}`
+							}
 						>
-							<X className="h-4 w-4" />
+							<Trash2 className="size-4" aria-hidden />
+							Delete mapping
 						</Button>
 					</div>
-					{rowHasMaskConflict(row) && (
-						<p
-							className="text-destructive text-xs"
-							data-testid={`${idPrefix}-mapping-${index}-mask-conflict`}
-						>
-							Masking needs this parameter mapped to a single
-							argument - with several the guardrail blocks instead
-							of masking.
-						</p>
-					)}
+					<div className="grid items-start gap-3 sm:grid-cols-2">
+						<GuardrailParameterNameField
+							name={`${namePrefix}.${index}.key`}
+							parameterOptions={parameterOptions}
+							parametersStatus={parametersStatus}
+							takenNames={value
+								.filter((other) => other.id !== row.id)
+								.map((other) => other.key.trim())}
+							disabled={disabled}
+							testIdPrefix={`${testIdPrefix}-mapping-${index}`}
+						/>
+						<GuardrailArgumentField
+							name={`${namePrefix}.${index}.args`}
+							options={argumentOptions}
+							disabled={disabled}
+							testIdPrefix={`${testIdPrefix}-mapping-${index}`}
+						/>
+					</div>
 				</div>
 			))}
 			<Button
@@ -107,16 +136,159 @@ export const GuardrailInputMappingField = ({
 				}
 				disabled={disabled}
 			>
-				<Plus className="h-4 w-4" />
-				Add Mapping
+				<Plus className="size-4" aria-hidden />
+				Add Input
 			</Button>
-			<FieldDescription>
-				Maps each guardrail parameter to the intercepted method argument
-				that feeds it - use arg0 for the method's first argument, or
-				result (output phase) for the model's response. Several
-				comma-separated arguments are concatenated before the guardrail
-				runs.
-			</FieldDescription>
 		</div>
+	);
+};
+
+interface GuardrailParameterNameFieldProps {
+	name: string;
+	parameterOptions: GuardrailParameterOption[];
+	parametersStatus: GuardrailParametersStatus;
+	/** Parameter names already used by the check's other rows. */
+	takenNames: string[];
+	disabled?: boolean;
+	testIdPrefix: string;
+}
+
+/** Names the guardrail parameter a row feeds, offering the engine's declared
+ * parameters so a misspelled name does not leave the guardrail without it. */
+const GuardrailParameterNameField = ({
+	name,
+	parameterOptions,
+	parametersStatus,
+	takenNames,
+	disabled,
+	testIdPrefix,
+}: GuardrailParameterNameFieldProps) => {
+	// untyped so the caller can pass an arbitrary mapping row path
+	const { control } = useFormContext();
+	const selectId = useId();
+	const customId = useId();
+	const [showCustom, setShowCustom] = useState(false);
+
+	if (parametersStatus !== "loaded" || parameterOptions.length === 0) {
+		return (
+			<FormInput
+				name={name}
+				label="Guardrail parameter"
+				placeholder="Guardrail parameter, such as prompt"
+				description={
+					parametersStatus === "loading"
+						? "Loading the parameters this guardrail declares."
+						: parametersStatus === "no-engine"
+							? "Select a guardrail engine to list its parameters."
+							: "The guardrail's parameters could not be listed, so enter the name it reads."
+				}
+				disabled={disabled}
+				data-testid={`${testIdPrefix}-key`}
+			/>
+		);
+	}
+
+	const taken = new Set(takenNames);
+
+	return (
+		<FormField
+			control={control}
+			name={name}
+			render={({ field, fieldState }) => {
+				const current = String(field.value ?? "");
+				const trimmed = current.trim();
+				const matched = parameterOptions.some(
+					(option) => option.name === trimmed,
+				);
+				const isCustom = showCustom || (!!trimmed && !matched);
+
+				return (
+					<Field data-invalid={!!fieldState.error}>
+						<FieldLabel htmlFor={selectId}>
+							Guardrail parameter
+						</FieldLabel>
+						<Select
+							value={isCustom ? CUSTOM_PARAMETER_OPTION : trimmed}
+							onValueChange={(next) => {
+								// the hidden native select Radix adds for the
+								// surrounding form reports an empty value while
+								// the option list is unmounted, and no option
+								// here is empty
+								if (!next) {
+									return;
+								}
+								if (next === CUSTOM_PARAMETER_OPTION) {
+									setShowCustom(true);
+									return;
+								}
+								setShowCustom(false);
+								field.onChange(next);
+							}}
+							disabled={disabled}
+						>
+							<SelectTrigger
+								id={selectId}
+								className="w-full"
+								aria-invalid={!!fieldState.error}
+								data-testid={`${testIdPrefix}-key`}
+							>
+								<SelectValue placeholder="Select the parameter to fill" />
+							</SelectTrigger>
+							<SelectContent>
+								{parameterOptions.map((option) => (
+									<SelectItem
+										key={option.name}
+										value={option.name}
+										disabled={
+											option.name !== trimmed &&
+											taken.has(option.name)
+										}
+									>
+										<span className="flex w-full min-w-0 items-center justify-between gap-4">
+											<span className="truncate font-mono">
+												{option.name}
+											</span>
+											<span className="shrink-0 text-muted-foreground text-xs">
+												{option.type}
+												{option.required
+													? " - required"
+													: ""}
+											</span>
+										</span>
+									</SelectItem>
+								))}
+								<SelectItem value={CUSTOM_PARAMETER_OPTION}>
+									Another parameter...
+								</SelectItem>
+							</SelectContent>
+						</Select>
+
+						{isCustom && (
+							<>
+								<FieldLabel htmlFor={customId}>
+									Parameter name
+								</FieldLabel>
+								<Input
+									id={customId}
+									value={current}
+									onChange={(event) =>
+										field.onChange(event.target.value)
+									}
+									onBlur={field.onBlur}
+									placeholder="Parameter name, such as prompt"
+									disabled={disabled}
+									aria-invalid={!!fieldState.error}
+									data-testid={`${testIdPrefix}-key-custom`}
+								/>
+							</>
+						)}
+
+						{fieldState.error?.message && (
+							<FieldError>{fieldState.error.message}</FieldError>
+						)}
+					</Field>
+				);
+			}}
+		/>
 	);
 };

--- a/packages/client/src/components/engine/guardrail-issue-list.tsx
+++ b/packages/client/src/components/engine/guardrail-issue-list.tsx
@@ -1,0 +1,137 @@
+import { AlertTriangle, Info } from "lucide-react";
+import { cn } from "@semoss/ui/next";
+import type { GuardrailConfigIssue } from "./engine-guardrail-settings.constants";
+
+export interface GuardrailIssueListProps {
+	/** Problems found in the current editor value. */
+	issues: GuardrailConfigIssue[];
+
+	/** Reveals an issue's rule and check when its message is selected. */
+	onSelect: (issue: GuardrailConfigIssue) => void;
+}
+
+interface GuardrailIssueGroupProps {
+	issues: GuardrailConfigIssue[];
+	/** Summary shown above the list when there is more than one issue. */
+	heading: string;
+	destructive: boolean;
+	testId: string;
+	onSelect: (issue: GuardrailConfigIssue) => void;
+}
+
+/** One message, made selectable when it can point at a rule. */
+const GuardrailIssueMessage = ({
+	issue,
+	onSelect,
+}: {
+	issue: GuardrailConfigIssue;
+	onSelect: (issue: GuardrailConfigIssue) => void;
+}) =>
+	issue.pipelineId ? (
+		<button
+			type="button"
+			onClick={() => onSelect(issue)}
+			className="cursor-pointer text-left underline decoration-dotted underline-offset-2 hover:decoration-solid"
+		>
+			{issue.message}
+		</button>
+	) : (
+		<span>{issue.message}</span>
+	);
+
+/**
+ * A single issue reads as one line; several are summarized and listed, so the
+ * summary stays proportional to what is wrong instead of taking a fixed block
+ * of the panel.
+ */
+const GuardrailIssueGroup = ({
+	issues,
+	heading,
+	destructive,
+	testId,
+	onSelect,
+}: GuardrailIssueGroupProps) => {
+	const Icon = destructive ? AlertTriangle : Info;
+
+	return (
+		<div
+			className={cn(
+				"flex items-start gap-2 rounded-md border px-3 py-2 text-sm",
+				destructive
+					? "border-destructive/40 bg-destructive/5 text-destructive"
+					: "border-border bg-muted/40 text-foreground",
+			)}
+			data-testid={testId}
+		>
+			<Icon className="mt-0.5 size-4 shrink-0" aria-hidden />
+			<div className="min-w-0 flex-1">
+				{issues.length === 1 && issues[0] ? (
+					<GuardrailIssueMessage
+						issue={issues[0]}
+						onSelect={onSelect}
+					/>
+				) : (
+					<>
+						<p className="font-medium">{heading}</p>
+						<ul className="mt-1 space-y-0.5">
+							{issues.map((issue, index) => (
+								<li
+									// issues are derived per render and carry no
+									// id, so the rule and position identify the row
+									key={`${issue.pipelineId ?? "config"}-${index}`}
+									className="flex gap-2"
+								>
+									<span aria-hidden>-</span>
+									<GuardrailIssueMessage
+										issue={issue}
+										onSelect={onSelect}
+									/>
+								</li>
+							))}
+						</ul>
+					</>
+				)}
+			</div>
+		</div>
+	);
+};
+
+/**
+ * Lists every problem in the configuration at once so a save attempt does not
+ * have to be repeated per error, and each message navigates to the rule and
+ * check it came from.
+ */
+export const GuardrailIssueList = ({
+	issues,
+	onSelect,
+}: GuardrailIssueListProps) => {
+	const errors = issues.filter((issue) => issue.severity === "error");
+	const warnings = issues.filter((issue) => issue.severity === "warning");
+
+	if (errors.length === 0 && warnings.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="space-y-2">
+			{errors.length > 0 && (
+				<GuardrailIssueGroup
+					issues={errors}
+					heading={`${errors.length} problems block saving`}
+					destructive
+					testId="engine-guardrail-settings--errors"
+					onSelect={onSelect}
+				/>
+			)}
+			{warnings.length > 0 && (
+				<GuardrailIssueGroup
+					issues={warnings}
+					heading={`${warnings.length} things to check`}
+					destructive={false}
+					testId="engine-guardrail-settings--warnings"
+					onSelect={onSelect}
+				/>
+			)}
+		</div>
+	);
+};

--- a/packages/client/src/components/engine/guardrail-method-field.tsx
+++ b/packages/client/src/components/engine/guardrail-method-field.tsx
@@ -1,0 +1,218 @@
+import { useId, useState } from "react";
+import {
+	Field,
+	FieldDescription,
+	FieldError,
+	FieldLabel,
+	FormField,
+	FormInput,
+	Input,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	useFormContext,
+} from "@semoss/ui/next";
+import {
+	GUARDRAIL_ALL_METHODS,
+	type GuardrailConfigFormValue,
+	type InterceptableMethod,
+} from "./engine-guardrail-settings.constants";
+
+export interface GuardrailMethodFieldProps {
+	/** React Hook Form path for this rule's method field. */
+	name: `pipelines.${number}.method`;
+
+	/** Methods the engine reports as interceptable. Empty falls back to free text. */
+	methods: InterceptableMethod[];
+
+	/** Methods already claimed by another rule, listed but not selectable since
+	 * two rules cannot cover the same call. */
+	takenMethods?: string[];
+
+	/** Whether the field accepts edits. */
+	disabled?: boolean;
+
+	/** Prefix for this field's test ids. */
+	testIdPrefix: string;
+
+	/** Class applied to the wrapping field. */
+	className?: string;
+}
+
+/** Sentinel for the option that reveals the free-text method input. */
+const CUSTOM_METHOD_OPTION = "__custom-method__";
+
+const methodSignature = (method: InterceptableMethod): string =>
+	`${method.name}(${method.arguments.map((argument) => argument.type).join(", ")})`;
+
+/**
+ * Picks the engine call a rule applies to. Choosing from the engine's reported
+ * methods keeps the stored name one the runtime resolves, while the custom
+ * option covers calls the engine exposes through another interface.
+ *
+ * The trigger stays a single line whatever is selected, so switching between
+ * rules does not change the height of the panel.
+ */
+export const GuardrailMethodField = ({
+	name,
+	methods,
+	takenMethods = [],
+	disabled,
+	testIdPrefix,
+	className,
+}: GuardrailMethodFieldProps) => {
+	const { control } = useFormContext<GuardrailConfigFormValue>();
+	const selectId = useId();
+	const customId = useId();
+	const [showCustom, setShowCustom] = useState(false);
+
+	if (methods.length === 0) {
+		return (
+			<FormInput
+				className={className}
+				name={name}
+				label="Applies to"
+				placeholder="Method name, or * for all calls"
+				description="Enter the Java method name, such as askRoom, or * to apply this rule to every call."
+				disabled={disabled}
+				data-testid={`${testIdPrefix}-method`}
+			/>
+		);
+	}
+
+	return (
+		<FormField
+			control={control}
+			name={name}
+			render={({ field, fieldState }) => {
+				const current = String(field.value ?? "");
+				const trimmed = current.trim();
+				const isAllCalls = trimmed === GUARDRAIL_ALL_METHODS;
+				const matched = methods.find(
+					(method) => method.name === trimmed,
+				);
+				const isCustom = showCustom || (!isAllCalls && !matched);
+				const taken = new Set(
+					takenMethods.map((method) => method.trim()).filter(Boolean),
+				);
+
+				return (
+					<Field
+						data-invalid={!!fieldState.error}
+						className={className}
+					>
+						<FieldLabel htmlFor={selectId}>Applies to</FieldLabel>
+						<Select
+							value={isCustom ? CUSTOM_METHOD_OPTION : trimmed}
+							onValueChange={(next) => {
+								// the hidden native select Radix adds for the
+								// surrounding form reports an empty value while
+								// the option list is unmounted, and no option
+								// here is empty
+								if (!next) {
+									return;
+								}
+								if (next === CUSTOM_METHOD_OPTION) {
+									setShowCustom(true);
+									field.onChange("");
+									return;
+								}
+								setShowCustom(false);
+								field.onChange(next);
+							}}
+							disabled={disabled}
+						>
+							<SelectTrigger
+								id={selectId}
+								className="w-full"
+								aria-invalid={!!fieldState.error}
+								data-testid={`${testIdPrefix}-method`}
+							>
+								<SelectValue placeholder="Select the calls this rule applies to" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem
+									value={GUARDRAIL_ALL_METHODS}
+									disabled={taken.has(GUARDRAIL_ALL_METHODS)}
+								>
+									<span className="flex w-full items-center justify-between gap-6">
+										<span className="truncate font-mono">
+											{GUARDRAIL_ALL_METHODS}
+										</span>
+										<span className="shrink-0 text-muted-foreground text-xs">
+											{taken.has(GUARDRAIL_ALL_METHODS)
+												? "already covered"
+												: "every call with no rule of its own"}
+										</span>
+									</span>
+								</SelectItem>
+								{methods.map((method) => {
+									const isTaken = taken.has(method.name);
+									return (
+										<SelectItem
+											key={method.name}
+											value={method.name}
+											disabled={isTaken}
+										>
+											<span className="flex w-full items-center justify-between gap-6">
+												<span className="truncate font-mono">
+													{method.name}
+												</span>
+												<span className="shrink-0 text-muted-foreground text-xs">
+													{isTaken
+														? "already covered"
+														: method.deprecated
+															? "deprecated"
+															: ""}
+												</span>
+											</span>
+										</SelectItem>
+									);
+								})}
+								<SelectItem value={CUSTOM_METHOD_OPTION}>
+									Another method...
+								</SelectItem>
+							</SelectContent>
+						</Select>
+
+						{isCustom && (
+							<Input
+								id={customId}
+								value={current}
+								onChange={(event) =>
+									field.onChange(event.target.value)
+								}
+								onBlur={field.onBlur}
+								placeholder="Java method name, such as askRoom"
+								aria-label="Method name"
+								disabled={disabled}
+								aria-invalid={!!fieldState.error}
+								data-testid={`${testIdPrefix}-method-custom`}
+							/>
+						)}
+
+						{/* the reserved line keeps the field one height whatever is
+						    selected, so switching rules does not shift what follows */}
+						<FieldDescription
+							className="min-h-4 truncate font-mono text-xs"
+							title={
+								matched ? methodSignature(matched) : undefined
+							}
+						>
+							{matched
+								? methodSignature(matched)
+								: isAllCalls
+									? "Any call with no rule of its own"
+									: null}
+						</FieldDescription>
+						{fieldState.error?.message && (
+							<FieldError>{fieldState.error.message}</FieldError>
+						)}
+					</Field>
+				);
+			}}
+		/>
+	);
+};

--- a/packages/client/src/components/engine/guardrail-pipeline-field.tsx
+++ b/packages/client/src/components/engine/guardrail-pipeline-field.tsx
@@ -1,183 +1,424 @@
-import { Plus, X } from "lucide-react";
+import { FoldVertical, Plus, UnfoldVertical } from "lucide-react";
+import { useEffect, useState } from "react";
 import {
+	Accordion,
 	Badge,
 	Button,
-	Field,
-	FieldDescription,
-	FieldLabel,
-	Input,
-	Separator,
+	Muted,
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
+	useFieldArray,
+	useFormContext,
 } from "@semoss/ui/next";
 import {
 	createGuardrailReactor,
+	type GuardrailConfigFormValue,
+	type GuardrailConfigIssue,
+	type GuardrailEngineDetails,
 	type GuardrailPhase,
 	type GuardrailPipelineFormValue,
+	type GuardrailReactorFormValue,
+	guardrailArgumentOptions,
+	type InterceptableMethod,
 } from "./engine-guardrail-settings.constants";
-import {
-	type GuardrailEngineOption,
-	GuardrailReactorEntryField,
-} from "./guardrail-reactor-entry-field";
+import { GuardrailMethodField } from "./guardrail-method-field";
+import { GuardrailReactorEntryField } from "./guardrail-reactor-entry-field";
+
+/** A check the rule editor should open. */
+export interface GuardrailRevealTarget {
+	entryId: string;
+}
 
 export interface GuardrailPipelineFieldProps {
+	/** The rule being edited. */
 	value: GuardrailPipelineFormValue;
-	onChange: (next: GuardrailPipelineFormValue) => void;
-	onRemove: () => void;
-	engineOptions: GuardrailEngineOption[];
-	enginesLoading: boolean;
-	engineNameFallbacks: Record<string, string>;
+
+	/** Phase whose checks are shown, held by the caller so switching rules
+	 * keeps the reader on the same side of the call. */
+	activePhase: GuardrailPhase;
+
+	/** Shows a different phase's checks. */
+	onPhaseChange: (phase: GuardrailPhase) => void;
+
+	/** Backend resolved details for engine ids the config references. */
+	engineDetails: Record<string, GuardrailEngineDetails>;
+
+	/** Display names for engine ids, keyed by id. */
+	engineNames: Record<string, string>;
+
+	/** Records the display name of a newly picked guardrail engine. */
+	onEngineResolved: (engineId: string, engineName: string) => void;
+
+	/** Methods the engine reports as interceptable. */
+	methods: InterceptableMethod[];
+
+	/** Methods other rules already cover, so this rule cannot claim them. */
+	takenMethods: string[];
+
+	/** Argument name carrying the intercepted method's return value. */
+	resultArgumentName: string;
+
+	/** Problems that belong to this rule. */
+	issues: GuardrailConfigIssue[];
+
+	/** Check to expand, set when a problem was selected from the summary. A
+	 * fresh object per selection reopens a check the user collapsed again. */
+	revealTarget?: GuardrailRevealTarget | null;
+
+	/** Whether the fields accept edits. */
 	disabled?: boolean;
+
+	/** Prefix for this rule's element ids. */
 	idPrefix: string;
+
+	/** Prefix for this rule's test ids. */
 	testIdPrefix: string;
+
+	/** React Hook Form path for this rule. */
+	namePrefix: `pipelines.${number}`;
 }
+
+/** Checks expanded by default, above which the list opens collapsed. */
+const AUTO_EXPAND_LIMIT = 2;
 
 const PHASES: Array<{
 	phase: GuardrailPhase;
 	label: string;
 	description: string;
+	addLabel: string;
+	emptyMessage: string;
 }> = [
 	{
 		phase: "input",
-		label: "Input phase",
-		description: "Run against the request before the model is called.",
+		label: "Request",
+		description: "Runs in order before the engine call.",
+		addLabel: "Add Request Check",
+		emptyMessage:
+			"Nothing screens the request before it reaches the engine.",
 	},
 	{
 		phase: "output",
-		label: "Output phase",
-		description: "Run against the model response before it is returned.",
+		label: "Response",
+		description: "Runs in order before the response is returned.",
+		addLabel: "Add Response Check",
+		emptyMessage:
+			"Nothing screens the response before it reaches the caller.",
 	},
 ];
 
 /**
- * Editor for one pipeline: the engine method it intercepts plus its ordered
- * input-phase and output-phase guardrail lists.
+ * Focused editor for one rule: the call it covers, then its request and
+ * response checks in the order they run.
  */
 export const GuardrailPipelineField = ({
 	value,
-	onChange,
-	onRemove,
-	engineOptions,
-	enginesLoading,
-	engineNameFallbacks,
+	activePhase,
+	onPhaseChange,
+	engineDetails,
+	engineNames,
+	onEngineResolved,
+	methods,
+	takenMethods,
+	resultArgumentName,
+	issues,
+	revealTarget,
 	disabled,
 	idPrefix,
 	testIdPrefix,
+	namePrefix,
 }: GuardrailPipelineFieldProps) => {
-	const updatePhase = (
-		phase: GuardrailPhase,
-		entries: GuardrailPipelineFormValue["input"],
-	) => onChange({ ...value, [phase]: entries });
+	const { control } = useFormContext<GuardrailConfigFormValue>();
+	const inputEntries = useFieldArray({
+		control,
+		name: `${namePrefix}.input`,
+		keyName: "fieldArrayId",
+	});
+	const outputEntries = useFieldArray({
+		control,
+		name: `${namePrefix}.output`,
+		keyName: "fieldArrayId",
+	});
+	const [expandedEntries, setExpandedEntries] = useState<
+		Record<GuardrailPhase, string[]>
+	>(() => {
+		const total = value.input.length + value.output.length;
+		return total > AUTO_EXPAND_LIMIT
+			? { input: [], output: [] }
+			: {
+					input: value.input.map((entry) => entry.id),
+					output: value.output.map((entry) => entry.id),
+				};
+	});
 
-	const moveEntry = (phase: GuardrailPhase, index: number, delta: number) => {
-		const entries = [...value[phase]];
-		const target = index + delta;
-		if (target < 0 || target >= entries.length) {
+	// a problem selected from the summary has to open the check it belongs to,
+	// including switching to the phase that check runs in
+	useEffect(() => {
+		const entryId = revealTarget?.entryId;
+		if (!entryId) {
 			return;
 		}
-		const [moved] = entries.splice(index, 1);
-		entries.splice(target, 0, moved);
-		updatePhase(phase, entries);
+		const phase: GuardrailPhase | null = value.input.some(
+			(entry) => entry.id === entryId,
+		)
+			? "input"
+			: value.output.some((entry) => entry.id === entryId)
+				? "output"
+				: null;
+		if (!phase) {
+			return;
+		}
+		onPhaseChange(phase);
+		setExpandedEntries((current) =>
+			current[phase].includes(entryId)
+				? current
+				: { ...current, [phase]: [...current[phase], entryId] },
+		);
+	}, [revealTarget, value.input, value.output, onPhaseChange]);
+
+	const addEntry = (phase: GuardrailPhase) => {
+		const entry = createGuardrailReactor(phase);
+		if (phase === "input") {
+			inputEntries.append(entry);
+		} else {
+			outputEntries.append(entry);
+		}
+		setExpandedEntries((current) => ({
+			...current,
+			[phase]: [...current[phase], entry.id],
+		}));
 	};
 
-	return (
-		<div
-			className="space-y-4 rounded-md border p-4"
-			data-testid={testIdPrefix}
-		>
-			<div className="flex items-end gap-2">
-				<Field className="flex-1">
-					<FieldLabel htmlFor={`${idPrefix}-method`}>
-						Method
-					</FieldLabel>
-					<Input
-						id={`${idPrefix}-method`}
-						placeholder="Method name, or * for all methods"
-						value={value.method}
-						onChange={(event) =>
-							onChange({ ...value, method: event.target.value })
-						}
-						disabled={disabled}
-						data-testid={`${testIdPrefix}-method`}
-					/>
-					<FieldDescription>
-						The engine method these guardrails intercept (e.g. ask).
-						Use * to apply to every method.
-					</FieldDescription>
-				</Field>
-				<Button
-					type="button"
-					variant="ghost"
-					size="icon"
-					aria-label="Remove pipeline"
-					className="mb-auto"
-					onClick={onRemove}
-					disabled={disabled}
-					data-testid={`${testIdPrefix}-remove`}
-				>
-					<X className="h-4 w-4" />
-				</Button>
-			</div>
+	const updateEntry = (
+		phase: GuardrailPhase,
+		index: number,
+		entry: GuardrailReactorFormValue,
+	) => {
+		if (phase === "input") {
+			inputEntries.update(index, entry);
+		} else {
+			outputEntries.update(index, entry);
+		}
+	};
 
-			{PHASES.map(({ phase, label, description }, phaseIndex) => (
-				<div key={phase} className="space-y-3">
-					{phaseIndex > 0 && <Separator />}
-					<div className="flex items-center gap-2">
-						<Badge>{label}</Badge>
-						<span className="text-muted-foreground text-xs">
-							{description}
-						</span>
-					</div>
-					{value[phase].map((entry, index) => (
-						<GuardrailReactorEntryField
-							key={entry.id}
-							value={entry}
-							onChange={(next) =>
-								updatePhase(
-									phase,
-									value[phase].map((other) =>
-										other.id === entry.id ? next : other,
-									),
-								)
-							}
-							onRemove={() =>
-								updatePhase(
-									phase,
-									value[phase].filter(
-										(other) => other.id !== entry.id,
-									),
-								)
-							}
-							onMoveUp={() => moveEntry(phase, index, -1)}
-							onMoveDown={() => moveEntry(phase, index, 1)}
-							index={index}
-							count={value[phase].length}
-							phase={phase}
-							engineOptions={engineOptions}
-							enginesLoading={enginesLoading}
-							engineNameFallbacks={engineNameFallbacks}
-							disabled={disabled}
-							idPrefix={`${idPrefix}-${phase}-${index}`}
-							testIdPrefix={`${testIdPrefix}-${phase}-entry-${index}`}
-						/>
+	const removeEntry = (
+		phase: GuardrailPhase,
+		index: number,
+		entryId: string,
+	) => {
+		if (phase === "input") {
+			inputEntries.remove(index);
+		} else {
+			outputEntries.remove(index);
+		}
+		setExpandedEntries((current) => ({
+			...current,
+			[phase]: current[phase].filter((id) => id !== entryId),
+		}));
+	};
+
+	const moveEntry = (phase: GuardrailPhase, index: number, delta: number) => {
+		const target = index + delta;
+		if (target < 0 || target >= value[phase].length) {
+			return;
+		}
+		if (phase === "input") {
+			inputEntries.move(index, target);
+		} else {
+			outputEntries.move(index, target);
+		}
+	};
+
+	const hasExpandedEntry = (phase: GuardrailPhase) =>
+		value[phase].some((entry) => expandedEntries[phase].includes(entry.id));
+
+	const toggleAllEntries = (phase: GuardrailPhase) => {
+		setExpandedEntries((current) => ({
+			...current,
+			[phase]: hasExpandedEntry(phase)
+				? []
+				: value[phase].map((entry) => entry.id),
+		}));
+	};
+
+	const phaseErrorCount = (phase: GuardrailPhase) =>
+		issues.filter(
+			(issue) => issue.severity === "error" && issue.phase === phase,
+		).length;
+
+	return (
+		<div className="space-y-4" data-testid={testIdPrefix}>
+			<GuardrailMethodField
+				name={`${namePrefix}.method`}
+				methods={methods}
+				takenMethods={takenMethods}
+				disabled={disabled}
+				testIdPrefix={testIdPrefix}
+				className="max-w-xl"
+			/>
+
+			<Tabs
+				value={activePhase}
+				onValueChange={(next) => onPhaseChange(next as GuardrailPhase)}
+				className="gap-3"
+			>
+				<TabsList>
+					{PHASES.map(({ phase, label }) => (
+						<TabsTrigger key={phase} value={phase}>
+							{label}
+							<Badge
+								variant={
+									phaseErrorCount(phase) > 0
+										? "destructive"
+										: "secondary"
+								}
+							>
+								{value[phase].length}
+							</Badge>
+						</TabsTrigger>
 					))}
-					<Button
-						type="button"
-						variant="outline"
-						size="sm"
-						className="w-fit"
-						onClick={() =>
-							updatePhase(phase, [
-								...value[phase],
-								createGuardrailReactor(phase),
-							])
-						}
-						disabled={disabled}
-						data-testid={`${testIdPrefix}-${phase}-add`}
-					>
-						<Plus className="h-4 w-4" />
-						Add Guardrail
-					</Button>
-				</div>
-			))}
+				</TabsList>
+
+				{PHASES.map(
+					({ phase, description, addLabel, emptyMessage }) => {
+						const entries = value[phase];
+						const argumentOptions = guardrailArgumentOptions({
+							method: value.method,
+							phase,
+							methods,
+							resultArgumentName,
+						});
+
+						return (
+							<TabsContent
+								key={phase}
+								value={phase}
+								// a small floor stops the panel collapsing when a
+								// rule with no checks in this phase is selected,
+								// without leaving dead space below the list
+								className="min-h-32 space-y-3"
+							>
+								<div className="flex flex-wrap items-center justify-between gap-2">
+									<Muted>{description}</Muted>
+									{entries.length > 0 && (
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											onClick={() =>
+												toggleAllEntries(phase)
+											}
+											data-testid={`${testIdPrefix}-${phase}-toggle-all`}
+										>
+											{hasExpandedEntry(phase) ? (
+												<>
+													<FoldVertical
+														className="size-4"
+														aria-hidden
+													/>
+													Collapse all
+												</>
+											) : (
+												<>
+													<UnfoldVertical
+														className="size-4"
+														aria-hidden
+													/>
+													Expand all
+												</>
+											)}
+										</Button>
+									)}
+								</div>
+
+								{entries.length === 0 ? (
+									<p className="rounded-md border border-dashed px-3 py-4 text-center text-muted-foreground text-xs">
+										{emptyMessage}
+									</p>
+								) : (
+									<Accordion
+										type="multiple"
+										value={expandedEntries[phase]}
+										onValueChange={(next) =>
+											setExpandedEntries((current) => ({
+												...current,
+												[phase]: next,
+											}))
+										}
+										className="space-y-3"
+									>
+										{entries.map((entry, index) => (
+											<GuardrailReactorEntryField
+												// Controllers are registered to the ordered slot, so
+												// keeping the slot mounted prevents stale registrations.
+												// biome-ignore lint/suspicious/noArrayIndexKey: The index identifies the form slot, not the guardrail entity.
+												key={`${phase}-${index}`}
+												value={entry}
+												onChange={(next) =>
+													updateEntry(
+														phase,
+														index,
+														next,
+													)
+												}
+												onRemove={() =>
+													removeEntry(
+														phase,
+														index,
+														entry.id,
+													)
+												}
+												onMoveUp={() =>
+													moveEntry(phase, index, -1)
+												}
+												onMoveDown={() =>
+													moveEntry(phase, index, 1)
+												}
+												index={index}
+												count={entries.length}
+												phase={phase}
+												engineDetails={engineDetails}
+												engineNames={engineNames}
+												onEngineResolved={
+													onEngineResolved
+												}
+												argumentOptions={
+													argumentOptions
+												}
+												issues={issues.filter(
+													(issue) =>
+														issue.phase === phase &&
+														issue.entryId ===
+															entry.id,
+												)}
+												disabled={disabled}
+												idPrefix={`${idPrefix}-${phase}-${index}`}
+												testIdPrefix={`${testIdPrefix}-${phase}-entry-${index}`}
+												namePrefix={`${namePrefix}.${phase}.${index}`}
+											/>
+										))}
+									</Accordion>
+								)}
+
+								{/* the new check is appended, so the control that
+								    adds it sits after the list */}
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => addEntry(phase)}
+									disabled={disabled}
+									data-testid={`${testIdPrefix}-${phase}-add`}
+								>
+									<Plus className="size-4" aria-hidden />
+									{addLabel}
+								</Button>
+							</TabsContent>
+						);
+					},
+				)}
+			</Tabs>
 		</div>
 	);
 };

--- a/packages/client/src/components/engine/guardrail-reactor-entry-field.tsx
+++ b/packages/client/src/components/engine/guardrail-reactor-entry-field.tsx
@@ -1,58 +1,121 @@
-import { ArrowDown, ArrowUp, ChevronsUpDown, X } from "lucide-react";
+import { AlertTriangle, Info, MoveDown, MoveUp, X } from "lucide-react";
 import {
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
 	Badge,
 	Button,
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-	Field,
-	FieldDescription,
-	FieldLabel,
-	Input,
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-	Switch,
+	FormInput,
+	FormRadioGroup,
+	FormSwitch,
+	Label,
+	Muted,
+	RadioGroupItem,
+	Separator,
 } from "@semoss/ui/next";
-import {
-	DEFAULT_MASK_TARGET_PARAM,
-	GUARDRAIL_REACTOR_OPTIONS,
-	type GuardrailPhase,
-	type GuardrailReactorFormValue,
+import type {
+	GuardrailConfigIssue,
+	GuardrailEngineDetails,
+	GuardrailFailureAction,
+	GuardrailPhase,
+	GuardrailReactorFormValue,
+	InterceptableMethodArgument,
 } from "./engine-guardrail-settings.constants";
 import { GuardrailDirectParametersField } from "./guardrail-direct-parameters-field";
+import { GuardrailEngineField } from "./guardrail-engine-field";
+import { useGuardrailEngineParameters } from "./guardrail-engine-parameters";
 import { GuardrailInputMappingField } from "./guardrail-input-mapping-field";
 
-export interface GuardrailEngineOption {
-	engine_id: string;
-	engine_name: string;
+export interface GuardrailReactorEntryFieldProps {
+	/** The check being edited. */
+	value: GuardrailReactorFormValue;
+
+	/** Replaces the check. */
+	onChange: (next: GuardrailReactorFormValue) => void;
+
+	/** Removes the check from its phase. */
+	onRemove: () => void;
+
+	/** Moves the check one place earlier in its phase. */
+	onMoveUp: () => void;
+
+	/** Moves the check one place later in its phase. */
+	onMoveDown: () => void;
+
+	/** Position within the phase. */
+	index: number;
+
+	/** Number of checks in the phase. */
+	count: number;
+
+	/** Phase this check runs in. */
+	phase: GuardrailPhase;
+
+	/** Backend resolved details for engine ids the config references, used to
+	 * flag engines that no longer resolve. */
+	engineDetails: Record<string, GuardrailEngineDetails>;
+
+	/** Display names for engine ids, keyed by id. */
+	engineNames: Record<string, string>;
+
+	/** Records the display name of a newly picked guardrail engine. */
+	onEngineResolved: (engineId: string, engineName: string) => void;
+
+	/** Arguments the rule's method exposes in this phase. */
+	argumentOptions: InterceptableMethodArgument[];
+
+	/** Problems that belong to this check. */
+	issues: GuardrailConfigIssue[];
+
+	/** Whether the fields accept edits. */
+	disabled?: boolean;
+
+	/** Prefix for this check's element ids. */
+	idPrefix: string;
+
+	/** Prefix for this check's test ids. */
+	testIdPrefix: string;
+
+	/** React Hook Form path for this check. */
+	namePrefix: string;
 }
 
-export interface GuardrailReactorEntryFieldProps {
-	value: GuardrailReactorFormValue;
-	onChange: (next: GuardrailReactorFormValue) => void;
-	onRemove: () => void;
-	onMoveUp: () => void;
-	onMoveDown: () => void;
-	index: number;
-	count: number;
-	phase: GuardrailPhase;
-	engineOptions: GuardrailEngineOption[];
-	enginesLoading: boolean;
-	/** Names for engine ids referenced by the config but missing from the
-	 * user's engine list, resolved by the backend. */
-	engineNameFallbacks: Record<string, string>;
-	disabled?: boolean;
-	idPrefix: string;
-	testIdPrefix: string;
-}
+const FAILURE_ACTION_OPTIONS: Array<{
+	value: GuardrailFailureAction;
+	label: string;
+	description: string;
+}> = [
+	{
+		value: "block",
+		label: "Block",
+		description: "Stop the engine call and return an error.",
+	},
+	{
+		value: "mask",
+		label: "Mask and continue",
+		description:
+			"Replace the guarded input with the guardrail's returned text.",
+	},
+	{
+		value: "respond",
+		label: "Return guardrail message",
+		description: "Skip the model and return the guardrail's message.",
+	},
+];
+
+const FAILURE_ACTION_BADGES: Record<GuardrailFailureAction, string> = {
+	block: "Blocks",
+	mask: "Masks",
+	respond: "Answers",
+};
+
+/** The mapping row that summarizes what a check reads. */
+const primaryMapping = (value: GuardrailReactorFormValue) =>
+	value.inputMapping[0];
 
 /**
- * Editor for one guardrail reactor entry inside a pipeline phase: the
- * guardrail engine, how it intercepts, what happens on failure, and the
- * advanced parameter wiring.
+ * Editor for one guardrail check inside a rule's phase: the guardrail engine,
+ * what happens when it flags the content, and how its parameters are fed.
  */
 export const GuardrailReactorEntryField = ({
 	value,
@@ -63,225 +126,285 @@ export const GuardrailReactorEntryField = ({
 	index,
 	count,
 	phase,
-	engineOptions,
-	enginesLoading,
-	engineNameFallbacks,
+	engineDetails,
+	engineNames,
+	onEngineResolved,
+	argumentOptions,
+	issues,
 	disabled,
 	idPrefix,
 	testIdPrefix,
+	namePrefix,
 }: GuardrailReactorEntryFieldProps) => {
 	const update = (partial: Partial<GuardrailReactorFormValue>) =>
 		onChange({ ...value, ...partial });
-
-	const reactorOptions = GUARDRAIL_REACTOR_OPTIONS[phase];
-	const selectedEngineIsMissing =
+	const parameters = useGuardrailEngineParameters(value.guardrailEngineId);
+	const details = engineDetails[value.guardrailEngineId];
+	const selectedEngineName = value.guardrailEngineId
+		? engineNames[value.guardrailEngineId] ||
+			details?.name ||
+			value.guardrailEngineId
+		: "No guardrail engine selected";
+	const engineIsGone = !!value.guardrailEngineId && details?.exists === false;
+	const engineIsHidden =
 		!!value.guardrailEngineId &&
-		!engineOptions.some(
-			(engine) => engine.engine_id === value.guardrailEngineId,
-		);
+		details?.exists !== false &&
+		details?.userCanView === false;
+	const errors = issues.filter((issue) => issue.severity === "error");
+	const warnings = issues.filter((issue) => issue.severity === "warning");
+	const mapping = primaryMapping(value);
 
 	return (
-		<div
-			className="space-y-3 rounded-md border p-3"
+		<AccordionItem
+			value={value.id}
+			className="overflow-hidden rounded-lg border bg-card last:border-b"
 			data-testid={testIdPrefix}
 		>
-			<div className="flex items-center gap-2">
-				<Badge variant="outline">#{index + 1}</Badge>
-				<div className="flex-1">
-					<Select
-						value={value.guardrailEngineId}
-						onValueChange={(guardrailEngineId) =>
-							update({ guardrailEngineId })
-						}
-						disabled={disabled || enginesLoading}
-					>
-						<SelectTrigger
-							id={`${idPrefix}-engine`}
-							className="w-full"
-							data-testid={`${testIdPrefix}-engine`}
-						>
-							<SelectValue
-								placeholder={
-									enginesLoading
-										? "Loading guardrail engines..."
-										: "Select a guardrail engine"
-								}
+			<div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-3">
+				<AccordionTrigger className="min-w-0 py-3 hover:no-underline">
+					<span className="flex min-w-0 flex-wrap items-center gap-2">
+						<Badge variant="outline">{index + 1}</Badge>
+						<span className="truncate font-medium text-sm">
+							{selectedEngineName}
+						</span>
+						<Badge variant="secondary">
+							{FAILURE_ACTION_BADGES[value.failureAction]}
+						</Badge>
+						{mapping?.key && mapping.args && (
+							<span className="truncate font-mono text-muted-foreground text-xs">
+								{mapping.key.trim()} &lt;- {mapping.args.trim()}
+							</span>
+						)}
+						{errors.length > 0 && (
+							<span
+								role="img"
+								className="size-2 shrink-0 rounded-full bg-destructive"
+								aria-label="Has a problem that blocks saving"
+								data-testid={`${testIdPrefix}-error-dot`}
 							/>
-						</SelectTrigger>
-						<SelectContent>
-							{selectedEngineIsMissing && (
-								<SelectItem value={value.guardrailEngineId}>
-									{engineNameFallbacks[
-										value.guardrailEngineId
-									] || value.guardrailEngineId}
-								</SelectItem>
-							)}
-							{engineOptions.map((engine) => (
-								<SelectItem
-									key={engine.engine_id}
-									value={engine.engine_id}
-								>
-									{engine.engine_name}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				</div>
-				<Button
-					type="button"
-					variant="ghost"
-					size="icon"
-					aria-label="Move guardrail up"
-					onClick={onMoveUp}
-					disabled={disabled || index === 0}
-					data-testid={`${testIdPrefix}-move-up`}
-				>
-					<ArrowUp className="h-4 w-4" />
-				</Button>
-				<Button
-					type="button"
-					variant="ghost"
-					size="icon"
-					aria-label="Move guardrail down"
-					onClick={onMoveDown}
-					disabled={disabled || index === count - 1}
-					data-testid={`${testIdPrefix}-move-down`}
-				>
-					<ArrowDown className="h-4 w-4" />
-				</Button>
-				<Button
-					type="button"
-					variant="ghost"
-					size="icon"
-					aria-label="Remove guardrail"
-					onClick={onRemove}
-					disabled={disabled}
-					data-testid={`${testIdPrefix}-remove`}
-				>
-					<X className="h-4 w-4" />
-				</Button>
-			</div>
-
-			<Field>
-				<FieldLabel htmlFor={`${idPrefix}-reactor-class`}>
-					Interception
-				</FieldLabel>
-				<Select
-					value={value.reactorClass}
-					onValueChange={(reactorClass) => update({ reactorClass })}
-					disabled={disabled || reactorOptions.length === 1}
-				>
-					<SelectTrigger
-						id={`${idPrefix}-reactor-class`}
-						className="w-full"
-					>
-						<SelectValue />
-					</SelectTrigger>
-					<SelectContent>
-						{reactorOptions.map((option) => (
-							<SelectItem key={option.value} value={option.value}>
-								{option.label}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-				{phase === "output" && (
-					<FieldDescription>
-						Output guardrails always check both the request and the
-						response.
-					</FieldDescription>
-				)}
-			</Field>
-
-			<div className="flex items-center gap-2">
-				<Switch
-					id={`${idPrefix}-block`}
-					checked={value.blockOnGuardrailFailure}
-					onCheckedChange={(blockOnGuardrailFailure) =>
-						update({ blockOnGuardrailFailure })
-					}
-					disabled={disabled}
-					data-testid={`${testIdPrefix}-block`}
-				/>
-				<FieldLabel htmlFor={`${idPrefix}-block`}>
-					Block the request when the guardrail fails
-				</FieldLabel>
-			</div>
-
-			<div className="flex items-center gap-2">
-				<Switch
-					id={`${idPrefix}-mask`}
-					checked={value.maskOnGuardrailFailure}
-					onCheckedChange={(maskOnGuardrailFailure) =>
-						update({ maskOnGuardrailFailure })
-					}
-					disabled={disabled}
-					data-testid={`${testIdPrefix}-mask`}
-				/>
-				<FieldLabel htmlFor={`${idPrefix}-mask`}>
-					Mask flagged content instead of blocking
-				</FieldLabel>
-			</div>
-
-			{value.maskOnGuardrailFailure && (
-				<Field>
-					<FieldLabel htmlFor={`${idPrefix}-mask-target`}>
-						Mask Target Parameter
-					</FieldLabel>
-					<Input
-						id={`${idPrefix}-mask-target`}
-						placeholder={DEFAULT_MASK_TARGET_PARAM}
-						value={value.maskTargetParam}
-						onChange={(event) =>
-							update({ maskTargetParam: event.target.value })
-						}
-						disabled={disabled}
-					/>
-					<FieldDescription>
-						The guardrail parameter whose masked value replaces the
-						original argument. It must be mapped to exactly one
-						argument below.
-					</FieldDescription>
-				</Field>
-			)}
-
-			<Collapsible>
-				<CollapsibleTrigger asChild>
+						)}
+					</span>
+				</AccordionTrigger>
+				<div className="flex items-center">
 					<Button
 						type="button"
 						variant="ghost"
-						size="sm"
-						className="w-fit px-2"
-						disabled={disabled}
-						data-testid={`${testIdPrefix}-advanced`}
+						size="icon-sm"
+						aria-label="Move guardrail up"
+						onClick={onMoveUp}
+						disabled={disabled || index === 0}
+						data-testid={`${testIdPrefix}-move-up`}
 					>
-						<ChevronsUpDown className="h-4 w-4" />
-						Advanced
+						<MoveUp className="size-4" aria-hidden />
 					</Button>
-				</CollapsibleTrigger>
-				<CollapsibleContent className="space-y-4 pt-2">
-					<GuardrailInputMappingField
-						value={value.inputMapping}
-						onChange={(inputMapping) => update({ inputMapping })}
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon-sm"
+						aria-label="Move guardrail down"
+						onClick={onMoveDown}
+						disabled={disabled || index === count - 1}
+						data-testid={`${testIdPrefix}-move-down`}
+					>
+						<MoveDown className="size-4" aria-hidden />
+					</Button>
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon-sm"
+						aria-label="Remove guardrail"
+						onClick={onRemove}
 						disabled={disabled}
-						idPrefix={idPrefix}
-						maskTargetParam={
-							value.maskOnGuardrailFailure
-								? value.maskTargetParam.trim() ||
-									DEFAULT_MASK_TARGET_PARAM
-								: null
-						}
-					/>
-					<GuardrailDirectParametersField
-						value={value.directParameters}
-						onChange={(directParameters) =>
-							update({ directParameters })
-						}
-						disabled={disabled}
-						idPrefix={idPrefix}
-					/>
-				</CollapsibleContent>
-			</Collapsible>
-		</div>
+						data-testid={`${testIdPrefix}-remove`}
+					>
+						<X className="size-4" aria-hidden />
+					</Button>
+				</div>
+			</div>
+
+			<AccordionContent className="px-4 pb-4">
+				{(errors.length > 0 || warnings.length > 0) && (
+					<ul className="mb-4 space-y-1">
+						{errors.map((issue) => (
+							<li
+								key={issue.message}
+								className="flex items-start gap-2 text-destructive text-xs"
+							>
+								<AlertTriangle
+									className="mt-0.5 size-3.5 shrink-0"
+									aria-hidden
+								/>
+								{issue.message}
+							</li>
+						))}
+						{warnings.map((issue) => (
+							<li
+								key={issue.message}
+								className="flex items-start gap-2 text-muted-foreground text-xs"
+							>
+								<Info
+									className="mt-0.5 size-3.5 shrink-0"
+									aria-hidden
+								/>
+								{issue.message}
+							</li>
+						))}
+					</ul>
+				)}
+
+				<div className="grid gap-6 lg:grid-cols-2">
+					<div className="space-y-4">
+						<GuardrailEngineField
+							name={`${namePrefix}.guardrailEngineId`}
+							engineName={
+								value.guardrailEngineId
+									? selectedEngineName
+									: ""
+							}
+							onEngineResolved={onEngineResolved}
+							disabled={disabled}
+							testIdPrefix={testIdPrefix}
+						/>
+
+						{engineIsGone && (
+							<p
+								className="flex items-start gap-2 text-destructive text-xs"
+								data-testid={`${testIdPrefix}-engine-missing`}
+							>
+								<AlertTriangle
+									className="mt-0.5 size-3.5 shrink-0"
+									aria-hidden
+								/>
+								<span>
+									This guardrail engine no longer exists.{" "}
+									<span className="font-mono">
+										{value.guardrailEngineId}
+									</span>{" "}
+									is not in the catalog, so this check cannot
+									run until another engine is chosen.
+								</span>
+							</p>
+						)}
+
+						{engineIsHidden && (
+							<p
+								className="flex items-start gap-2 text-destructive text-xs"
+								data-testid={`${testIdPrefix}-engine-hidden`}
+							>
+								<AlertTriangle
+									className="mt-0.5 size-3.5 shrink-0"
+									aria-hidden
+								/>
+								<span>
+									You cannot access this guardrail engine, so
+									saving is rejected until another engine is
+									chosen.
+								</span>
+							</p>
+						)}
+
+						<Separator />
+
+						{phase === "input" ? (
+							<FormRadioGroup
+								name={`${namePrefix}.failureAction`}
+								label="If flagged"
+								description="Choose exactly one outcome for flagged input."
+								className="gap-3"
+								disabled={disabled}
+							>
+								<div className="grid gap-3">
+									{FAILURE_ACTION_OPTIONS.map((option) => {
+										const optionId = `${idPrefix}-failure-${option.value}`;
+										return (
+											<Label
+												key={option.value}
+												htmlFor={optionId}
+												className="flex cursor-pointer items-start gap-3 rounded-md border p-3 has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5"
+											>
+												<RadioGroupItem
+													id={optionId}
+													value={option.value}
+													className="mt-0.5"
+												/>
+												<span className="space-y-1">
+													<span className="block font-medium text-sm">
+														{option.label}
+													</span>
+													<span className="block font-normal text-muted-foreground text-xs">
+														{option.description}
+													</span>
+												</span>
+											</Label>
+										);
+									})}
+								</div>
+							</FormRadioGroup>
+						) : (
+							<div className="rounded-md border bg-muted/30 p-3">
+								<h4 className="font-medium text-sm">
+									If flagged, block the response
+								</h4>
+								<Muted>
+									A response check runs after the model and
+									stops a flagged response from reaching the
+									caller. Blocking is the only outcome
+									available after the model has answered.
+								</Muted>
+							</div>
+						)}
+
+						{value.failureAction === "block" && (
+							<div className="space-y-3">
+								<FormSwitch
+									name={`${namePrefix}.closeRoomOnBlock`}
+									label="Close room after block"
+									description="Close the room after this guardrail blocks the call."
+									disabled={disabled}
+									className="rounded-md border p-3"
+									data-testid={`${testIdPrefix}-close-room`}
+								/>
+								<FormInput
+									name={`${namePrefix}.blockErrorMessage`}
+									label="Custom block message"
+									placeholder="The request was blocked by a guardrail."
+									description="Optional message returned when this guardrail blocks the call."
+									disabled={disabled}
+								/>
+							</div>
+						)}
+					</div>
+
+					<div className="space-y-6">
+						<GuardrailInputMappingField
+							value={value.inputMapping}
+							onChange={(inputMapping) =>
+								update({ inputMapping })
+							}
+							parameterOptions={parameters.options}
+							parametersStatus={parameters.status}
+							argumentOptions={argumentOptions}
+							disabled={disabled}
+							testIdPrefix={testIdPrefix}
+							namePrefix={`${namePrefix}.inputMapping`}
+						/>
+						<GuardrailDirectParametersField
+							value={value.directParameters}
+							onChange={(directParameters) =>
+								update({ directParameters })
+							}
+							parameterOptions={parameters.options}
+							parametersStatus={parameters.status}
+							mappedParameterNames={value.inputMapping.map(
+								(row) => row.key,
+							)}
+							disabled={disabled}
+							idPrefix={idPrefix}
+							namePrefix={`${namePrefix}.directParameters`}
+						/>
+					</div>
+				</div>
+			</AccordionContent>
+		</AccordionItem>
 	);
 };

--- a/packages/client/src/components/import/guardrail/guardrail-import-form.tsx
+++ b/packages/client/src/components/import/guardrail/guardrail-import-form.tsx
@@ -36,6 +36,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 	Separator,
+	Textarea,
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
@@ -555,6 +556,43 @@ export const GuardrailForm = ({
 			}}
 			render={({ field, fieldState: { error } }) => {
 				switch (val.type) {
+					case "textarea":
+						return (
+							<Field
+								className={
+									computeVisibility(val, {}) ? "" : "hidden"
+								}
+								data-testid={`guardrail-form-field-${val.key}`}
+							>
+								<FieldLabel htmlFor={val.key}>
+									{val.label}
+									{val.required && (
+										<span className="text-destructive">
+											{" "}
+											*
+										</span>
+									)}
+								</FieldLabel>
+								<Textarea
+									{...field}
+									id={val.key}
+									rows={5}
+									disabled={val.disabled}
+									data-testid={`guardrail-form-input-${val.key}`}
+								/>
+								{error && (
+									<FieldDescription className="text-destructive">
+										{getHelperText(error, val)}
+									</FieldDescription>
+								)}
+								{!error && val.helperText && (
+									<FieldDescription>
+										{val.helperText}
+									</FieldDescription>
+								)}
+							</Field>
+						);
+
 					case "text":
 						return (
 							<Field

--- a/packages/client/src/components/import/guardrail/guardrail-import.constants.ts
+++ b/packages/client/src/components/import/guardrail/guardrail-import.constants.ts
@@ -1,13 +1,14 @@
+import Brain from "@/assets/img/BRAIN.png";
 import Gliner from "@/assets/img/HUGGINGFACE_COLOR.svg";
 import Python from "@/assets/img/PYTHON.svg";
 export const GUARDRAIL_CONNECTION = {
 	description: {
 		General:
-			"Basic information about the storage catalog such as name, description, tags, type of storage, and high-level metadata.",
+			"Basic information used to identify the guardrail in the catalog.",
 		Settings:
-			"Configure your storage provider, index structure, dimensionality, and similarity metric to optimize retrieval accuracy and performance.",
+			"Configure how the guardrail evaluates content and which supporting engines it uses.",
 		Credentials:
-			"Provide your storage API key or connection details to securely enable indexing and search operations.",
+			"Provide any credentials required by the selected guardrail provider.",
 	},
 	GUARDRAIL: [
 		{
@@ -62,6 +63,7 @@ export const GUARDRAIL_CONNECTION = {
 					value: "EMBEDDED_GLINER",
 					type: "text",
 					disabled: true,
+					hidden: true,
 					required: false,
 					category: "Settings",
 				},
@@ -110,6 +112,7 @@ export const GUARDRAIL_CONNECTION = {
 					value: "EMBEDDED_DETOXIFY",
 					type: "text",
 					disabled: true,
+					hidden: true,
 					required: false,
 					category: "Settings",
 				},
@@ -203,6 +206,7 @@ export const GUARDRAIL_CONNECTION = {
 					value: "EMBEDDED_ON_TOPIC",
 					type: "text",
 					disabled: true,
+					hidden: true,
 					required: false,
 					category: "Settings",
 				},
@@ -211,7 +215,7 @@ export const GUARDRAIL_CONNECTION = {
 		{
 			name: "Aggressive / Self-Harm",
 			disable: false,
-			icon: Python,
+			icon: Brain,
 			description:
 				"Detects aggressive, violent, or self-harm content in user prompts by routing the check through a configured LLM.",
 			fields: [
@@ -254,15 +258,41 @@ export const GUARDRAIL_CONNECTION = {
 						"The LLM used to evaluate whether a prompt contains aggressive or self-harm content.",
 				},
 				{
-					key: "DEFAULT_THRESHOLD",
-					label: "Default Threshold",
-					value: "0.5",
-					type: "number",
+					key: "SYSTEM_PROMPT",
+					label: "System Prompt Override",
+					value: "",
+					type: "textarea",
 					disabled: false,
 					required: false,
 					category: "Settings",
 					helperText:
-						"Score threshold (0-1) above which a prompt is considered harmful. Defaults to 0.5.",
+						"Optional SAFE/UNSAFE classifier instructions. Leave empty to use the built-in self-harm and aggression prompt.",
+				},
+				{
+					key: "BLOCKED_MESSAGE",
+					label: "Blocked Message Override",
+					value: "",
+					type: "textarea",
+					disabled: false,
+					required: false,
+					category: "Settings",
+					helperText:
+						"Optional message returned when a pipeline is configured to respond on guardrail failure. Leave empty to use the built-in crisis response.",
+				},
+				{
+					key: "FAIL_OPEN",
+					label: "On Judge Error",
+					value: "false",
+					type: "select",
+					options: [
+						{ value: "false", display: "Block the call" },
+						{ value: "true", display: "Allow the call" },
+					],
+					disabled: false,
+					required: true,
+					category: "Settings",
+					helperText:
+						"Choose whether the protected operation is allowed when the judge model is unavailable or errors.",
 				},
 				{
 					key: "GUARDRAIL_TYPE",
@@ -270,6 +300,111 @@ export const GUARDRAIL_CONNECTION = {
 					value: "EMBEDDED_AGGRESSIVE_SELF_HARM",
 					type: "text",
 					disabled: true,
+					hidden: true,
+					required: false,
+					category: "Settings",
+				},
+			],
+		},
+		{
+			name: "Policy Compliance",
+			disable: false,
+			icon: Brain,
+			description:
+				"Uses an LLM judge to classify prompts, responses, or function data against a configurable policy.",
+			fields: [
+				{
+					key: "MODEL_NAME",
+					label: "Catalog Name",
+					value: "",
+					type: "text",
+					disabled: false,
+					required: true,
+					category: "General",
+					rules: {
+						pattern: {
+							value: /^[\w\-\s]+$/,
+							message:
+								"Catalog names can only contain alphanumeric characters and dashes.",
+						},
+						custom_rules: {
+							value: 'CheckEngineName ( "[VALUE]") ;',
+							message:
+								"This Catalog name has already been used, please try another.",
+						},
+					},
+				},
+				{
+					key: "MODEL_ENGINE_ID",
+					label: "Model Engine",
+					value: "",
+					type: "select",
+					options: [],
+					optionRule: {
+						pixel: `MyEngines(engineTypes=['MODEL']);`,
+						optionDisplay: "engine_name",
+						optionValue: "engine_id",
+					},
+					disabled: false,
+					required: true,
+					category: "Settings",
+					helperText:
+						"The LLM judge that classifies selected content as SAFE or UNSAFE.",
+				},
+				{
+					key: "POLICY_DESCRIPTION",
+					label: "Default Policy",
+					value: "",
+					type: "textarea",
+					disabled: false,
+					required: true,
+					category: "Settings",
+					helperText:
+						"Describe precisely what should be classified as UNSAFE. A pipeline can override this policy for an individual use case.",
+				},
+				{
+					key: "SYSTEM_PROMPT",
+					label: "System Prompt Override",
+					value: "",
+					type: "textarea",
+					disabled: false,
+					required: false,
+					category: "Settings",
+					helperText: `Optional judge instructions. Use \${POLICY_DESCRIPTION} where the configured or per-call policy should be inserted.`,
+				},
+				{
+					key: "BLOCKED_MESSAGE",
+					label: "Blocked Message",
+					value: "",
+					type: "textarea",
+					disabled: false,
+					required: false,
+					category: "Settings",
+					helperText:
+						"Optional message returned when an input pipeline responds instead of throwing on a policy failure.",
+				},
+				{
+					key: "FAIL_OPEN",
+					label: "On Judge Error",
+					value: "false",
+					type: "select",
+					options: [
+						{ value: "false", display: "Block the call" },
+						{ value: "true", display: "Allow the call" },
+					],
+					disabled: false,
+					required: true,
+					category: "Settings",
+					helperText:
+						"Block is recommended for sends and other irreversible operations. Allow preserves availability if the judge fails.",
+				},
+				{
+					key: "GUARDRAIL_TYPE",
+					label: "Guardrail Type",
+					value: "EMBEDDED_POLICY_COMPLIANCE",
+					type: "text",
+					disabled: true,
+					hidden: true,
 					required: false,
 					category: "Settings",
 				},
@@ -310,6 +445,7 @@ export const GUARDRAIL_CONNECTION = {
 					value: "LOCAL_PYTHON",
 					type: "text",
 					disabled: true,
+					hidden: true,
 					required: false,
 					category: "Settings",
 				},
@@ -419,6 +555,7 @@ export const GUARDRAIL_CONNECTION = {
 					value: "EMBEDDED_PERSPECTIVE_API",
 					type: "text",
 					disabled: true,
+					hidden: true,
 					required: false,
 					category: "Settings",
 				},
@@ -475,6 +612,7 @@ export const GUARDRAIL_CONNECTION = {
 					value: "EMBEDDED_OPENAI_MODERATION",
 					type: "text",
 					disabled: true,
+					hidden: true,
 					required: false,
 					category: "Settings",
 				},
@@ -531,6 +669,7 @@ export const GUARDRAIL_CONNECTION = {
 					value: "EMBEDDED_MICROSOFT_CONTENT_MODERATION",
 					type: "text",
 					disabled: true,
+					hidden: true,
 					required: false,
 					category: "Settings",
 				},
@@ -596,6 +735,7 @@ export const GUARDRAIL_CONNECTION = {
 					value: "EMBEDDED_NVIDIA_NEMO",
 					type: "text",
 					disabled: true,
+					hidden: true,
 					required: false,
 					category: "Settings",
 				},
@@ -654,6 +794,7 @@ export const GUARDRAIL_CONNECTION = {
 					value: "EMBEDDED_REBUFF",
 					type: "text",
 					disabled: true,
+					hidden: true,
 					required: false,
 					category: "Settings",
 				},
@@ -710,6 +851,7 @@ export const GUARDRAIL_CONNECTION = {
 					value: "EMBEDDED_LAKERA_GUARD",
 					type: "text",
 					disabled: true,
+					hidden: true,
 					required: false,
 					category: "Settings",
 				},
@@ -757,6 +899,7 @@ export const GUARDRAIL_CONNECTION = {
 					value: "EMBEDDED_PROMPTGUARD_META",
 					type: "text",
 					disabled: true,
+					hidden: true,
 					required: false,
 					category: "Settings",
 				},


### PR DESCRIPTION
## What this does

Rebuilds the model guardrail settings editor so a rule is configured from what the engine reports it can intercept, rather than from free-text fields where a typo silently produces a guardrail that screens nothing.

Pairs with SEMOSS/Semoss#2961, which adds the `interceptableMethods` metadata this relies on. The editor degrades to free-text entry when that field is absent, so it does not hard-depend on the backend shipping first.

## The problem

Two free-text fields decided whether a guardrail ran at all: the intercepted method name, and the argument each guardrail parameter read from. `askRom` instead of `askRoom`, or `arg1` instead of `arg0`, saved cleanly, looked correct, and screened nothing. There was no feedback until something got through in production.

The response payload also carried six fields the UI was discarding, including whether the engine loads a pipeline file at all and whether a referenced guardrail engine still exists. So "guardrails off" and "guardrails on with zero rules" looked identical, and a rule pointing at a deleted engine showed a raw UUID.

## Configuration is now picked, not typed

- **Applies to** lists the calls the engine reports as interceptable, showing the method names the backend sends. Calls another rule already covers are greyed out with `already covered`, so a duplicate cannot be created from the picker.
- **Inputs** picks the guardrail parameter from the engine's declared parameters and the argument from the selected method's real arguments, each labelled with its type and whether it holds text a guardrail can screen.
- Free text stays available behind an explicit `Another method...` / `Another argument or a dot path...` option, for calls exposed through another interface and for dot paths into map arguments.
- A new rule starts on a call nothing else covers, so it does not open already reporting a duplicate.

## State the editor now surfaces

- Guardrails not enabled for the engine, the configured pipeline file not existing, or enabled with no rules, each stated rather than left to be inferred from an empty editor.
- A stored file that could not be parsed, with its raw contents behind a disclosure and a copy button, since saving replaces it.
- A referenced guardrail engine that no longer exists or is inaccessible, flagged on the check instead of surfacing as a backend error at save.
- Warnings for configuration that saves cleanly but is unlikely to work: an argument name the method does not have, `result` in a request check, a plumbing argument like the `Room` feeding a text guardrail, or a call whose return value is not a model response.

## Validation

Validation returned the first problem as a bare string in a toast, so three bad rules meant three save attempts with no pointer to what to fix. It now collects every problem at once, tagged with the rule, phase, and check it belongs to, split into errors that block saving and warnings that do not. Each message navigates to the check it came from, and rules and phase tabs carry markers.

## Layout

The editor lives in a settings submenu, so it is built for a narrow column:

- One rule is edited at a time, selected from a top-level dropdown showing its check counts and error state. This replaces a left navigation rail that took a quarter of the width to duplicate what the method field already showed.
- Request and response checks are separated into tabs, with the add control after the list so a new check appears where it lands.
- A check's engine, failure action, inputs, and fixed values are all visible when it is expanded. The previous "Advanced parameter wiring" collapsible hid the wiring behind an extra click, and hid it entirely from read-only users.
- The guardrail engine picker is the shared `EngineSelect`, so options carry the same icon, name, and id as every other engine picker, and a long catalog stays searchable.
- The selected phase persists across rule switches, and the method field holds one height whatever is selected, so the panel does not jump.

## Also here

- Removing a rule asks for confirmation, since it takes all of its checks with it.
- Unsaved changes warn on reload or tab close. In-app navigation is not covered: that needs `useBlocker`, which requires the data router API this app does not use.
- The JSON view gained a copy button and only serializes while it is the active tab.
- Distinct icons for reorder versus collapse, which were both chevron pairs.
- `GUARDRAIL_TYPE` is hidden in the guardrail import form. It was an uneditable text input showing an internal value; it stays in the submitted payload, it is just no longer shown.
- `useFieldArray` is re-exported from `@semoss/ui/next` alongside the other react-hook-form primitives.

## A known backend gap

A guardrail whose declared parameter is a list, mapped from a method argument, will receive joined text rather than a list, because a guardrail reads a text parameter as a single value. Every built-in guardrail's list parameter is a fixed configuration value set through the fixed-values editor, which is unaffected, so this is theoretical today.

## Testing

Unit tests cover the pure helpers (response extraction, argument options, issue collection, the masking rule) and the component (tabs, rule selection and addition, duplicate blocking, the pickers, missing engines, parse failures, phase persistence, read-only inspection).

Worth clicking through before merge:

- add a rule, confirm it becomes the selected one and cannot claim a call already covered
- point a check at a guardrail engine, then delete that engine and reload
- open an engine with no pipeline file configured
