### PR TITLE
feat: guardrail log out

### DIFF
--- a/libs/i18n/src/resources/locales/en/common.json
+++ b/libs/i18n/src/resources/locales/en/common.json
@@ -58,6 +58,11 @@
 		"logOut": "Log out",
 		"acknowledge": "Acknowledge"
 	},
+	"sessionRevoked": {
+		"title": "You have been signed out",
+		"body": "You have been signed out. Please contact support for assistance.",
+		"action": "Return to sign in"
+	},
 	"pagination": {
 		"rowsPerPage": "Rows per page:"
 	},

--- a/libs/sdk/src/api/base.ts
+++ b/libs/sdk/src/api/base.ts
@@ -1,5 +1,5 @@
 import { Env } from "../env";
-import { CSRF, get, post } from "../utility";
+import { CSRF, get, notifySessionRevoked, post } from "../utility";
 /**
  * Get the System's configuration information
  */
@@ -86,6 +86,9 @@ export const runPixel = async <O extends unknown[] | []>(
 		if (operationType.indexOf("ERROR") > -1) {
 			errors.push(output as string);
 		}
+		if (operationType.indexOf("USER_LOGGED_OUT_ERROR") > -1) {
+			notifySessionRevoked(output as string);
+		}
 	}
 
 	return {
@@ -163,6 +166,9 @@ export const getPixelAsyncResult = async <O extends unknown[] | []>(
 
 		if (operationType.indexOf("ERROR") > -1) {
 			errors.push(output as string);
+		}
+		if (operationType.indexOf("USER_LOGGED_OUT_ERROR") > -1) {
+			notifySessionRevoked(output as string);
 		}
 	}
 

--- a/libs/sdk/src/utility/fetch.ts
+++ b/libs/sdk/src/utility/fetch.ts
@@ -134,6 +134,42 @@ const interceptors: {
 };
 
 /**
+ * Registered once by the app so the SDK can report a guardrail block that
+ * also force-logged the user out (USER_LOGGED_OUT_ERROR op type), without the
+ * SDK depending on any UI framework. Mirrors the CSRF/interceptors module
+ * state above.
+ */
+let sessionRevokedHandler: ((message: string) => void) | null = null;
+
+/** Fires at most once per session — a multi-statement pixel, a retry, or two
+ * concurrent calls can all carry the op type, but the app should only ever
+ * see one notification. Effectively terminal, the same way handleHeaderRedirect's
+ * navigation is. */
+let sessionRevokedFired = false;
+
+/**
+ * Register the handler the SDK calls when a guardrail block also logs the
+ * user out. Intended to be called once by the app during setup.
+ */
+export const registerSessionRevokedHandler = (
+	handler: (message: string) => void,
+): void => {
+	sessionRevokedHandler = handler;
+};
+
+/**
+ * Report a guardrail-forced logout to the registered handler, if any. No-ops
+ * after the first call so the app can't be asked to show more than one notice.
+ */
+export const notifySessionRevoked = (message: string): void => {
+	if (sessionRevokedFired) {
+		return;
+	}
+	sessionRevokedFired = true;
+	sessionRevokedHandler?.(message);
+};
+
+/**
  * Make a get call to the backend
  * @param path - path
  * @param options - options to pass into the fetch
@@ -205,7 +241,7 @@ export const post = async <O>(
 			"application/x-www-form-urlencoded";
 	}
 
-	options = {
+	const baseOptions: RequestInit = {
 		method: "POST",
 		headers: headers,
 		body: isFormData
@@ -225,19 +261,30 @@ export const post = async <O>(
 		...options,
 	};
 
-	// intercept
-	if (interceptors.request) {
-		options = await interceptors.request(options);
-	}
+	// One attempt: intercept (attaches the CSRF header, fetching a nonce if
+	// CSRF.token is empty), fetch, then run the response interceptor.
+	const attempt = async (): Promise<Response> => {
+		let attemptOptions = baseOptions;
+		if (interceptors.request) {
+			attemptOptions = await interceptors.request(attemptOptions);
+		}
 
-	// get the data
-	const response = await fetch(`${path}`, options);
+		const response = await fetch(`${path}`, attemptOptions);
 
-	// handle the response
-	if (interceptors.response) {
-		await interceptors.response({
-			response: response,
-		});
+		if (interceptors.response) {
+			await interceptors.response({
+				response: response,
+			});
+		}
+
+		return response;
+	};
+
+	let response = await attempt();
+
+	if (response.status === 403) {
+		CSRF.token = "";
+		response = await attempt();
 	}
 
 	if (!response.ok) {

--- a/packages/playground/src/components/common/session-revoked-dialog.tsx
+++ b/packages/playground/src/components/common/session-revoked-dialog.tsx
@@ -1,0 +1,73 @@
+import { observer } from "mobx-react-lite";
+import type React from "react";
+import { useTranslation } from "@semoss/i18n";
+import { logout } from "@semoss/sdk/react";
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@semoss/ui/next";
+import { useRoot } from "@/hooks";
+
+/**
+ * Perform the real logout (Monolith's /api/auth/logout/all — session teardown,
+ * cookie expiry, registerLogout) then reload unconditionally. The reload is
+ * what discards the stale module-level CSRF token and lets the app bootstrap
+ * against a clean, logged-out session, so it has to run even if logout()
+ * itself fails — a user stuck behind a broken button is the exact failure
+ * this dialog exists to remove.
+ */
+const acknowledgeAndSignOut = async (): Promise<void> => {
+	try {
+		await logout();
+	} catch (e) {
+		console.error("Failed to log out after a guardrail revocation", e);
+	} finally {
+		window.location.reload();
+	}
+};
+
+/**
+ * Non-dismissible notice shown when a guardrail block has marked the session
+ * pending revocation (see registerSessionRevokedHandler in @semoss/sdk). The
+ * session is deliberately still technically alive at this point — see
+ * markPendingRevocation on the backend — so there's nothing to close back
+ * into; the only action performs the real logout and reloads, which lets the
+ * server's own redirect (whatever login page or custom logout URL the
+ * deployment is configured with) take over.
+ */
+export const SessionRevokedDialog: React.FC = observer(() => {
+	const { t } = useTranslation("common");
+	const { root } = useRoot();
+	const { revoked, message } = root.sessionRevoked;
+
+	if (!revoked) {
+		return null;
+	}
+
+	return (
+		<Dialog open={revoked}>
+			<DialogContent
+				showCloseButton={false}
+				onEscapeKeyDown={(e) => e.preventDefault()}
+				onInteractOutside={(e) => e.preventDefault()}
+			>
+				<DialogHeader>
+					<DialogTitle>{t("sessionRevoked.title")}</DialogTitle>
+				</DialogHeader>
+				<p>{t("sessionRevoked.body")}</p>
+				{message ? (
+					<p className="text-muted-foreground text-sm">{message}</p>
+				) : null}
+				<DialogFooter>
+					<Button variant="default" onClick={acknowledgeAndSignOut}>
+						{t("sessionRevoked.action")}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+});

--- a/packages/playground/src/components/room/room-input.tsx
+++ b/packages/playground/src/components/room/room-input.tsx
@@ -372,7 +372,11 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 		const [isPromptLibraryOpen, setIsPromptLibraryOpen] = useState(false);
 
 		const runPredefinedPrompt = async (prompt: string) => {
-			if (isLoading || hasOutstandingTools) {
+			if (
+				isLoading ||
+				hasOutstandingTools ||
+				root.sessionRevoked.revoked
+			) {
 				return;
 			}
 
@@ -530,8 +534,14 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 			// Capture files before clearing (for potential restore on error)
 			const userFiles = [...files];
 
-			// Guard: prevent submission if empty, loading, or waiting for tool response
-			if (!userInput || isLoading || hasOutstandingTools) {
+			// Guard: prevent submission if empty, loading, waiting for tool response,
+			// or the session has been revoked (every subsequent pixel would fail anyway)
+			if (
+				!userInput ||
+				isLoading ||
+				hasOutstandingTools ||
+				root.sessionRevoked.revoked
+			) {
 				return;
 			}
 
@@ -574,6 +584,7 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 		// parent from the turn + cancel state); only the idle "send" case needs
 		// the local editor/tool signals to decide enablement + tooltip.
 		const sendDisabled =
+			root.sessionRevoked.revoked ||
 			sendState === "loading" ||
 			(sendState === "send" && (isEmpty || hasOutstandingTools));
 		const handleSendClick = () => {

--- a/packages/playground/src/pages/main-layout.tsx
+++ b/packages/playground/src/pages/main-layout.tsx
@@ -25,6 +25,7 @@ import {
 import { GlobalFooter, GlobalNav } from "@/components";
 import { GlobalDialog } from "@/components/common/global-dialog";
 import { LandingTour } from "@/components/common/landing-tour";
+import { SessionRevokedDialog } from "@/components/common/session-revoked-dialog";
 import { ChatContext, NavbarContext, TourContext } from "@/contexts";
 import { useRoot } from "@/hooks";
 import { useThemeTitle } from "@/hooks/use-theme-title";
@@ -195,6 +196,7 @@ export const MainLayout = observer(() => {
 									}
 								}}
 							/>
+							<SessionRevokedDialog />
 							<div
 								data-testid="main-layout"
 								className="flex h-dvh w-full flex-col overflow-hidden bg-background"

--- a/packages/playground/src/pages/root-layout.tsx
+++ b/packages/playground/src/pages/root-layout.tsx
@@ -1,5 +1,5 @@
 import { type PropsWithChildren, useMemo } from "react";
-import { useInsight } from "@semoss/sdk/react";
+import { registerSessionRevokedHandler, useInsight } from "@semoss/sdk/react";
 import type { ThemeMap } from "@semoss/shared";
 import { Spinner } from "@semoss/ui/next";
 import { RootContext } from "@/contexts";
@@ -11,6 +11,13 @@ export const RootLayout = ({ children }: PropsWithChildren) => {
 	// set up the store
 	const rootStore = useMemo(() => {
 		const store = new RootStore();
+
+		// the SDK stays UI-agnostic; this is the one place that connects a
+		// guardrail-forced logout to this store's observable (see
+		// session-revoked-dialog.tsx)
+		registerSessionRevokedHandler((message) => {
+			store.setSessionRevoked(message);
+		});
 
 		if (system?.config?.theme) {
 			// parse the theme

--- a/packages/playground/src/stores/root/root.store.ts
+++ b/packages/playground/src/stores/root/root.store.ts
@@ -32,6 +32,16 @@ interface RootStoreInterface {
 	 * Optional right-side actions to render in the main layout header
 	 */
 	navbarActions?: React.ReactNode | null;
+
+	/**
+	 * Set once a guardrail block also force-logged the user out (see
+	 * registerSessionRevokedHandler in @semoss/sdk). Never cleared — the
+	 * session is gone, so the only way out is the dialog's reload.
+	 */
+	sessionRevoked: {
+		revoked: boolean;
+		message: string;
+	};
 }
 
 /**
@@ -42,6 +52,10 @@ export class RootStore {
 		isInitialized: false,
 		breadcrumbs: [],
 		navbarActions: null,
+		sessionRevoked: {
+			revoked: false,
+			message: "",
+		},
 		theme: {
 			name: "",
 			banner: "",
@@ -165,6 +179,13 @@ export class RootStore {
 	}
 
 	/**
+	 * Get whether a guardrail block has force-logged the user out
+	 */
+	get sessionRevoked() {
+		return this._store.sessionRevoked;
+	}
+
+	/**
 	 * Set custom breadcrumbs
 	 */
 	setBreadcrumbs = (breadcrumbs: RootStore["breadcrumbs"]) => {
@@ -190,6 +211,17 @@ export class RootStore {
 	 */
 	clearNavbarActions = () => {
 		this._store.navbarActions = null;
+	};
+
+	/**
+	 * Record that a guardrail block force-logged the user out. Called from the
+	 * SDK's registerSessionRevokedHandler — see root-layout.tsx.
+	 */
+	setSessionRevoked = (message: string) => {
+		this._store.sessionRevoked = {
+			revoked: true,
+			message,
+		};
 	};
 
 	/**


### PR DESCRIPTION
## Description
SDK detects USER_LOGGED_OUT_ERROR and fires a once-per-session callback; a non-dismissible SessionRevokedDialog performs the real logout and reloads to clear the stale CSRF token. RoomInput is gated on the revoked flag. Also retries post() once on a 403 with a fresh CSRF nonce.

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->