### PR TITLE
Agent Activity: Analyze tab (LLM-as-judge run assessment), graph fullscreen, collapsible detail panel

### DIFF
--- a/packages/client/src/pages/project/agent/agent-activity-types.ts
+++ b/packages/client/src/pages/project/agent/agent-activity-types.ts
@@ -148,6 +148,66 @@ export interface EngineInfo {
 	name: string;
 }
 
+/** Model engine option for the judge model select. */
+export interface JudgeModelOption {
+	engineId: string;
+	engineName: string;
+}
+
+/** One judge-scored dimension from AssessAgentEffectiveness. */
+export interface AssessmentDimension {
+	score?: number;
+	rationale?: string;
+}
+
+/**
+ * Structured judge output from AssessAgentEffectiveness. Every field is
+ * optional because the shape is produced by an LLM - render defensively.
+ */
+export interface AgentRunAssessment {
+	goalAchievement?: AssessmentDimension;
+	toolUseQuality?: AssessmentDimension;
+	efficiency?: AssessmentDimension;
+	skillUtilization?: AssessmentDimension;
+	communicationQuality?: AssessmentDimension;
+	overallScore?: number;
+	verdict?: string;
+	topIssues?: string[];
+	recommendations?: string[];
+	metricsDisagreements?: string[];
+}
+
+/** Full AssessAgentEffectiveness pixel output. */
+export interface AssessAgentEffectivenessOutput {
+	runId: string;
+	roomId?: string;
+	harnessType?: string;
+	judgeModelId: string;
+	/** null when the judge response was not parseable JSON - see assessmentRaw. */
+	assessment: AgentRunAssessment | null;
+	assessmentRaw?: string;
+	parseError?: string;
+	judgeUsage?: {
+		promptTokens?: number;
+		responseTokens?: number;
+	};
+	metrics?: Record<string, unknown>;
+}
+
+/**
+ * Lifecycle of one run's assessment. Keyed by runId in the graph so results
+ * survive switching between nodes while another assessment is in flight.
+ */
+export type RunAssessmentState =
+	| { status: "running"; judgeModelId: string }
+	| {
+			status: "done";
+			judgeModelId: string;
+			elapsedMs: number;
+			output: AssessAgentEffectivenessOutput;
+	  }
+	| { status: "error"; judgeModelId: string; message: string };
+
 export const toMs = (dateStr: string | undefined): number =>
 	dateStr && dayjs.utc(dateStr).isValid()
 		? dayjs.utc(dateStr).valueOf()

--- a/packages/client/src/pages/project/agent/agent-run-assessment.tsx
+++ b/packages/client/src/pages/project/agent/agent-run-assessment.tsx
@@ -1,0 +1,375 @@
+import { AlertTriangle, ChevronRight, Copy, Sparkles } from "lucide-react";
+import { useState } from "react";
+import {
+	Button,
+	Code,
+	CodeContainer,
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+	Input,
+	Progress,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	Spinner,
+	toast,
+} from "@semoss/ui/next";
+import type {
+	AgentRunAssessment,
+	AgentRunDetail,
+	AssessAgentEffectivenessOutput,
+	AssessmentDimension,
+	EngineInfo,
+	JudgeModelOption,
+	RunAssessmentState,
+} from "./agent-activity-types";
+import { toPrettyJson } from "./agent-activity-types";
+
+const DIMENSIONS: {
+	key: keyof Pick<
+		AgentRunAssessment,
+		| "goalAchievement"
+		| "toolUseQuality"
+		| "efficiency"
+		| "skillUtilization"
+		| "communicationQuality"
+	>;
+	label: string;
+}[] = [
+	{ key: "goalAchievement", label: "Goal achievement" },
+	{ key: "toolUseQuality", label: "Tool use quality" },
+	{ key: "efficiency", label: "Efficiency" },
+	{ key: "skillUtilization", label: "Skill utilization" },
+	{ key: "communicationQuality", label: "Communication" },
+];
+
+/** 0-10 dimension score, or null when the judge omitted/mistyped it. */
+const scoreOf = (dimension?: AssessmentDimension): number | null =>
+	typeof dimension?.score === "number" && Number.isFinite(dimension.score)
+		? Math.max(0, Math.min(10, dimension.score))
+		: null;
+
+/** 0-100 overall score, or null when the judge omitted/mistyped it. */
+const overallScoreOf = (assessment: AgentRunAssessment): number | null =>
+	typeof assessment.overallScore === "number" &&
+	Number.isFinite(assessment.overallScore)
+		? Math.max(0, Math.min(100, assessment.overallScore))
+		: null;
+
+const stringItems = (values?: string[]): string[] =>
+	Array.isArray(values)
+		? values.filter(
+				(value): value is string =>
+					typeof value === "string" && value.trim().length > 0,
+			)
+		: [];
+
+const BulletSection = ({ title, items }: { title: string; items: string[] }) =>
+	items.length > 0 ? (
+		<div>
+			<p className="mb-1 font-medium text-xs">{title}</p>
+			<ul className="flex list-disc flex-col gap-1 pl-4 text-muted-foreground text-xs">
+				{items.map((item) => (
+					<li key={item}>{item}</li>
+				))}
+			</ul>
+		</div>
+	) : null;
+
+export interface AnalyzeRunPanelProps {
+	/** The run the assessment targets. Key the panel by its runId. */
+	run: AgentRunDetail;
+	/** Model engine id -> display info resolved via GetEngineMetadata. */
+	engineInfo: Record<string, EngineInfo>;
+	/** Judge model options from MyEngines; null while the fetch is in flight. */
+	judgeModels: JudgeModelOption[] | null;
+	/** This run's assessment lifecycle, owned by the graph so it survives node switches. */
+	state?: RunAssessmentState;
+	onAnalyze: (
+		run: AgentRunDetail,
+		judgeModelId: string,
+		focus: string,
+	) => void;
+}
+
+/**
+ * "Analyze" tab of the run graph detail panel - runs AssessAgentEffectiveness
+ * (LLM-as-judge over the run transcript plus deterministic metrics) with a
+ * caller-picked judge model and optional focus, and renders the structured
+ * assessment it returns.
+ */
+export const AnalyzeRunPanel = ({
+	run,
+	engineInfo,
+	judgeModels,
+	state,
+	onAnalyze,
+}: AnalyzeRunPanelProps) => {
+	const [judgeModelId, setJudgeModelId] = useState<string>(run.modelId ?? "");
+	const [focus, setFocus] = useState("");
+
+	const loadingModels = judgeModels === null;
+	const options = judgeModels ?? [];
+	// The run's own model can be missing from the text-generation list (e.g.
+	// untagged engine) - surface it anyway so the default selection has a label.
+	const runModelListed =
+		!run.modelId ||
+		options.some((option) => option.engineId === run.modelId);
+	const running = state?.status === "running";
+
+	const resolveModelName = (engineId: string): string =>
+		options.find((option) => option.engineId === engineId)?.engineName ??
+		engineInfo[engineId]?.name ??
+		engineId;
+
+	const handleCopy = async (output: AssessAgentEffectivenessOutput) => {
+		try {
+			await navigator.clipboard.writeText(toPrettyJson(output));
+			toast.success("Assessment copied to clipboard");
+		} catch (error) {
+			console.error("Error copying assessment:", error);
+			toast.error("Unable to copy to clipboard");
+		}
+	};
+
+	return (
+		<div className="flex flex-col gap-3">
+			<div>
+				<p
+					className="truncate font-medium text-sm"
+					title={run.input || run.runId}
+				>
+					{run.input || run.runId}
+				</p>
+				<p
+					className="truncate font-mono text-[10px] text-muted-foreground"
+					title={run.runId}
+				>
+					{run.runId}
+				</p>
+			</div>
+
+			<Select
+				value={judgeModelId}
+				onValueChange={setJudgeModelId}
+				disabled={loadingModels || running}
+			>
+				<SelectTrigger className="w-full">
+					<SelectValue
+						placeholder={
+							loadingModels
+								? "Loading models..."
+								: "Select judge model"
+						}
+					/>
+				</SelectTrigger>
+				<SelectContent>
+					{!runModelListed && run.modelId && (
+						<SelectItem value={run.modelId}>
+							{engineInfo[run.modelId]?.name ?? run.modelId}
+						</SelectItem>
+					)}
+					{options.map((option) => (
+						<SelectItem
+							key={option.engineId}
+							value={option.engineId}
+						>
+							{option.engineName}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+
+			<div className="flex items-center gap-2">
+				<Input
+					value={focus}
+					placeholder="Focus on something (optional)"
+					disabled={running}
+					onChange={(event) => setFocus(event.target.value)}
+				/>
+				<Button
+					size="sm"
+					className="shrink-0"
+					disabled={running || !judgeModelId}
+					onClick={() => onAnalyze(run, judgeModelId, focus)}
+				>
+					<Sparkles className="size-4" />
+					Analyze
+				</Button>
+			</div>
+
+			{!state && (
+				<p className="text-muted-foreground text-xs">
+					Runs an LLM-as-judge assessment of this run - goal
+					achievement, tool use quality, efficiency, skill
+					utilization, and communication - grounded in metrics
+					computed from the transcript.
+				</p>
+			)}
+
+			{state?.status === "running" && (
+				<div className="flex items-center gap-2 rounded-lg border bg-muted/40 p-3 text-muted-foreground text-xs">
+					<Spinner className="shrink-0" />
+					Assessing with {resolveModelName(state.judgeModelId)}...
+					this can take a minute.
+				</div>
+			)}
+
+			{state?.status === "error" && (
+				<div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-destructive text-xs">
+					<p className="mb-1 flex items-center gap-1 font-medium">
+						<AlertTriangle className="size-3.5 shrink-0" />
+						Assessment failed
+					</p>
+					<p className="whitespace-pre-wrap">{state.message}</p>
+				</div>
+			)}
+
+			{state?.status === "done" && (
+				<AssessmentResult
+					state={state}
+					judgeModelName={resolveModelName(state.judgeModelId)}
+					onCopy={handleCopy}
+				/>
+			)}
+		</div>
+	);
+};
+
+const AssessmentResult = ({
+	state,
+	judgeModelName,
+	onCopy,
+}: {
+	state: Extract<RunAssessmentState, { status: "done" }>;
+	judgeModelName: string;
+	onCopy: (output: AssessAgentEffectivenessOutput) => void;
+}) => {
+	const { output } = state;
+	const assessment = output.assessment;
+	const overall = assessment ? overallScoreOf(assessment) : null;
+
+	return (
+		<>
+			{assessment ? (
+				<>
+					{overall !== null && (
+						<div className="flex flex-col gap-1.5 rounded-lg border bg-muted/40 p-3">
+							<div className="flex items-baseline justify-between gap-2">
+								<span className="font-medium text-muted-foreground text-xs">
+									Overall score
+								</span>
+								<span className="font-semibold text-lg">
+									{overall}
+									<span className="font-normal text-muted-foreground text-xs">
+										{" "}
+										/ 100
+									</span>
+								</span>
+							</div>
+							<Progress value={overall} />
+						</div>
+					)}
+					{assessment.verdict && (
+						<p className="text-sm">{assessment.verdict}</p>
+					)}
+					<div className="flex flex-col gap-2.5">
+						{DIMENSIONS.map(({ key, label }) => {
+							const dimension = assessment[key];
+							const score = scoreOf(dimension);
+							if (score === null && !dimension?.rationale) {
+								return null;
+							}
+							return (
+								<div key={key} className="flex flex-col gap-1">
+									<div className="flex items-center justify-between gap-2 text-xs">
+										<span className="font-medium">
+											{label}
+										</span>
+										{score !== null && (
+											<span className="text-muted-foreground">
+												{score}/10
+											</span>
+										)}
+									</div>
+									{score !== null && (
+										<Progress
+											value={score * 10}
+											className="h-1.5"
+										/>
+									)}
+									{dimension?.rationale && (
+										<p className="text-muted-foreground text-xs">
+											{dimension.rationale}
+										</p>
+									)}
+								</div>
+							);
+						})}
+					</div>
+					<BulletSection
+						title="Top issues"
+						items={stringItems(assessment.topIssues)}
+					/>
+					<BulletSection
+						title="Recommendations"
+						items={stringItems(assessment.recommendations)}
+					/>
+					<BulletSection
+						title="Metric disagreements"
+						items={stringItems(assessment.metricsDisagreements)}
+					/>
+				</>
+			) : (
+				<div className="flex flex-col gap-2">
+					<p className="flex items-center gap-1 text-destructive text-xs">
+						<AlertTriangle className="size-3.5 shrink-0" />
+						{output.parseError ??
+							"The judge did not return structured output."}
+					</p>
+					{output.assessmentRaw && (
+						<CodeContainer className="max-h-64 overflow-auto bg-muted text-xs">
+							<Code code={output.assessmentRaw} language="text" />
+						</CodeContainer>
+					)}
+				</div>
+			)}
+
+			{output.metrics && (
+				<Collapsible>
+					<CollapsibleTrigger className="group flex items-center gap-1 font-medium text-muted-foreground text-xs">
+						<ChevronRight className="size-3.5 transition-transform group-data-[state=open]:rotate-90" />
+						Deterministic metrics
+					</CollapsibleTrigger>
+					<CollapsibleContent className="pt-2">
+						<CodeContainer className="max-h-64 overflow-auto bg-muted text-xs">
+							<Code
+								code={toPrettyJson(output.metrics)}
+								language="json"
+							/>
+						</CodeContainer>
+					</CollapsibleContent>
+				</Collapsible>
+			)}
+
+			<div className="flex items-center justify-between gap-2 border-t pt-2 text-muted-foreground text-xs">
+				<span className="min-w-0 truncate">
+					Generated by {judgeModelName} in{" "}
+					{(state.elapsedMs / 1000).toFixed(1)}s
+				</span>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="shrink-0"
+					onClick={() => onCopy(output)}
+				>
+					<Copy className="size-3.5" />
+					Copy
+				</Button>
+			</div>
+		</>
+	);
+};

--- a/packages/client/src/pages/project/agent/agent-run-graph.tsx
+++ b/packages/client/src/pages/project/agent/agent-run-graph.tsx
@@ -10,31 +10,44 @@ import {
 	ReactFlow,
 } from "@xyflow/react";
 import type { ReactNode } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import "@xyflow/react/dist/style.css";
 import {
 	Bot,
 	Brain,
 	CheckCircle2,
+	Maximize2,
 	MessageSquare,
+	Minimize2,
+	PanelRightClose,
+	PanelRightOpen,
 	User,
 	Wrench,
 	XCircle,
 } from "lucide-react";
 import {
 	Badge,
+	Button,
 	Code,
 	CodeContainer,
 	cn,
 	Markdown,
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
 	TreeView,
 	TreeViewItem,
 	useTheme,
 } from "@semoss/ui/next";
+import { useRootStore } from "@/hooks";
 import type {
 	AgentRunDetail,
+	AssessAgentEffectivenessOutput,
 	EngineInfo,
+	JudgeModelOption,
 	RoomRunDetail,
+	RunAssessmentState,
 	SubagentRunNode,
 	TranscriptToolCall,
 	TranscriptToolResult,
@@ -47,6 +60,7 @@ import {
 	toPrettyJson,
 	tryParseJson,
 } from "./agent-activity-types";
+import { AnalyzeRunPanel } from "./agent-run-assessment";
 
 // GRAPH DATA TYPES
 
@@ -73,7 +87,13 @@ type GraphSelection =
 	| { kind: "run"; run: RoomRunDetail }
 	| { kind: "subagent"; run: SubagentRunNode }
 	| { kind: "subroom"; roomId: string; run: SubagentRunNode }
-	| { kind: "tool"; toolName: string; invocations: ToolInvocation[] };
+	| {
+			kind: "tool";
+			toolName: string;
+			invocations: ToolInvocation[];
+			/** The run that made these calls - the Analyze tab's target. */
+			run: AgentRunDetail;
+	  };
 
 interface LayoutTreeNode {
 	id: string;
@@ -206,7 +226,7 @@ const buildToolTreeNodes = (run: AgentRunDetail): LayoutTreeNode[] =>
 					? "FAILED"
 					: undefined,
 			},
-			selection: { kind: "tool" as const, toolName, invocations },
+			selection: { kind: "tool" as const, toolName, invocations, run },
 			children: [],
 		}),
 	);
@@ -905,10 +925,18 @@ interface AgentRunGraphProps {
 	engineInfo?: Record<string, EngineInfo>;
 }
 
+/** Subset of the MyEngines output the judge model select reads. */
+interface ModelEngineOutput {
+	engine_id: string;
+	engine_name: string;
+	engine_display_name?: string;
+}
+
 /**
  * Node-graph view of a room's agent activity: room -> agent runs -> tool
  * calls and (recursive) sub-agent runs, with a detail panel for the selected
- * node. Render with key={roomId} so selection resets when the room changes.
+ * node (Inspect the transcript, or Analyze the run via LLM-as-judge).
+ * Render with key={roomId} so selection resets when the room changes.
  */
 export const AgentRunGraph = ({
 	roomId,
@@ -917,6 +945,7 @@ export const AgentRunGraph = ({
 	engineInfo = {},
 }: AgentRunGraphProps) => {
 	const { resolvedTheme } = useTheme();
+	const { monolithStore } = useRootStore();
 	const isDarkTheme = resolvedTheme === "dark";
 
 	const { nodes, edges, selectionById } = useMemo(
@@ -925,10 +954,143 @@ export const AgentRunGraph = ({
 	);
 
 	const [selectedNodeId, setSelectedNodeId] = useState<string>("room-root");
+	const [detailTab, setDetailTab] = useState<"inspect" | "analyze">(
+		"inspect",
+	);
+	const [isPanelOpen, setIsPanelOpen] = useState(true);
+	const [isFullscreen, setIsFullscreen] = useState(false);
+	// Keyed by runId so results survive switching nodes/tabs, and an in-flight
+	// assessment lands even if its run is no longer selected when it finishes.
+	const [assessments, setAssessments] = useState<
+		Record<string, RunAssessmentState>
+	>({});
+	const [judgeModels, setJudgeModels] = useState<JudgeModelOption[] | null>(
+		null,
+	);
+
 	const selection = selectionById.get(selectedNodeId) ?? null;
 
+	// Every selection maps to the run the Analyze tab would assess: the run
+	// itself, the run that owns the selected tool/sub-room node, or - for the
+	// room node - its lone run when there is exactly one.
+	const analyzeTarget = useMemo((): AgentRunDetail | null => {
+		if (!selection || selection.kind === "room") {
+			const roomRuns = selection?.kind === "room" ? selection.runs : runs;
+			return roomRuns.length === 1 ? roomRuns[0] : null;
+		}
+		return selection.run;
+	}, [selection, runs]);
+
+	useEffect(() => {
+		let cancelled = false;
+		monolithStore
+			.runQuery<[ModelEngineOutput[]]>(
+				`MyEngines(metaKeys=[], metaFilters=[{"tag":"text-generation"}], engineTypes=["MODEL"]);`,
+			)
+			.then((response) => {
+				const { operationType, output } = response.pixelReturn[0];
+				if (operationType.indexOf("ERROR") > -1) {
+					throw new Error(String(output));
+				}
+				if (!cancelled) {
+					setJudgeModels(
+						(output ?? []).map((engine) => ({
+							engineId: engine.engine_id,
+							engineName:
+								engine.engine_display_name ||
+								engine.engine_name,
+						})),
+					);
+				}
+			})
+			.catch((error) => {
+				console.error("Error fetching judge model options:", error);
+				// An empty list still renders the select (with the run's own
+				// model appended) instead of a permanent loading state.
+				if (!cancelled) {
+					setJudgeModels([]);
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [monolithStore]);
+
+	useEffect(() => {
+		if (!isFullscreen) {
+			return;
+		}
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				setIsFullscreen(false);
+			}
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => {
+			window.removeEventListener("keydown", handleKeyDown);
+		};
+	}, [isFullscreen]);
+
+	const startAssessment = useCallback(
+		async (run: AgentRunDetail, judgeModelId: string, focus: string) => {
+			const runId = run.runId;
+			setAssessments((prev) => ({
+				...prev,
+				[runId]: { status: "running", judgeModelId },
+			}));
+			const startMs = performance.now();
+			try {
+				const args = [
+					`runId=["${runId}"]`,
+					`judgeModelId=["${judgeModelId}"]`,
+				];
+				const trimmedFocus = focus.trim();
+				if (trimmedFocus) {
+					args.push(`focus=[${JSON.stringify(trimmedFocus)}]`);
+				}
+				const response = await monolithStore.runQuery<
+					[AssessAgentEffectivenessOutput]
+				>(`AssessAgentEffectiveness(${args.join(", ")});`);
+				const { operationType, output } = response.pixelReturn[0];
+				if (operationType.indexOf("ERROR") > -1) {
+					throw new Error(String(output));
+				}
+				setAssessments((prev) => ({
+					...prev,
+					[runId]: {
+						status: "done",
+						judgeModelId,
+						elapsedMs: performance.now() - startMs,
+						output,
+					},
+				}));
+			} catch (error) {
+				console.error("Error assessing agent run:", error);
+				setAssessments((prev) => ({
+					...prev,
+					[runId]: {
+						status: "error",
+						judgeModelId,
+						message:
+							error instanceof Error
+								? error.message
+								: String(error),
+					},
+				}));
+			}
+		},
+		[monolithStore],
+	);
+
 	return (
-		<div className="flex h-[600px] overflow-hidden rounded-xl border">
+		<div
+			className={cn(
+				"flex overflow-hidden border",
+				isFullscreen
+					? "fixed inset-0 z-50 bg-background"
+					: "h-[600px] rounded-xl",
+			)}
+		>
 			<div className="relative min-w-0 flex-1">
 				<ReactFlow
 					nodes={nodes}
@@ -960,42 +1122,121 @@ export const AgentRunGraph = ({
 						</div>
 					))}
 				</div>
+				<div className="absolute top-2 right-2 z-10 flex gap-1.5">
+					<Button
+						variant="outline"
+						size="icon-sm"
+						className="bg-card/95 shadow-sm backdrop-blur"
+						title={
+							isFullscreen ? "Exit full screen" : "Full screen"
+						}
+						onClick={() => setIsFullscreen((prev) => !prev)}
+					>
+						{isFullscreen ? (
+							<Minimize2 className="size-4" />
+						) : (
+							<Maximize2 className="size-4" />
+						)}
+					</Button>
+					<Button
+						variant="outline"
+						size="icon-sm"
+						className="bg-card/95 shadow-sm backdrop-blur"
+						title={
+							isPanelOpen
+								? "Hide details panel"
+								: "Show details panel"
+						}
+						onClick={() => setIsPanelOpen((prev) => !prev)}
+					>
+						{isPanelOpen ? (
+							<PanelRightClose className="size-4" />
+						) : (
+							<PanelRightOpen className="size-4" />
+						)}
+					</Button>
+				</div>
 			</div>
-			<div className="w-[380px] shrink-0 overflow-y-auto border-l bg-background p-4">
-				{selection?.kind === "run" && (
-					<RunDetailPanel
-						run={selection.run}
-						title="Agent run"
-						engineInfo={engineInfo}
-					/>
-				)}
-				{selection?.kind === "subagent" && (
-					<RunDetailPanel
-						run={selection.run}
-						title="Sub-agent run"
-						engineInfo={engineInfo}
-					/>
-				)}
-				{selection?.kind === "subroom" && (
-					<SubroomDetailPanel
-						roomId={selection.roomId}
-						run={selection.run}
-					/>
-				)}
-				{selection?.kind === "tool" && (
-					<ToolDetailPanel
-						toolName={selection.toolName}
-						invocations={selection.invocations}
-					/>
-				)}
-				{(!selection || selection.kind === "room") && (
-					<RoomDetailPanel
-						roomId={roomId}
-						roomName={roomName}
-						runs={runs}
-					/>
-				)}
-			</div>
+			{isPanelOpen && (
+				<div className="flex w-[380px] shrink-0 flex-col border-l bg-background">
+					<Tabs
+						value={detailTab}
+						onValueChange={(value) =>
+							setDetailTab(value as "inspect" | "analyze")
+						}
+						className="flex min-h-0 flex-1 flex-col gap-0"
+					>
+						<div className="border-b p-3">
+							<TabsList className="w-full">
+								<TabsTrigger value="inspect">
+									Inspect
+								</TabsTrigger>
+								<TabsTrigger value="analyze">
+									Analyze
+								</TabsTrigger>
+							</TabsList>
+						</div>
+						<TabsContent
+							value="inspect"
+							className="min-h-0 flex-1 overflow-y-auto p-4"
+						>
+							{selection?.kind === "run" && (
+								<RunDetailPanel
+									run={selection.run}
+									title="Agent run"
+									engineInfo={engineInfo}
+								/>
+							)}
+							{selection?.kind === "subagent" && (
+								<RunDetailPanel
+									run={selection.run}
+									title="Sub-agent run"
+									engineInfo={engineInfo}
+								/>
+							)}
+							{selection?.kind === "subroom" && (
+								<SubroomDetailPanel
+									roomId={selection.roomId}
+									run={selection.run}
+								/>
+							)}
+							{selection?.kind === "tool" && (
+								<ToolDetailPanel
+									toolName={selection.toolName}
+									invocations={selection.invocations}
+								/>
+							)}
+							{(!selection || selection.kind === "room") && (
+								<RoomDetailPanel
+									roomId={roomId}
+									roomName={roomName}
+									runs={runs}
+								/>
+							)}
+						</TabsContent>
+						<TabsContent
+							value="analyze"
+							className="min-h-0 flex-1 overflow-y-auto p-4"
+						>
+							{analyzeTarget ? (
+								<AnalyzeRunPanel
+									key={analyzeTarget.runId}
+									run={analyzeTarget}
+									engineInfo={engineInfo}
+									judgeModels={judgeModels}
+									state={assessments[analyzeTarget.runId]}
+									onAnalyze={startAssessment}
+								/>
+							) : (
+								<p className="text-muted-foreground text-sm">
+									Select an agent run or sub-agent node to
+									analyze it.
+								</p>
+							)}
+						</TabsContent>
+					</Tabs>
+				</div>
+			)}
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary

Adds run-effectiveness analysis to the Agent Activity execution graph. The right-hand detail panel
now has **Inspect | Analyze** tabs: Inspect is the existing transcript/detail view, and Analyze runs
the new `AssessAgentEffectiveness` Pixel (LLM-as-judge over the run transcript plus deterministic
metrics) against the selected run, with a caller-picked judge model and an optional focus prompt.
The graph itself gains a fullscreen toggle and the detail panel can be collapsed.

Depends on the Semoss `agent-run-effectiveness` branch, which ships the
`AssessAgentEffectiveness` reactor.

### Analyze tab

- **Judge model select** — text-generation `MODEL` engines via `MyEngines`, defaulting to the model
  that executed the run. If the run's model isn't in the tagged list (e.g. untagged engine), it is
  appended as an option so the default selection always has a label.
- **Focus input** — optional free-text emphasis ("Focus on something (optional)"), passed through as
  the reactor's `focus` param.
- **Results** — rendered from the reactor's structured output: overall score /100 with a progress
  bar, the judge's verdict, five dimension scores (goal achievement, tool use quality, efficiency,
  skill utilization, communication) each with a bar and rationale, top issues, recommendations, and
  any disagreements the judge flags with the deterministic numbers. The deterministic metrics ride
  along in a collapsible JSON block, and a footer shows "Generated by {model} in {n}s" with a Copy
  button (copies the full output as JSON). When the judge returns unparseable output, the raw text
  is shown with the parse error instead of failing silently.
- **Target resolution** — clicking any node inside a run's subtree targets that run: tool nodes now
  carry their owning run in the graph selection, sub-agent and sub-room nodes resolve to their run,
  and the room node resolves to its lone run when the room has exactly one.
- **State survives navigation** — assessment lifecycle (running/done/error) is owned by the graph
  component keyed by runId, so switching nodes or tabs mid-assessment doesn't lose the request, and
  a finished assessment is still there when you come back to the run.

### Graph chrome

- **Fullscreen** — toggle button overlaid top-right of the graph; CSS overlay (`fixed inset-0`),
  Escape also exits.
- **Collapsible detail panel** — second toggle next to fullscreen hides/shows the 380px right panel;
  the button lives on the graph overlay so it stays reachable while collapsed.

### Files

- `packages/client/src/pages/project/agent/agent-run-assessment.tsx` (new) — `AnalyzeRunPanel`:
  judge model select, focus input, and assessment rendering.
- `packages/client/src/pages/project/agent/agent-run-graph.tsx` — Inspect/Analyze tabs, fullscreen,
  panel collapse, per-run assessment state + the `AssessAgentEffectiveness` call, judge model fetch,
  tool selections carry their owning run.
- `packages/client/src/pages/project/agent/agent-activity-types.ts` — types for the reactor output
  (`AssessAgentEffectivenessOutput`, `AgentRunAssessment`) and the per-run assessment lifecycle.