### PR TITLE
feat: make room settings overlay on mobile

### DIFF
--- a/packages/playground/src/pages/new-room-page.tsx
+++ b/packages/playground/src/pages/new-room-page.tsx
@@ -26,6 +26,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 	toast,
+	useIsMobile,
 	useTheme,
 } from "@semoss/ui/next";
 import landingImage from "@/assets/img/landing.png";
@@ -81,6 +82,7 @@ export const NewRoomPage = observer(() => {
 	const { t } = useTranslation(["room", "workspace", "common", "chat"]);
 	const { root } = useRoot();
 	const { theme: colorMode } = useTheme();
+	const isMobile = useIsMobile();
 
 	const isDark =
 		colorMode === "dark" ||
@@ -745,11 +747,11 @@ export const NewRoomPage = observer(() => {
 													/>
 												)}
 												<DropdownMenuItem
-													onSelect={(e) => {
-														e.preventDefault();
+													onSelect={() => {
 														setIsConfgurationOpen(
 															!isConfigurationOpen,
 														);
+														onOpenChange(false);
 													}}
 												>
 													<Settings2Icon />
@@ -796,7 +798,7 @@ export const NewRoomPage = observer(() => {
 						</DropHighlight>
 					</FileDragProvider>
 				</ResizablePanel>
-				{isConfigurationOpen && (
+				{isConfigurationOpen && !isMobile && (
 					<>
 						<ResizableHandle />
 						<ResizablePanel
@@ -806,67 +808,108 @@ export const NewRoomPage = observer(() => {
 							<div
 								className={`relative h-full w-full overflow-hidden rounded-lg border border-input bg-background shadow-xs`}
 							>
-								{isConfigurationOpen && (
-									<>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<Button
-													className="absolute end-2 top-2 z-10"
-													variant="ghost"
-													size="icon-sm"
-													onClick={() => {
-														// close it
-														setIsConfgurationOpen(
-															false,
-														);
-													}}
-												>
-													<XIcon />
-												</Button>
-											</TooltipTrigger>
-											<TooltipContent>
-												{t("room:settings.close")}
-											</TooltipContent>
-										</Tooltip>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Button
+											className="absolute end-2 top-2 z-10"
+											variant="ghost"
+											size="icon-sm"
+											onClick={() => {
+												// close it
+												setIsConfgurationOpen(false);
+											}}
+										>
+											<XIcon />
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent>
+										{t("room:settings.close")}
+									</TooltipContent>
+								</Tooltip>
 
-										<ScrollArea className="h-full w-full px-2">
-											<RoomOptionsForm
-												model={chat.models.selected}
-												options={tempRoomStore.options}
-												onModelChange={(model) => {
-													if (model) {
-														chat.setSelectedModel(
-															model,
-														);
-													}
-												}}
-												agentEditable
-												onOptionsChange={(opts) => {
-													if (!opts) return;
-													if ("workspace" in opts) {
-														if (opts.workspace) {
-															setSelectedWorkspaceId(
-																opts.workspace
-																	.workspace_id,
-															);
-														} else {
-															setSelectedWorkspaceId(
-																"",
-															);
-														}
-													}
-													tempRoomStore.setOptions({
-														...tempRoomStore.options,
-														...opts,
-													});
-												}}
-											/>
-										</ScrollArea>
-									</>
-								)}
+								<ScrollArea className="h-full w-full px-2">
+									<RoomOptionsForm
+										model={chat.models.selected}
+										options={tempRoomStore.options}
+										onModelChange={(model) => {
+											if (model) {
+												chat.setSelectedModel(model);
+											}
+										}}
+										agentEditable
+										onOptionsChange={(opts) => {
+											if (!opts) return;
+											if ("workspace" in opts) {
+												if (opts.workspace) {
+													setSelectedWorkspaceId(
+														opts.workspace
+															.workspace_id,
+													);
+												} else {
+													setSelectedWorkspaceId("");
+												}
+											}
+											tempRoomStore.setOptions({
+												...tempRoomStore.options,
+												...opts,
+											});
+										}}
+									/>
+								</ScrollArea>
 							</div>
 						</ResizablePanel>
 					</>
+				)}
+				{isConfigurationOpen && isMobile && (
+					<div className="fixed inset-0 z-50 flex flex-col bg-background">
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									className="absolute end-2 top-2 z-10"
+									variant="ghost"
+									size="icon-sm"
+									onClick={() => {
+										// close it
+										setIsConfgurationOpen(false);
+									}}
+								>
+									<XIcon />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>
+								{t("room:settings.close")}
+							</TooltipContent>
+						</Tooltip>
+
+						<ScrollArea className="h-full w-full px-2">
+							<RoomOptionsForm
+								model={chat.models.selected}
+								options={tempRoomStore.options}
+								onModelChange={(model) => {
+									if (model) {
+										chat.setSelectedModel(model);
+									}
+								}}
+								agentEditable
+								onOptionsChange={(opts) => {
+									if (!opts) return;
+									if ("workspace" in opts) {
+										if (opts.workspace) {
+											setSelectedWorkspaceId(
+												opts.workspace.workspace_id,
+											);
+										} else {
+											setSelectedWorkspaceId("");
+										}
+									}
+									tempRoomStore.setOptions({
+										...tempRoomStore.options,
+										...opts,
+									});
+								}}
+							/>
+						</ScrollArea>
+					</div>
 				)}
 				{preCreatedRoom?.sidebar.isOpen && (
 					<>

--- a/packages/playground/src/pages/room-page.tsx
+++ b/packages/playground/src/pages/room-page.tsx
@@ -9,6 +9,7 @@ import {
 	ResizablePanelGroup,
 	Spinner,
 	toast,
+	useIsMobile,
 } from "@semoss/ui/next";
 import { RoomContent, RoomSidebar, SaveWorkspaceDialog } from "@/components";
 import { FileDragProvider } from "@/contexts";
@@ -27,6 +28,7 @@ export const RoomPage = observer(() => {
 	const { chat } = useChat();
 	const { root } = useRoot();
 	const navigate = useNavigate();
+	const isMobile = useIsMobile();
 
 	const platformLinksDisabled = !root.theme.featureFlags?.showPlatformLinks;
 
@@ -163,7 +165,7 @@ export const RoomPage = observer(() => {
 							<RoomContent room={room} />
 						</FileDragProvider>
 					</ResizablePanel>
-					{room.sidebar.isOpen && (
+					{room.sidebar.isOpen && !isMobile && (
 						<>
 							<ResizableHandle />
 							<ResizablePanel
@@ -176,6 +178,11 @@ export const RoomPage = observer(() => {
 						</>
 					)}
 				</ResizablePanelGroup>
+				{room.sidebar.isOpen && isMobile && (
+					<div className="fixed inset-0 z-50 bg-background p-2">
+						<RoomSidebar room={room} />
+					</div>
+				)}
 			</div>
 		</InsightProvider>
 	);


### PR DESCRIPTION
## Description
Adjusting Room Settings Panel on mobile such that it takes up the entire screen, unlike before when it only covered part of it.

## Changes Made
All changes came on new-room-page and room-page. All of the changes are HTML.

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Open the app in mobile view
2. Open the Room Settings and test behavior

## Notes
<img width="1920" height="1080" alt="Screenshot 2026-04-30 at 2 13 09 PM" src="https://github.com/user-attachments/assets/45596dcf-29af-4842-960b-941701355533" />
<img width="1920" height="1080" alt="Screenshot 2026-04-30 at 2 13 16 PM" src="https://github.com/user-attachments/assets/737e608a-0cac-439e-b503-72f688d9bfc8" />