### PR TITLE
fix: propogate error when file in use

### DIFF
--- a/libs/i18n/src/resources/locales/en/playground/room.json
+++ b/libs/i18n/src/resources/locales/en/playground/room.json
@@ -110,7 +110,7 @@
 	},
 	"errors": {
 		"createRoom": "An error occurred while creating the room. Error: {{message}}",
-		"fileInUse": "Uploaded file(s) currently in use by another program. Close the program and re-upload the file(s) in a new chat."
+		"fileInUse": "At least one uploaded file is currently in use by another program. Close the program and re-upload."
 	},
 	"contextWindow": {
 		"descriptionLow": "All conversations have a limit. Very long conversations will eventually cause the model to forget earlier messages.",

--- a/packages/playground/src/components/room/room-content.tsx
+++ b/packages/playground/src/components/room/room-content.tsx
@@ -67,15 +67,8 @@ export const RoomContent: React.FC<RoomContentProps> = observer(({ room }) => {
 		// update the options
 		await room.updateRoomOptions(room.options);
 
-		try {
-			// ask the room
-			await room.askMessage(prompt, files);
-		} catch (e) {
-			if ((e as Error)?.name === "UploadError") {
-				toast.error(t("errors.fileInUse"));
-			}
-			throw e;
-		}
+		// ask the room — let errors propagate so room-input can restore files
+		await room.askMessage(prompt, files);
 
 		// re-sync room options from backend after message completes,
 		// preserving workspace MCPs that are only held in memory. Skipped when

--- a/packages/playground/src/components/room/room-input.tsx
+++ b/packages/playground/src/components/room/room-input.tsx
@@ -552,7 +552,11 @@ export const RoomInput: React.FC<RoomInputProps> = observer(
 				}
 			} catch (e) {
 				// Show error to user
-				toast.error(getGracefulErrorMessage(e as Error as Error));
+				toast.error(
+					(e as Error)?.name === "UploadError"
+						? t("errors.fileInUse")
+						: getGracefulErrorMessage(e as Error),
+				);
 
 				// Restore files for retry
 				addFiles(userFiles);

--- a/packages/playground/src/stores/chat/chat.store.ts
+++ b/packages/playground/src/stores/chat/chat.store.ts
@@ -1,6 +1,8 @@
 import { makeAutoObservable, runInAction } from "mobx";
+import { getI18n } from "@semoss/i18n";
 import { download, type Insight, runPixel } from "@semoss/sdk/react";
 import type { ThemeMap } from "@semoss/shared";
+import { toast } from "@semoss/ui/next";
 import type {
 	AbstractPixelMessage,
 	Engine,
@@ -376,10 +378,11 @@ export class ChatStore {
 					this._store.keys.roomCounter++;
 				});
 			} catch (e) {
-				// UploadError: the message was never sent but the room still
-				// exists — leave the optimistic entry so the user can retry.
-				// Any other error means the room has no data; drop it.
-				if ((e as Error)?.name !== "UploadError") {
+				if ((e as Error)?.name === "UploadError") {
+					// Leave the optimistic room so the user can retry with a new message.
+					toast.error(getI18n().t("room:errors.fileInUse"));
+				} else {
+					// Any other error means the room has no data; drop it.
 					this.removeOptimisticRoom(roomId);
 				}
 			}

--- a/packages/playground/src/stores/room/room.store.ts
+++ b/packages/playground/src/stores/room/room.store.ts
@@ -1227,15 +1227,21 @@ export class RoomStore {
 				});
 			}
 		} catch (e) {
-			// remove the placeholder messages if the upload fails
+			// remove the placeholder messages and stop the room spinner
 			runInAction(() => {
 				uploadPlaceholder.isThinking = false;
 			});
 			parentMessage.removeChild(inputMessage);
+			this.setIsLoading(false);
 
-			// Re-throw UploadErrors as-is (e.g. the uploaded.length === 0 case above)
-			if ((e as Error)?.name === "UploadError") {
-				throw e;
+			// Network-level failures (ERR_FAILED / Failed to fetch) mean the
+			// browser couldn't complete the request — most likely the file is
+			// locked at the OS level. Convert to UploadError so callers show
+			// the "file in use" toast instead of a silent failure.
+			if (e instanceof TypeError) {
+				const uploadError = new Error("File is in use");
+				uploadError.name = "UploadError";
+				throw uploadError;
 			}
 
 			throw e;


### PR DESCRIPTION
## Fix: file-in-use upload error shows no toast

### Problem

When a user drags and drops a file that is open in another program (e.g. a `.docx` open in Word) and sends a message, the upload fails silently with no feedback.

The original fix checked `uploaded.length === 0` (server returns an empty array), but the actual failure mode is a network-level abort: Chrome throws `TypeError: Failed to fetch` (`net::ERR_FAILED`) before the server ever responds. The `TypeError` propagated through the catch block unconverted, and callers only checked `e.name === "UploadError"`, so the toast never fired.

A second issue: the `createRoom` fire-and-forget in `chat.store.ts` — the code path hit when creating a new room — had no toast logic at all. The original fix only covered the existing-room and pre-created-room paths.

### Changes

- **`room.store.ts`** — Convert `TypeError` (network failure) to `UploadError` in the upload catch block. Also call `setIsLoading(false)` here, since the only existing reset lived inside `runRoomPixelStreaming` and was never reached when the upload failed, leaving the spinner stuck.
- **`chat.store.ts`** — Show the file-in-use toast in the `createRoom` fire-and-forget catch, covering the new-room code path.
- **`room-content.tsx` / `room-input.tsx`** — Consolidate to a single toast site (`room-input.tsx`), eliminating the double-toast that appeared in the existing-room flow.
